### PR TITLE
Fix occupancy map on restart

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -361,6 +361,9 @@ class Game {
     units.length = 0
     bullets.length = 0
 
+    // Reinitialize occupancy map for the fresh map
+    gameState.occupancyMap = initializeOccupancyMap(units, mapGrid)
+
     // Reset production queue and clear all pending items
     if (typeof productionQueue !== 'undefined') {
       productionQueue.unitItems.length = 0


### PR DESCRIPTION
## Summary
- ensure restart regenerates occupancy map

## Testing
- `npm run lint` *(fails: trailing spaces and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_686a54be3dcc83289e2344841e45e1f9