### PR TITLE
Implement tank inertia shake animation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -104,6 +104,9 @@ export const TURRET_RECOIL_DISTANCE = 6 // pixels for building turrets
 export const SMOKE_PARTICLE_LIFETIME = 1500 // milliseconds (reduced from 2000)
 export const SMOKE_EMIT_INTERVAL = 120 // milliseconds between puffs (slightly less frequent)
 export const SMOKE_PARTICLE_SIZE = 8 // radius of smoke particles (reduced from 12)
+// Small shake when tanks start or stop moving
+export const TANK_SHAKE_DURATION = 300 // milliseconds
+export const TANK_SHAKE_AMPLITUDE = 3 // pixels
 
 // Wind effects for smoke particles
 export const WIND_DIRECTION = { x: 0.3, y: -0.1 } // Slight eastward and upward wind

--- a/src/game/unitMovement.js
+++ b/src/game/unitMovement.js
@@ -5,7 +5,7 @@ import { findPath, updateUnitOccupancy, removeUnitOccupancy } from '../units.js'
 import { getCachedPath } from './pathfinding.js'
 import { selectedUnits, cleanupDestroyedSelectedUnits } from '../inputHandler.js'
 import { angleDiff, smoothRotateTowardsAngle, findAdjacentTile } from '../logic.js'
-import { updateUnitPosition, initializeUnitMovement, stopUnitMovement } from './unifiedMovement.js'
+import { updateUnitPosition, initializeUnitMovement, stopUnitMovement, isUnitMoving } from './unifiedMovement.js'
 import { updateRetreatBehavior, shouldExitRetreat, cancelRetreat } from '../behaviours/retreat.js'
 
 /**
@@ -42,6 +42,7 @@ export function updateUnitMovement(units, mapGrid, occupancyMap, gameState, now,
 
     // Initialize movement system for all units
     initializeUnitMovement(unit)
+    const wasMoving = isUnitMoving(unit)
 
     // Store previous position for collision detection
     const prevX = unit.x, prevY = unit.y
@@ -123,6 +124,12 @@ export function updateUnitMovement(units, mapGrid, occupancyMap, gameState, now,
 
     // Use unified movement system for natural movement
     updateUnitPosition(unit, mapGrid, occupancyMap, now, units, gameState, factories)
+
+    const isMovingNow = isUnitMoving(unit)
+    if (wasMoving !== isMovingNow) {
+      unit.shakeStartTime = now
+    }
+    unit.wasMoving = isMovingNow
 
     // Update last moved time
     if (unit.x !== prevX || unit.y !== prevY) {

--- a/src/rendering/tankImageRenderer.js
+++ b/src/rendering/tankImageRenderer.js
@@ -1,6 +1,6 @@
 // rendering/tankImageRenderer.js
 // Image-based tank rendering system using 3 separate image assets
-import { TILE_SIZE, RECOIL_DISTANCE, RECOIL_DURATION, MUZZLE_FLASH_DURATION, MUZZLE_FLASH_SIZE } from '../config.js'
+import { TILE_SIZE, RECOIL_DISTANCE, RECOIL_DURATION, MUZZLE_FLASH_DURATION, MUZZLE_FLASH_SIZE, TANK_SHAKE_DURATION, TANK_SHAKE_AMPLITUDE } from '../config.js'
 import tankImageConfigData from '../tankImageConfig.json'
 
 // Tank image asset cache - organized by tank variant
@@ -140,11 +140,21 @@ export function renderTankWithImages(ctx, unit, centerX, centerY) {
   const variant = getTankVariant(unit.type)
   const variantConfig = tankImageConfig[variant]
 
+  let shakeX = 0
+  let shakeY = 0
+  if (unit.shakeStartTime && now - unit.shakeStartTime < TANK_SHAKE_DURATION) {
+    const progress = (now - unit.shakeStartTime) / TANK_SHAKE_DURATION
+    const damp = 1 - progress
+    const amount = Math.sin(progress * Math.PI * 4) * TANK_SHAKE_AMPLITUDE * damp
+    shakeX = Math.cos(unit.direction) * amount
+    shakeY = Math.sin(unit.direction) * amount
+  }
+
   // Save context state
   ctx.save()
 
-  // Move to tank center
-  ctx.translate(centerX, centerY)
+  // Move to tank center with shake offset
+  ctx.translate(centerX + shakeX, centerY + shakeY)
 
   // 1. Render tank wagon (chassis)
   ctx.save()

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -1,5 +1,5 @@
 // rendering/unitRenderer.js
-import { TILE_SIZE, HARVESTER_CAPPACITY, HARVESTER_UNLOAD_TIME, RECOIL_DISTANCE, RECOIL_DURATION, MUZZLE_FLASH_DURATION, MUZZLE_FLASH_SIZE, TANK_FIRE_RANGE, ATTACK_TARGET_INDICATOR_SIZE, ATTACK_TARGET_BOUNCE_SPEED, UNIT_TYPE_COLORS, PARTY_COLORS } from '../config.js'
+import { TILE_SIZE, HARVESTER_CAPPACITY, HARVESTER_UNLOAD_TIME, RECOIL_DISTANCE, RECOIL_DURATION, MUZZLE_FLASH_DURATION, MUZZLE_FLASH_SIZE, TANK_FIRE_RANGE, ATTACK_TARGET_INDICATOR_SIZE, ATTACK_TARGET_BOUNCE_SPEED, UNIT_TYPE_COLORS, PARTY_COLORS, TANK_SHAKE_DURATION, TANK_SHAKE_AMPLITUDE } from '../config.js'
 import { gameState } from '../gameState.js'
 import { selectedUnits } from '../inputHandler.js'
 import { renderTankWithImages, areTankImagesLoaded } from './tankImageRenderer.js'
@@ -17,8 +17,19 @@ export class UnitRenderer {
     // Save the current context state
     ctx.save()
 
+    let shakeX = 0
+    let shakeY = 0
+    const now = performance.now()
+    if (unit.shakeStartTime && now - unit.shakeStartTime < TANK_SHAKE_DURATION) {
+      const progress = (now - unit.shakeStartTime) / TANK_SHAKE_DURATION
+      const damp = 1 - progress
+      const amount = Math.sin(progress * Math.PI * 4) * TANK_SHAKE_AMPLITUDE * damp
+      shakeX = Math.cos(unit.direction) * amount
+      shakeY = Math.sin(unit.direction) * amount
+    }
+
     // Translate to center of unit and rotate
-    ctx.translate(centerX, centerY)
+    ctx.translate(centerX + shakeX, centerY + shakeY)
     ctx.rotate(unit.direction)
 
     // Draw the rectangular body centered on the unit position

--- a/src/units.js
+++ b/src/units.js
@@ -436,7 +436,10 @@ export function createUnit(factory, unitType, x, y) {
     turretDirection: 0,
     rotationSpeed: unitProps.rotationSpeed,
     turretRotationSpeed: unitProps.turretRotationSpeed || unitProps.rotationSpeed,
-    isRotating: false
+    isRotating: false,
+    // Movement inertia effect
+    shakeStartTime: null,
+    wasMoving: false
   }
 
   // Add unit-specific properties


### PR DESCRIPTION
## Summary
- allow tanks to shake slightly when they start or stop moving
- track start/stop transitions for shake effect
- apply shaking in both image-based and fallback tank rendering

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npx eslint src/config.js src/units.js src/game/unitMovement.js src/rendering/tankImageRenderer.js src/rendering/unitRenderer.js` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ae7faf24c8328a8ac560b706e4b2f