### PR TITLE
Fix notifications stacking

### DIFF
--- a/src/ui/notifications.js
+++ b/src/ui/notifications.js
@@ -2,6 +2,9 @@
 // Handle notification display system
 
 export function showNotification(message, duration = 3000) {
+  // Remove any existing notifications immediately
+  document.querySelectorAll('.notification').forEach((el) => el.remove())
+
   const notification = document.createElement('div')
   notification.className = 'notification'
   notification.textContent = message


### PR DESCRIPTION
## Summary
- ensure any existing notifications are cleared before displaying a new one

## Testing
- `npm run lint` *(fails: 2429 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869291b02308328b5df94e794c6c7ae