### PR TITLE
Fix critical damage sound trigger

### DIFF
--- a/src/game/bulletSystem.js
+++ b/src/game/bulletSystem.js
@@ -131,8 +131,12 @@ export function updateBullets(bullets, units, factories, gameState, mapGrid) {
             updateUnitSpeedModifier(unit)
           }
 
-          // Play critical damage sound for rear hits on tanks (with cooldown)
-          if (hitZoneResult.isRearHit && canPlayCriticalDamageSound(unit, now)) {
+          // Play critical damage sound for rear hits on player's units only (with cooldown)
+          if (
+            hitZoneResult.isRearHit &&
+            unit.owner === gameState.humanPlayer &&
+            canPlayCriticalDamageSound(unit, now)
+          ) {
             playSound('criticalDamage', 0.7)
             recordCriticalDamageSoundPlayed(unit, now)
           }

--- a/src/logic.js
+++ b/src/logic.js
@@ -46,8 +46,12 @@ export function triggerExplosion(x, y, baseDamage, units, factories, shooter, no
         const hitZoneResult = calculateHitZoneDamageMultiplier(mockBullet, unit)
         damage = Math.round(damage * hitZoneResult.multiplier)
         
-        // Play critical damage sound for rear hits on tanks (with cooldown)
-        if (hitZoneResult.isRearHit && canPlayCriticalDamageSound(unit, now)) {
+        // Play critical damage sound only when player's units are hit from behind (with cooldown)
+        if (
+          hitZoneResult.isRearHit &&
+          unit.owner === gameState.humanPlayer &&
+          canPlayCriticalDamageSound(unit, now)
+        ) {
           playSound('criticalDamage', 0.7)
           recordCriticalDamageSoundPlayed(unit, now)
         }


### PR DESCRIPTION
## Summary
- play the `criticalDamage` sound only when the player's units are hit from behind

## Testing
- `npm run lint` *(fails: Trailing spaces and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a675ac7708328877904356a194d9d