### PR TITLE
Fix wandering units near destination

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -109,6 +109,9 @@ export const ATTACK_PATH_CALC_INTERVAL = 3000
 // Distance threshold for using occupancy map in pathfinding (in tiles)
 export const PATHFINDING_THRESHOLD = 10
 
+// How close a unit needs to be (in tiles) to consider a move target reached
+export const MOVE_TARGET_REACHED_THRESHOLD = 1.5
+
 // Unit stuck detection and productivity check intervals (in milliseconds)
 export const STUCK_CHECK_INTERVAL = 500  // Check every 0.5 seconds for stuck units
 export const HARVESTER_PRODUCTIVITY_CHECK_INTERVAL = 500  // Check harvester productivity every 0.5 seconds

--- a/src/game/pathfinding.js
+++ b/src/game/pathfinding.js
@@ -1,5 +1,5 @@
 // Path Finding Module - Handles unit pathfinding and formation management
-import { PATH_CALC_INTERVAL, PATHFINDING_THRESHOLD, TILE_SIZE, ATTACK_PATH_CALC_INTERVAL } from '../config.js'
+import { PATH_CALC_INTERVAL, PATHFINDING_THRESHOLD, TILE_SIZE, ATTACK_PATH_CALC_INTERVAL, MOVE_TARGET_REACHED_THRESHOLD } from '../config.js'
 import { findPath } from '../units.js'
 
 /**
@@ -117,7 +117,7 @@ export function updateGlobalPathfinding(units, mapGrid, occupancyMap, gameState)
             } else {
               unit.lastPathCalcTime = now
             }
-          } else if (Math.hypot(unit.tileX - targetPos.x, unit.tileY - targetPos.y) < 1) {
+          } else if (Math.hypot(unit.tileX - targetPos.x, unit.tileY - targetPos.y) < MOVE_TARGET_REACHED_THRESHOLD) {
             // Clear moveTarget if we've reached destination
             unit.moveTarget = null
           }

--- a/src/game/unitMovement.js
+++ b/src/game/unitMovement.js
@@ -1,5 +1,5 @@
 // unitMovement.js - Handles all unit movement logic
-import { TILE_SIZE, PATH_CALC_INTERVAL, PATHFINDING_THRESHOLD, ATTACK_PATH_CALC_INTERVAL } from '../config.js'
+import { TILE_SIZE, PATH_CALC_INTERVAL, PATHFINDING_THRESHOLD, ATTACK_PATH_CALC_INTERVAL, MOVE_TARGET_REACHED_THRESHOLD } from '../config.js'
 import { gameState } from '../gameState.js'
 import { findPath, buildOccupancyMap } from '../units.js'
 import { selectedUnits, cleanupDestroyedSelectedUnits } from '../inputHandler.js'
@@ -132,6 +132,17 @@ export function updateUnitMovement(units, mapGrid, occupancyMap, gameState, now,
 
     // Update rotation for units with turrets
     updateUnitRotation(unit, now)
+
+    // Clear moveTarget when close enough and no further path exists
+    if (unit.moveTarget && (!unit.path || unit.path.length === 0)) {
+      const distToTarget = Math.hypot(
+        unit.x / TILE_SIZE - unit.moveTarget.x,
+        unit.y / TILE_SIZE - unit.moveTarget.y
+      )
+      if (distToTarget < MOVE_TARGET_REACHED_THRESHOLD) {
+        unit.moveTarget = null
+      }
+    }
   }
 }
 
@@ -174,7 +185,7 @@ export function updateUnitPathfinding(units, mapGrid, gameState) {
         if (newPath.length > 1) {
           unit.path = newPath.slice(1)
           unit.lastPathCalcTime = now
-        } else if (Math.hypot(unit.tileX - targetPos.x, unit.tileY - targetPos.y) < 1) {
+        } else if (Math.hypot(unit.tileX - targetPos.x, unit.tileY - targetPos.y) < MOVE_TARGET_REACHED_THRESHOLD) {
           // Clear moveTarget if we've reached destination
           unit.moveTarget = null
         }


### PR DESCRIPTION
## Summary
- add `MOVE_TARGET_REACHED_THRESHOLD` config
- clear `moveTarget` when close enough to destination
- use new constant in pathfinding checks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6860401e822883288a60b7092efc08d8