### PR TITLE
Make spawn crystals impassable

### DIFF
--- a/src/ai/enemyBuilding.js
+++ b/src/ai/enemyBuilding.js
@@ -183,7 +183,8 @@ function ensurePathsAroundBuilding(x, y, width, height, mapGrid, buildings, fact
     // Check if this tile is blocked by another building
     if (mapGrid[checkY][checkX].building ||
         mapGrid[checkY][checkX].type === 'water' ||
-        mapGrid[checkY][checkX].type === 'rock') {
+        mapGrid[checkY][checkX].type === 'rock' ||
+        mapGrid[checkY][checkX].seedCrystal) {
       northClear = false
       break
     }
@@ -205,7 +206,8 @@ function ensurePathsAroundBuilding(x, y, width, height, mapGrid, buildings, fact
     // Check if this tile is blocked by another building
     if (mapGrid[checkY][checkX].building ||
         mapGrid[checkY][checkX].type === 'water' ||
-        mapGrid[checkY][checkX].type === 'rock') {
+        mapGrid[checkY][checkX].type === 'rock' ||
+        mapGrid[checkY][checkX].seedCrystal) {
       southClear = false
       break
     }
@@ -227,7 +229,8 @@ function ensurePathsAroundBuilding(x, y, width, height, mapGrid, buildings, fact
     // Check if this tile is blocked by another building
     if (mapGrid[checkY][checkX].building ||
         mapGrid[checkY][checkX].type === 'water' ||
-        mapGrid[checkY][checkX].type === 'rock') {
+        mapGrid[checkY][checkX].type === 'rock' ||
+        mapGrid[checkY][checkX].seedCrystal) {
       westClear = false
       break
     }
@@ -249,7 +252,8 @@ function ensurePathsAroundBuilding(x, y, width, height, mapGrid, buildings, fact
     // Check if this tile is blocked by another building
     if (mapGrid[checkY][checkX].building ||
         mapGrid[checkY][checkX].type === 'water' ||
-        mapGrid[checkY][checkX].type === 'rock') {
+        mapGrid[checkY][checkX].type === 'rock' ||
+        mapGrid[checkY][checkX].seedCrystal) {
       eastClear = false
       break
     }
@@ -404,7 +408,8 @@ function checkSimplePath(start, end, mapGrid, maxSteps) {
       // Check if passable
       if (mapGrid[nextY][nextX].building ||
           mapGrid[nextY][nextX].type === 'water' ||
-          mapGrid[nextY][nextX].type === 'rock') {
+          mapGrid[nextY][nextX].type === 'rock' ||
+          mapGrid[nextY][nextX].seedCrystal) {
         continue
       }
 

--- a/src/ai/enemySpawner.js
+++ b/src/ai/enemySpawner.js
@@ -48,7 +48,7 @@ function isPositionValidForSpawn(x, y, mapGrid, units) {
     return false
   }
   const tile = mapGrid[y][x]
-  if (tile.type === 'water' || tile.type === 'rock' || tile.building) {
+  if (tile.type === 'water' || tile.type === 'rock' || tile.building || tile.seedCrystal) {
     return false
   }
   for (const unit of units) {

--- a/src/ai/enemyStrategies.js
+++ b/src/ai/enemyStrategies.js
@@ -469,7 +469,7 @@ function checkAttackPath(unit, target, angle, distance, gameState) {
     
     // Check for obstacles in the path
     const tile = getTileAtPosition(checkX, checkY, gameState.mapGrid || [])
-    if (tile && (tile.type === 'rock' || tile.type === 'water')) {
+    if (tile && (tile.type === 'rock' || tile.type === 'water' || tile.seedCrystal)) {
       return false
     }
   }

--- a/src/behaviours/retreat.js
+++ b/src/behaviours/retreat.js
@@ -44,6 +44,7 @@ export function initiateRetreat(selectedUnits, targetX, targetY, mapGrid) {
       retreatTileY < 0 || retreatTileY >= mapGrid.length ||
       mapGrid[retreatTileY][retreatTileX].type === 'water' ||
       mapGrid[retreatTileY][retreatTileX].type === 'rock' ||
+      mapGrid[retreatTileY][retreatTileX].seedCrystal ||
       mapGrid[retreatTileY][retreatTileX].building) {
     return // Invalid retreat position
   }
@@ -468,7 +469,7 @@ function checkRetreatPathBlocked(unit, mapGrid, units) {
     
     // Check terrain obstacles
     const tile = mapGrid[currentY][currentX]
-    if (tile.type === 'water' || tile.type === 'rock' || tile.building) {
+    if (tile.type === 'water' || tile.type === 'rock' || tile.seedCrystal || tile.building) {
       return true // Terrain blocked
     }
     

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -313,6 +313,7 @@ export function canPlaceBuilding(type, tileX, tileY, mapGrid, units, buildings, 
       // Check map terrain
       if (mapGrid[y][x].type === 'water' ||
           mapGrid[y][x].type === 'rock' ||
+          mapGrid[y][x].seedCrystal ||
           mapGrid[y][x].building) {
         return false
       }
@@ -344,6 +345,7 @@ export function isTileValid(tileX, tileY, mapGrid, _units, _buildings, _factorie
   // Invalid terrain
   if (mapGrid[tileY][tileX].type === 'water' ||
       mapGrid[tileY][tileX].type === 'rock' ||
+      mapGrid[tileY][tileX].seedCrystal ||
       mapGrid[tileY][tileX].building) {
     return false
   }

--- a/src/game/unifiedMovement.js
+++ b/src/game/unifiedMovement.js
@@ -751,7 +751,7 @@ function isValidDodgePosition(x, y, mapGrid, units) {
   
   // Check terrain
   const tile = mapGrid[y][x];
-  if (tile.type === 'water' || tile.type === 'rock' || tile.building) {
+  if (tile.type === 'water' || tile.type === 'rock' || tile.seedCrystal || tile.building) {
     return false;
   }
   

--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -34,9 +34,11 @@ export class CursorManager {
     }
 
     // Check if the tile type is impassable
-    const tileType = mapGrid[tileY][tileX].type
-    const hasBuilding = mapGrid[tileY][tileX].building
-    return tileType === 'water' || tileType === 'rock' || hasBuilding
+    const tile = mapGrid[tileY][tileX]
+    const tileType = tile.type
+    const hasBuilding = tile.building
+    const hasSeedCrystal = tile.seedCrystal
+    return tileType === 'water' || tileType === 'rock' || hasBuilding || hasSeedCrystal
   }
 
   // Function to update custom cursor position and visibility

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -407,7 +407,7 @@ export class KeyboardHandler {
     
     // Check tile type and buildings
     const tile = mapGrid[y][x]
-    if (tile.type === 'water' || tile.type === 'rock' || tile.building) {
+    if (tile.type === 'water' || tile.type === 'rock' || tile.seedCrystal || tile.building) {
       return false
     }
     


### PR DESCRIPTION
## Summary
- prevent selecting blocked terrain over seed crystals
- treat seed crystal tiles as impassable in pathfinding and movement
- block buildings and spawns on seed crystal tiles

## Testing
- `npm run lint` *(fails: trailing spaces and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687178bf9cc88328b74dc6fce2657d3b