### PR TITLE
Optimize occupancy map updates

### DIFF
--- a/src/ai/enemySpawner.js
+++ b/src/ai/enemySpawner.js
@@ -138,6 +138,16 @@ export function spawnEnemyUnit(spawnBuilding, unitType, units, mapGrid, gameStat
 
   initializeUnitMovement(unit)
 
+  // Update occupancy map for the newly spawned unit
+  if (gameState.occupancyMap) {
+    const centerTileX = Math.floor((unit.x + TILE_SIZE / 2) / TILE_SIZE)
+    const centerTileY = Math.floor((unit.y + TILE_SIZE / 2) / TILE_SIZE)
+    if (centerTileY >= 0 && centerTileY < gameState.occupancyMap.length &&
+        centerTileX >= 0 && centerTileX < gameState.occupancyMap[0].length) {
+      gameState.occupancyMap[centerTileY][centerTileX] = (gameState.occupancyMap[centerTileY][centerTileX] || 0) + 1
+    }
+  }
+
   if (window.cheatSystem && window.cheatSystem.isGodModeActive()) {
     window.cheatSystem.addUnitToGodMode(unit)
   }

--- a/src/ai/enemyStrategies.js
+++ b/src/ai/enemyStrategies.js
@@ -1,7 +1,7 @@
 // enemyStrategies.js - Enhanced enemy AI strategies
 import { TILE_SIZE, TANK_FIRE_RANGE, ATTACK_PATH_CALC_INTERVAL } from '../config.js'
 import { gameState } from '../gameState.js'
-import { findPath, buildOccupancyMap } from '../units.js'
+import { findPath } from '../units.js'
 
 // Configuration constants for AI behavior
 const AI_CONFIG = {
@@ -651,7 +651,7 @@ export function handleMultiDirectionalAttack(unit, units, gameState, mapGrid) {
     const pathRecalcNeeded = !unit.lastAttackPathCalcTime || (now - unit.lastAttackPathCalcTime > ATTACK_PATH_CALC_INTERVAL)
     
     if (pathRecalcNeeded) {
-      const occupancyMap = buildOccupancyMap(units, mapGrid)
+      const occupancyMap = gameState.occupancyMap
       const path = findPath(
         { x: unit.tileX, y: unit.tileY },
         unit.approachPosition,
@@ -689,7 +689,7 @@ export function handleMultiDirectionalAttack(unit, units, gameState, mapGrid) {
     
     // Set path to approach position
     // Always respect the occupancy map for attack movement
-    const occupancyMap = buildOccupancyMap(units, mapGrid)
+    const occupancyMap = gameState.occupancyMap
     const path = findPath(
       { x: unit.tileX, y: unit.tileY },
       approachPos,

--- a/src/ai/enemyUnitBehavior.js
+++ b/src/ai/enemyUnitBehavior.js
@@ -1,5 +1,5 @@
 import { TILE_SIZE, TANK_FIRE_RANGE, ATTACK_PATH_CALC_INTERVAL } from '../config.js'
-import { findPath, buildOccupancyMap } from '../units.js'
+import { findPath } from '../units.js'
 import { applyEnemyStrategies, shouldConductGroupAttack, shouldRetreatLowHealth } from './enemyStrategies.js'
 import { getClosestEnemyFactory, isEnemyTo } from './enemyUtils.js'
 
@@ -151,7 +151,7 @@ function updateAIUnit(unit, units, gameState, mapGrid, now, aiPlayerId, targeted
           unit.moveTarget = targetPos
           if (!unit.isDodging && targetPos) {
             // Use occupancy map in attack mode to prevent moving through occupied tiles
-            const occupancyMap = buildOccupancyMap(units, mapGrid)
+            const occupancyMap = gameState.occupancyMap
             const path = findPath(
               { x: unit.tileX, y: unit.tileY },
               targetPos,
@@ -176,7 +176,7 @@ function updateAIUnit(unit, units, gameState, mapGrid, now, aiPlayerId, targeted
           targetPos = { x: unit.target.x, y: unit.target.y }
         }
         // Use occupancy map in attack mode to prevent moving through occupied tiles
-        const occupancyMap = buildOccupancyMap(units, mapGrid)
+        const occupancyMap = gameState.occupancyMap
         const path = findPath(
           { x: unit.tileX, y: unit.tileY },
           targetPos,
@@ -300,7 +300,7 @@ function updateAIUnit(unit, units, gameState, mapGrid, now, aiPlayerId, targeted
               const hasBuilding = mapGrid[destTileY][destTileX].building
               if (tileType !== 'water' && tileType !== 'rock' && !hasBuilding) {
                 // Use occupancy map for tactical retreat movement to avoid moving through units
-                const occupancyMap = buildOccupancyMap(units, mapGrid)
+                const occupancyMap = gameState.occupancyMap
                 const newPath = findPath(
                   { x: unit.tileX, y: unit.tileY },
                   { x: destTileX, y: destTileY },

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -1,6 +1,7 @@
 // Building configuration and management
 import { playSound } from './sound.js'
 import { showNotification } from './ui/notifications.js'
+import { gameState } from './gameState.js'
 
 // Building dimensions and costs
 export const buildingData = {
@@ -334,7 +335,7 @@ export function isTileValid(tileX, tileY, mapGrid, _units, _buildings, _factorie
 }
 
 // Place building in the map grid
-export function placeBuilding(building, mapGrid) {
+export function placeBuilding(building, mapGrid, occupancyMap = gameState.occupancyMap) {
   // Create an array to store original tile types
   building.originalTiles = []
 
@@ -347,6 +348,9 @@ export function placeBuilding(building, mapGrid) {
 
       // Mark tile as having a building (for collision detection) but preserve the original tile type for rendering
       mapGrid[y][x].building = building
+      if (occupancyMap && occupancyMap[y] && occupancyMap[y][x] !== undefined) {
+        occupancyMap[y][x] = (occupancyMap[y][x] || 0) + 1
+      }
       
       // Remove any ore from tiles where buildings are placed
       if (mapGrid[y][x].ore) {
@@ -362,7 +366,7 @@ export function placeBuilding(building, mapGrid) {
 }
 
 // Remove building from the map grid: restore original tiles and clear building flag
-export function clearBuildingFromMapGrid(building, mapGrid) {
+export function clearBuildingFromMapGrid(building, mapGrid, occupancyMap = gameState.occupancyMap) {
   for (let y = building.y; y < building.y + building.height; y++) {
     for (let x = building.x; x < building.x + building.width; x++) {
       if (mapGrid[y] && mapGrid[y][x]) {
@@ -380,6 +384,9 @@ export function clearBuildingFromMapGrid(building, mapGrid) {
         }
         // Clear any building reference to unblock this tile for pathfinding
         delete mapGrid[y][x].building
+        if (occupancyMap && occupancyMap[y] && occupancyMap[y][x] !== undefined) {
+          occupancyMap[y][x] = Math.max(0, (occupancyMap[y][x] || 0) - 1)
+        }
       }
     }
   }

--- a/src/enemy.js
+++ b/src/enemy.js
@@ -1,10 +1,9 @@
 // enemy orchestrator
-import { buildOccupancyMap } from './units.js'
 import { updateAIPlayer } from './ai/enemyAIPlayer.js'
 export { spawnEnemyUnit } from './ai/enemySpawner.js'
 
 export function updateEnemyAI(units, factories, bullets, mapGrid, gameState) {
-  const occupancyMap = buildOccupancyMap(units, mapGrid)
+  const occupancyMap = gameState.occupancyMap
   const now = performance.now()
   const humanPlayer = gameState.humanPlayer || 'player1'
   const playerCount = gameState.playerCount || 2

--- a/src/game/bulletSystem.js
+++ b/src/game/bulletSystem.js
@@ -8,6 +8,7 @@ import { calculateHitZoneDamageMultiplier } from './hitZoneCalculator.js'
 import { canPlayCriticalDamageSound, recordCriticalDamageSoundPlayed } from './soundCooldownManager.js'
 import { updateUnitSpeedModifier } from '../utils.js'
 import { markBuildingForRepairPause } from '../buildings.js'
+import { removeUnitOccupancy } from '../units.js'
 
 /**
  * Updates all bullets in the game including movement, collision detection, and cleanup
@@ -153,7 +154,11 @@ export function updateBullets(bullets, units, factories, gameState, mapGrid) {
           if (unit.health <= 0) {
             playSound('explosion', 0.5)
             unit.health = 0
-            
+            if (!unit.occupancyRemoved) {
+              removeUnitOccupancy(unit, gameState.occupancyMap)
+              unit.occupancyRemoved = true
+            }
+
             // Award experience to the shooter for killing ANY unit or building (except harvesters cannot receive XP)
             if (bullet.shooter && bullet.shooter.owner !== unit.owner && bullet.shooter.type !== 'harvester') {
               awardExperience(bullet.shooter, unit)

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -1,6 +1,6 @@
 // Game State Management Module - Handles win/loss conditions, cleanup, and map scrolling
 import { INERTIA_DECAY, TILE_SIZE, ORE_SPREAD_INTERVAL, ORE_SPREAD_PROBABILITY } from '../config.js'
-import { resolveUnitCollisions } from '../units.js'
+import { resolveUnitCollisions, removeUnitOccupancy } from '../units.js'
 import { explosions } from '../logic.js'
 import { playSound } from '../sound.js'
 import { clearFactoryFromMapGrid } from '../factories.js'
@@ -109,6 +109,9 @@ export function cleanupDestroyedUnits(units, gameState) {
         window.cheatSystem.removeUnitFromTracking(unit.id)
       }
       
+      if (!unit.occupancyRemoved) {
+        removeUnitOccupancy(unit, gameState.occupancyMap)
+      }
       units.splice(i, 1)
     }
   }

--- a/src/game/unitCombat.js
+++ b/src/game/unitCombat.js
@@ -2,7 +2,7 @@
 import { TILE_SIZE, TANK_FIRE_RANGE, TANK_BULLET_SPEED, TURRET_AIMING_THRESHOLD, TANK_V3_BURST, ATTACK_PATH_CALC_INTERVAL } from '../config.js'
 import { playSound } from '../sound.js'
 import { hasClearShot, angleDiff } from '../logic.js'
-import { findPath, buildOccupancyMap } from '../units.js'
+import { findPath } from '../units.js'
 import { stopUnitMovement } from './unifiedMovement.js'
 import { gameState } from '../gameState.js'
 import { updateUnitSpeedModifier } from '../utils.js'
@@ -438,7 +438,7 @@ function processAttackQueue(unit, units, mapGrid) {
       
       // Immediately calculate new path with occupancy map for attack movement
       if (mapGrid) {
-        const occupancyMap = buildOccupancyMap(units, mapGrid)
+        const occupancyMap = gameState.occupancyMap
         
         // Calculate target position
         let targetTileX, targetTileY
@@ -503,7 +503,7 @@ export function cleanupAttackGroupTargets() {
  * Updates unit combat behavior including targeting and shooting
  */
 export function updateUnitCombat(units, bullets, mapGrid, gameState, now) {
-  const occupancyMap = buildOccupancyMap(units, mapGrid)
+  const occupancyMap = gameState.occupancyMap
   
   let combatUnitsCount = 0
   let unitsWithTargets = 0

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -29,6 +29,7 @@ export const gameState = {
   buildings: [],
   factories: [], // Add factories array to gameState
   mapGrid: [], // Add mapGrid array to gameState
+  occupancyMap: [], // Global occupancy map updated incrementally
   powerSupply: 0,
   buildingPlacementMode: false,
   currentBuildingType: null,

--- a/src/input/unitCommands.js
+++ b/src/input/unitCommands.js
@@ -1,6 +1,6 @@
 // unitCommands.js
 import { TILE_SIZE, TANK_FIRE_RANGE } from '../config.js'
-import { findPath, buildOccupancyMap } from '../units.js'
+import { findPath } from '../units.js'
 import { playSound } from '../sound.js'
 import { gameState } from '../gameState.js'
 import { cancelRetreatForUnits } from '../behaviours/retreat.js'
@@ -167,7 +167,7 @@ export class UnitCommandsHandler {
       }
 
       // Find path to the target position, always respect occupancy map (including in attack mode)
-      const occupancyMap = gameState.units ? buildOccupancyMap(gameState.units, mapGrid) : null
+      const occupancyMap = gameState.occupancyMap
       const path = findPath({ x: unit.tileX, y: unit.tileY }, desiredTile, mapGrid, occupancyMap)
 
       if (path && path.length > 0 && (unit.tileX !== desiredTile.x || unit.tileY !== desiredTile.y)) {

--- a/src/logic.js
+++ b/src/logic.js
@@ -3,7 +3,6 @@ import {
   TILE_SIZE
 } from './config.js'
 import { gameState } from './gameState.js'
-import { buildOccupancyMap } from './units.js'
 import { playSound } from './sound.js'
 import { calculateHitZoneDamageMultiplier } from './game/hitZoneCalculator.js'
 import { canPlayCriticalDamageSound, recordCriticalDamageSoundPlayed } from './game/soundCooldownManager.js'
@@ -339,8 +338,8 @@ export function findPositionWithClearShot(unit, target, units, mapGrid) {
     { x: -1, y: -1 }  // up-left
   ]
 
-  // Create the occupancy map once instead of checking each unit repeatedly
-  const occupancyMap = buildOccupancyMap(units, mapGrid)
+  // Use the global occupancy map
+  const occupancyMap = gameState.occupancyMap
 
   // Create a temporary unit copy for testing line of sight
   const testUnit = { ...unit, path: [...(unit.path || [])] }

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 // Refactored main game orchestrator
 
 import { setupInputHandlers, selectedUnits } from './inputHandler.js'
-import { unitCosts } from './units.js'
+import { unitCosts, initializeOccupancyMap } from './units.js'
 import { gameState } from './gameState.js'
 import { buildingData } from './buildings.js'
 import { productionQueue } from './productionQueue.js'
@@ -121,6 +121,8 @@ class Game {
         unit.baseCost = unit.baseCost || unitCosts[unit.type] || 1000
       }
     })
+
+    gameState.occupancyMap = initializeOccupancyMap(units, mapGrid)
   }
 
   centerOnPlayerFactory() {
@@ -264,9 +266,11 @@ class Game {
     
     // Ensure no ore overlaps with buildings or factories
     cleanupOreFromBuildings(mapGrid, gameState.buildings, factories)
-    
+
     units.length = 0
     bullets.length = 0
+
+    gameState.occupancyMap = initializeOccupancyMap(units, mapGrid)
 
     this.centerOnPlayerFactory()
 
@@ -288,6 +292,8 @@ class Game {
     }).catch(err => {
       console.warn('Could not resume production after map shuffle:', err)
     })
+
+    gameState.occupancyMap = initializeOccupancyMap(units, mapGrid)
   }
 
   async resetGame() {

--- a/src/productionQueue.js
+++ b/src/productionQueue.js
@@ -353,7 +353,7 @@ export const productionQueue = {
 
     if (spawnFactory) {
       // Pass the specific factory's rally point to spawnUnit
-      const newUnit = spawnUnit(spawnFactory, unitType, units, mapGrid, rallyPointTarget)
+      const newUnit = spawnUnit(spawnFactory, unitType, units, mapGrid, rallyPointTarget, gameState.occupancyMap)
       if (newUnit) {
         units.push(newUnit)
         // Play random unit ready sound

--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -10,7 +10,6 @@ import { RetreatTargetRenderer } from './retreatTargetRenderer.js'
 import { UIRenderer } from './uiRenderer.js'
 import { MinimapRenderer } from './minimapRenderer.js'
 import { HarvesterHUD } from '../ui/harvesterHUD.js'
-import { buildOccupancyMap } from '../units.js'
 import { preloadTankImages } from './tankImageRenderer.js'
 
 export class Renderer {
@@ -78,7 +77,7 @@ export class Renderer {
     // Build occupancy map for visualization if needed
     let occupancyMap = null
     if (gameState.occupancyVisible) {
-      occupancyMap = buildOccupancyMap(units, mapGrid)
+      occupancyMap = gameState.occupancyMap
     }
     
     this.mapRenderer.render(gameCtx, mapGrid, scrollOffset, gameCanvas, gameState, occupancyMap)

--- a/src/saveGame.js
+++ b/src/saveGame.js
@@ -9,6 +9,7 @@ import { createUnit } from './units.js'
 import { buildingData } from './buildings.js'
 import { showNotification } from './ui/notifications.js'
 import { milestoneSystem } from './game/milestoneSystem.js'
+import { initializeOccupancyMap } from './units.js'
 
 // === Save/Load Game Logic ===
 export function getSaveGames() {
@@ -309,6 +310,8 @@ export function loadGame(key) {
     
     // Ensure no ore overlaps with buildings or factories after loading
     cleanupOreFromBuildings(mapGrid, gameState.buildings, factories)
+
+    gameState.occupancyMap = initializeOccupancyMap(units, mapGrid)
 
     // Restore targeted ore tiles for harvester system
     if (loaded.targetedOreTiles) {

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -1,6 +1,6 @@
 // Main Game Update Module - Coordinates all game systems
 import { TILE_SIZE } from './config.js'
-import { buildOccupancyMap } from './units.js'
+
 import { updateEnemyAI } from './enemy.js'
 import { cleanupDestroyedSelectedUnits } from './inputHandler.js'
 import { updateBuildingsUnderRepair, updateBuildingsAwaitingRepair } from './buildings.js'
@@ -30,7 +30,7 @@ export function updateGame(delta, mapGrid, factories, units, bullets, gameState)
   try {
     if (gameState.gamePaused) return
     const now = performance.now()
-    const occupancyMap = buildOccupancyMap(units, mapGrid)
+    const occupancyMap = gameState.occupancyMap
 
     // Update game time
     updateGameTime(gameState, delta)

--- a/src/utils.js
+++ b/src/utils.js
@@ -320,6 +320,17 @@ export function debugSpawnEnemyUnit(unitType = 'tank') {
     }
     
     units.push(enemyUnit)
+    
+    // Update occupancy map for debug spawned unit
+    if (window.gameState && window.gameState.occupancyMap) {
+      const centerTileX = Math.floor((enemyUnit.x + TILE_SIZE) / TILE_SIZE)
+      const centerTileY = Math.floor((enemyUnit.y + TILE_SIZE) / TILE_SIZE)
+      if (centerTileY >= 0 && centerTileY < window.gameState.occupancyMap.length &&
+          centerTileX >= 0 && centerTileX < window.gameState.occupancyMap[0].length) {
+        window.gameState.occupancyMap[centerTileY][centerTileX] = (window.gameState.occupancyMap[centerTileY][centerTileX] || 0) + 1
+      }
+    }
+    
     console.log(`🎯 Spawned enemy ${unitType} at (500, 500) for testing`)
     console.log(`💡 Use your tanks to destroy it and gain experience!`)
     


### PR DESCRIPTION
## Summary
- maintain an occupancy map in `gameState`
- update occupancy map incrementally when units move, spawn or die
- reinitialize the map when creating or resetting the game
- use the global occupancy map for pathfinding and rendering

## Testing
- `npm run lint` *(fails: Trailing spaces etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861a54a08fc8328a8f21516d0da0227