### PR TITLE
Improve pathfinding performance via caching

### DIFF
--- a/src/game/unitMovement.js
+++ b/src/game/unitMovement.js
@@ -2,6 +2,7 @@
 import { TILE_SIZE, PATH_CALC_INTERVAL, PATHFINDING_THRESHOLD, ATTACK_PATH_CALC_INTERVAL, MOVE_TARGET_REACHED_THRESHOLD } from '../config.js'
 import { gameState } from '../gameState.js'
 import { findPath, updateUnitOccupancy, removeUnitOccupancy } from '../units.js'
+import { getCachedPath } from './pathfinding.js'
 import { selectedUnits, cleanupDestroyedSelectedUnits } from '../inputHandler.js'
 import { angleDiff, smoothRotateTowardsAngle, findAdjacentTile } from '../logic.js'
 import { updateUnitPosition, initializeUnitMovement, stopUnitMovement } from './unifiedMovement.js'
@@ -97,7 +98,7 @@ export function updateUnitMovement(units, mapGrid, occupancyMap, gameState, now,
           unit.moveTarget = { x: targetCenterX, y: targetCenterY }
           unit.lastAttackPathCalcTime = now
           // Use proper pathfinding with occupancy map for attack movement
-          const path = findPath(
+          const path = getCachedPath(
             { x: unit.tileX, y: unit.tileY },
             { x: targetTileX, y: targetTileY },
             mapGrid,


### PR DESCRIPTION
## Summary
- add simple caching layer to share A* results in `updateGlobalPathfinding`
- use cached paths for attack movement calculations

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68697283cab08328ad42fe1c93c67387