### PR TITLE
Implement building construction animation

### DIFF
--- a/src/buildings.js
+++ b/src/buildings.js
@@ -173,7 +173,10 @@ export function createBuilding(type, x, y) {
     maxHealth: data.health,
     power: data.power,
     isBuilding: true,
-    owner: 'neutral' // Default owner, should be set explicitly when added to gameState
+    owner: 'neutral', // Default owner, should be set explicitly when added to gameState
+    // Timestamp for construction animation
+    constructionStartTime: performance.now(),
+    constructionFinished: false
   }
 
   // Initialize rally point for unit-producing buildings


### PR DESCRIPTION
## Summary
- add construction timer metadata when creating buildings
- animate newly placed buildings: grayscale fade-in from bottom to top

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a830ccf58832893985c489c38b246