### PR TITLE
Add spreading seed crystal ore

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,7 @@ export const TILE_COLORS = {
   rock: '#808080',
   street: '#D3D3D3',
   ore: '#FFD700',
+  seedCrystal: '#FF5555',
   building: 'transparent' // Buildings should be transparent so background shows through
 }
 
@@ -51,6 +52,10 @@ export const TILE_IMAGES = {
   ore: {
     paths: ['images/map/ore01', 'images/map/ore02', 'images/map/ore03', 'images/map/ore04'],
     rotate: false // Ore should not be rotated
+  },
+  seedCrystal: {
+    paths: ['images/map/ore1_red'],
+    rotate: false // Seed crystals should not be rotated
   }
 }
 

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -40,7 +40,8 @@ export function updateOreSpread(gameState, mapGrid, factories = []) {
     
     for (let y = 0; y < mapGrid.length; y++) {
       for (let x = 0; x < mapGrid[0].length; x++) {
-        if (mapGrid[y][x].ore) {
+        if (mapGrid[y][x].ore || mapGrid[y][x].seedCrystal) {
+          const spreadProb = (mapGrid[y][x].seedCrystal ? ORE_SPREAD_PROBABILITY * 2 : ORE_SPREAD_PROBABILITY)
           directions.forEach(dir => {
             const nx = x + dir.x, ny = y + dir.y
             if (nx >= 0 && nx < mapGrid[0].length && ny >= 0 && ny < mapGrid.length) {
@@ -57,9 +58,9 @@ export function updateOreSpread(gameState, mapGrid, factories = []) {
                        ny >= factory.y && ny < factory.y + factory.height
               })
               
-              // Only spread to land or street tiles that don't already have ore and don't have buildings or factories
+              // Only spread to land or street tiles that don't already have ore or seed crystals and don't have buildings or factories
               const tileType = mapGrid[ny][nx].type
-              if ((tileType === 'land' || tileType === 'street') && !mapGrid[ny][nx].ore && !hasBuilding && !hasFactory && Math.random() < ORE_SPREAD_PROBABILITY) {
+              if ((tileType === 'land' || tileType === 'street') && !mapGrid[ny][nx].ore && !mapGrid[ny][nx].seedCrystal && !hasBuilding && !hasFactory && Math.random() < spreadProb) {
                 mapGrid[ny][nx].ore = true
               }
             }

--- a/src/game/harvesterLogic.js
+++ b/src/game/harvesterLogic.js
@@ -172,7 +172,8 @@ export function updateHarvesterLogic(units, mapGrid, occupancyMap, gameState, fa
       
       if (distanceToOreField <= 0.7) { // Allow harvester to be within 0.7 tiles of the ore field
         // We're close enough to the ore field, check if we can harvest
-        if (mapGrid[unit.oreField.y][unit.oreField.x].ore && 
+        if (mapGrid[unit.oreField.y][unit.oreField.x].ore &&
+            !mapGrid[unit.oreField.y][unit.oreField.x].seedCrystal &&
             !harvestedTiles.has(tileKey)) {
           // Start harvesting
           unit.harvesting = true
@@ -1038,9 +1039,9 @@ function findAlternativeOreTarget(unit, mapGrid, occupancyMap) {
       const searchX = Math.round(unitTileX + Math.cos(angle) * radius)
       const searchY = Math.round(unitTileY + Math.sin(angle) * radius)
       
-      if (searchX >= 0 && searchY >= 0 && 
+      if (searchX >= 0 && searchY >= 0 &&
           searchX < mapGrid[0].length && searchY < mapGrid.length &&
-          mapGrid[searchY][searchX].ore) {
+          mapGrid[searchY][searchX].ore && !mapGrid[searchY][searchX].seedCrystal) {
         
         const tileKey = `${searchX},${searchY}`
         
@@ -1092,9 +1093,9 @@ function findNearbyOreTile(unit, mapGrid, centerTileX, centerTileY) {
       const checkX = centerTileX + dx
       const checkY = centerTileY + dy
       
-      if (checkX >= 0 && checkY >= 0 && 
+      if (checkX >= 0 && checkY >= 0 &&
           checkX < mapGrid[0].length && checkY < mapGrid.length &&
-          mapGrid[checkY][checkX].ore) {
+          mapGrid[checkY][checkX].ore && !mapGrid[checkY][checkX].seedCrystal) {
         
         // Calculate distance from harvester center to tile center
         const tileCenter = {

--- a/src/gameSetup.js
+++ b/src/gameSetup.js
@@ -134,7 +134,7 @@ export function generateMap(seed, mapGrid, MAP_TILES_X, MAP_TILES_Y) {
     mapGrid[y] = []
     for (let x = 0; x < MAP_TILES_X; x++) {
       // Initially all land with no ore overlay
-      mapGrid[y][x] = { type: 'land', ore: false }
+      mapGrid[y][x] = { type: 'land', ore: false, seedCrystal: false }
     }
   }
 
@@ -284,6 +284,24 @@ export function generateMap(seed, mapGrid, MAP_TILES_X, MAP_TILES_Y) {
         }
       }
     }
+
+    // Place 1-3 seed crystals in the center of the ore field
+    const seedCount = Math.floor(rand() * 3) + 1
+    const seedPositions = [{ x: cluster.x, y: cluster.y }]
+    while (seedPositions.length < seedCount) {
+      const dx = Math.floor(rand() * 3) - 1
+      const dy = Math.floor(rand() * 3) - 1
+      const pos = { x: cluster.x + dx, y: cluster.y + dy }
+      if (!seedPositions.some(p => p.x === pos.x && p.y === pos.y)) {
+        seedPositions.push(pos)
+      }
+    }
+    seedPositions.forEach(pos => {
+      if (pos.x >= 0 && pos.y >= 0 && pos.x < MAP_TILES_X && pos.y < MAP_TILES_Y) {
+        mapGrid[pos.y][pos.x].ore = true
+        mapGrid[pos.y][pos.x].seedCrystal = true
+      }
+    })
   })
 }
 

--- a/src/logic.js
+++ b/src/logic.js
@@ -230,7 +230,7 @@ export function findClosestOre(unit, mapGrid, targetedOreTiles = {}) {
   
   for (let y = 0; y < mapGrid.length; y++) {
     for (let x = 0; x < mapGrid[0].length; x++) {
-      if (mapGrid[y][x].ore) {
+      if (mapGrid[y][x].ore && !mapGrid[y][x].seedCrystal) {
         // Skip this ore tile if it's already targeted by another unit
         const tileKey = `${x},${y}`
         if (targetedOreTiles[tileKey] && targetedOreTiles[tileKey] !== unit.id) {

--- a/src/rendering/mapRenderer.js
+++ b/src/rendering/mapRenderer.js
@@ -48,6 +48,23 @@ export class MapRenderer {
       }
     }
 
+    const drawSeedOverlay = (x, y) => {
+      const screenX = Math.floor(x * TILE_SIZE - scrollOffset.x)
+      const screenY = Math.floor(y * TILE_SIZE - scrollOffset.y)
+      if (useTexture && this.textureManager.tileTextureCache.seedCrystal) {
+        const idx = this.textureManager.getTileVariation('seedCrystal', x, y)
+        if (idx >= 0 && idx < this.textureManager.tileTextureCache.seedCrystal.length) {
+          ctx.drawImage(this.textureManager.tileTextureCache.seedCrystal[idx], screenX, screenY, TILE_SIZE + 1, TILE_SIZE + 1)
+        } else {
+          ctx.fillStyle = TILE_COLORS.seedCrystal
+          ctx.fillRect(screenX, screenY, TILE_SIZE + 1, TILE_SIZE + 1)
+        }
+      } else {
+        ctx.fillStyle = TILE_COLORS.seedCrystal
+        ctx.fillRect(screenX, screenY, TILE_SIZE + 1, TILE_SIZE + 1)
+      }
+    }
+
     // Single pass rendering: process all layers for each tile in one iteration
     for (let y = startTileY; y < endTileY; y++) {
       for (let x = startTileX; x < endTileX; x++) {
@@ -97,8 +114,10 @@ export class MapRenderer {
           }
         }
         
-        // Render ore overlay if present
-        if (tile.ore) {
+        // Render ore or seed overlays if present
+        if (tile.seedCrystal) {
+          drawSeedOverlay(x, y)
+        } else if (tile.ore) {
           drawOreOverlay(x, y)
         }
       }


### PR DESCRIPTION
## Summary
- support seed crystal overlay graphics and color
- draw seed crystals on the map
- generate 1-3 seed crystals in the center of ore fields
- double ore spread probability from seed crystals
- prevent harvesters from targeting seed crystals

## Testing
- `npm run lint` *(fails: trailing spaces, quotes, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686a6712d47c832889e327a8b3475fe1