### PR TITLE
Fix HUD layering

### DIFF
--- a/src/rendering/buildingRenderer.js
+++ b/src/rendering/buildingRenderer.js
@@ -20,7 +20,7 @@ export class BuildingRenderer {
     }
   }
 
-  renderBuilding(ctx, building, scrollOffset) {
+  renderBuildingBase(ctx, building, scrollOffset) {
     const screenX = building.x * TILE_SIZE - scrollOffset.x
     const screenY = building.y * TILE_SIZE - scrollOffset.y
     const width = building.width * TILE_SIZE
@@ -39,11 +39,19 @@ export class BuildingRenderer {
 
     this.renderTurret(ctx, building, screenX, screenY, width, height)
     this.renderSelection(ctx, building, screenX, screenY, width, height)
-    this.renderHealthBar(ctx, building, screenX, screenY, width)
     this.renderOwnerIndicator(ctx, building, screenX, screenY)
-    this.renderAttackTargetIndicator(ctx, building, screenX, screenY, width, height)
     this.renderRepairAnimation(ctx, building, screenX, screenY, width, height)
     this.renderPendingRepairCountdown(ctx, building, screenX, screenY, width, height)
+  }
+
+  renderBuildingOverlays(ctx, building, scrollOffset) {
+    const screenX = building.x * TILE_SIZE - scrollOffset.x
+    const screenY = building.y * TILE_SIZE - scrollOffset.y
+    const width = building.width * TILE_SIZE
+    const height = building.height * TILE_SIZE
+
+    this.renderHealthBar(ctx, building, screenX, screenY, width)
+    this.renderAttackTargetIndicator(ctx, building, screenX, screenY, width, height)
   }
 
   drawBuildingImageNatural(ctx, img, screenX, screenY, maxWidth, maxHeight) {
@@ -465,11 +473,18 @@ export class BuildingRenderer {
     ctx.restore()
   }
 
-  render(ctx, buildings, scrollOffset) {
-    // Draw buildings if they exist
+  renderBases(ctx, buildings, scrollOffset) {
     if (buildings && buildings.length > 0) {
       buildings.forEach(building => {
-        this.renderBuilding(ctx, building, scrollOffset)
+        this.renderBuildingBase(ctx, building, scrollOffset)
+      })
+    }
+  }
+
+  renderOverlays(ctx, buildings, scrollOffset) {
+    if (buildings && buildings.length > 0) {
+      buildings.forEach(building => {
+        this.renderBuildingOverlays(ctx, building, scrollOffset)
       })
     }
   }

--- a/src/rendering/factoryRenderer.js
+++ b/src/rendering/factoryRenderer.js
@@ -251,7 +251,7 @@ export class FactoryRenderer {
     }
   }
 
-  renderFactory(ctx, factory) {
+  renderFactoryBaseLayer(ctx, factory) {
     if (factory.destroyed) return
     const pos = tileToPixel(factory.x, factory.y)
     const screenX = pos.x - factory.scrollOffset?.x || 0
@@ -260,12 +260,21 @@ export class FactoryRenderer {
     const height = factory.height * TILE_SIZE
 
     this.renderFactoryBase(ctx, factory, screenX, screenY, width, height)
-    this.renderHealthBar(ctx, factory, screenX, screenY, width)
     this.renderSelection(ctx, factory, screenX, screenY, width, height)
     this.renderCurrentlyBuilding(ctx, factory, screenX, screenY, width, height)
     this.renderBudget(ctx, factory, screenX, screenY)
     this.renderRepairAnimation(ctx, factory, screenX, screenY, width, height)
     this.renderPendingRepairCountdown(ctx, factory, screenX, screenY, width, height)
+  }
+
+  renderFactoryOverlays(ctx, factory) {
+    if (factory.destroyed) return
+    const pos = tileToPixel(factory.x, factory.y)
+    const screenX = pos.x - factory.scrollOffset?.x || 0
+    const screenY = pos.y - factory.scrollOffset?.y || 0
+    const width = factory.width * TILE_SIZE
+
+    this.renderHealthBar(ctx, factory, screenX, screenY, width)
   }
 
   renderRepairAnimation(ctx, factory, screenX, screenY, width, height) {
@@ -367,12 +376,18 @@ export class FactoryRenderer {
     ctx.restore()
   }
 
-  render(ctx, factories, scrollOffset) {
-    // Draw factories.
+  renderBases(ctx, factories, scrollOffset) {
     factories.forEach(factory => {
-      // Store scroll offset temporarily for rendering
       factory.scrollOffset = scrollOffset
-      this.renderFactory(ctx, factory)
+      this.renderFactoryBaseLayer(ctx, factory)
+      delete factory.scrollOffset
+    })
+  }
+
+  renderOverlays(ctx, factories, scrollOffset) {
+    factories.forEach(factory => {
+      factory.scrollOffset = scrollOffset
+      this.renderFactoryOverlays(ctx, factory)
       delete factory.scrollOffset
     })
   }

--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -82,9 +82,9 @@ export class Renderer {
     }
     
     this.mapRenderer.render(gameCtx, mapGrid, scrollOffset, gameCanvas, gameState, occupancyMap)
-    this.buildingRenderer.render(gameCtx, buildings, scrollOffset)
-    this.factoryRenderer.render(gameCtx, factories, scrollOffset)
-    this.unitRenderer.render(gameCtx, units, scrollOffset)
+    this.buildingRenderer.renderBases(gameCtx, buildings, scrollOffset)
+    this.factoryRenderer.renderBases(gameCtx, factories, scrollOffset)
+    this.unitRenderer.renderBases(gameCtx, units, scrollOffset)
     this.effectsRenderer.render(gameCtx, bullets, gameState, units, scrollOffset)
     
     // Render movement target indicators (green triangles)
@@ -95,7 +95,11 @@ export class Renderer {
     
     // Render harvester HUD overlay (if enabled)
     this.harvesterHUD.render(gameCtx, units, gameState, scrollOffset)
-    
+
+    this.buildingRenderer.renderOverlays(gameCtx, buildings, scrollOffset)
+    this.factoryRenderer.renderOverlays(gameCtx, factories, scrollOffset)
+    this.unitRenderer.renderOverlays(gameCtx, units, scrollOffset)
+
     this.uiRenderer.render(gameCtx, gameCanvas, gameState, selectionActive, selectionStart, selectionEnd, scrollOffset, factories, buildings, mapGrid, units)
   }
 

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -392,7 +392,7 @@ export class UnitRenderer {
     ctx.restore()
   }
 
-  renderUnit(ctx, unit, scrollOffset) {
+  renderUnitBase(ctx, unit, scrollOffset) {
     if (unit.health <= 0) return
 
     const centerX = unit.x + TILE_SIZE / 2 - scrollOffset.x
@@ -410,12 +410,6 @@ export class UnitRenderer {
         // Image rendering successful, still render other components
         this.renderSelection(ctx, unit, centerX, centerY)
         this.renderAlertMode(ctx, unit, centerX, centerY)
-        this.renderHealthBar(ctx, unit, scrollOffset)
-        this.renderLevelStars(ctx, unit, scrollOffset)
-        this.renderHarvesterProgress(ctx, unit, scrollOffset)
-        this.renderQueueNumber(ctx, unit, scrollOffset)
-        this.renderGroupNumber(ctx, unit, scrollOffset)
-        this.renderAttackTargetIndicator(ctx, unit, centerX, centerY)
         return
       }
       // If image rendering failed, fall through to original rendering
@@ -426,6 +420,14 @@ export class UnitRenderer {
     this.renderSelection(ctx, unit, centerX, centerY)
     this.renderAlertMode(ctx, unit, centerX, centerY)
     this.renderTurret(ctx, unit, centerX, centerY)
+  }
+
+  renderUnitOverlay(ctx, unit, scrollOffset) {
+    if (unit.health <= 0) return
+
+    const centerX = unit.x + TILE_SIZE / 2 - scrollOffset.x
+    const centerY = unit.y + TILE_SIZE / 2 - scrollOffset.y
+
     this.renderHealthBar(ctx, unit, scrollOffset)
     this.renderLevelStars(ctx, unit, scrollOffset)
     this.renderHarvesterProgress(ctx, unit, scrollOffset)
@@ -434,10 +436,15 @@ export class UnitRenderer {
     this.renderAttackTargetIndicator(ctx, unit, centerX, centerY)
   }
 
-  render(ctx, units, scrollOffset) {
-    // Draw units.
+  renderBases(ctx, units, scrollOffset) {
     units.forEach(unit => {
-      this.renderUnit(ctx, unit, scrollOffset)
+      this.renderUnitBase(ctx, unit, scrollOffset)
+    })
+  }
+
+  renderOverlays(ctx, units, scrollOffset) {
+    units.forEach(unit => {
+      this.renderUnitOverlay(ctx, unit, scrollOffset)
     })
   }
 


### PR DESCRIPTION
## Summary
- ensure building/factory/unit base renders are separate from overlay passes
- draw HUD overlays after all game elements so health bars and attack pins are always on top

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686959d248c48328811d86054cfe37b3