### PR TITLE
Fix level star size during selection

### DIFF
--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -352,16 +352,17 @@ export class UnitRenderer {
     }
 
     initializeUnitLeveling(unit)
-    
+
     // Position stars above the health bar
     const starSize = 6
     const starSpacing = 8
     const totalWidth = (unit.level * starSpacing) - (starSpacing - starSize)
     const startX = unit.x + TILE_SIZE / 2 - scrollOffset.x - totalWidth / 2
     const starY = unit.y - 20 - scrollOffset.y // Above health bar
-
+    ctx.save()
     ctx.fillStyle = '#FFD700' // Gold color for stars
     ctx.strokeStyle = '#FFA500' // Orange outline
+    ctx.lineWidth = 1
 
     for (let i = 0; i < unit.level; i++) {
       const starX = startX + (i * starSpacing)
@@ -387,6 +388,8 @@ export class UnitRenderer {
       ctx.fill()
       ctx.stroke()
     }
+
+    ctx.restore()
   }
 
   renderUnit(ctx, unit, scrollOffset) {


### PR DESCRIPTION
## Summary
- save/restore canvas state when rendering unit level stars so they remain small even when units are selected

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686929346fac8328b8300e7faa3793f1