### PR TITLE
Implement narrated sound queuing

### DIFF
--- a/src/buildingRepairHandler.js
+++ b/src/buildingRepairHandler.js
@@ -36,7 +36,7 @@ export function buildingRepairHandler(e, gameState, gameCanvas, mapGrid, units, 
           gameState.money += refund
           gameState.buildingsUnderRepair = gameState.buildingsUnderRepair.filter(r => r !== existing)
           showNotification('Building repair cancelled')
-          playSound('constructionCancelled')
+          playSound('constructionCancelled', 1.0, 0, true)
           moneyEl.textContent = gameState.money
           return
         }
@@ -51,7 +51,7 @@ export function buildingRepairHandler(e, gameState, gameCanvas, mapGrid, units, 
         if (timeSinceLastAttack < 10) {
           // Building is under attack - enable repair mode but don't start repair yet
           // Play the sound immediately
-          playSound('Repair_impossible_when_under_attack', 1.0, 30)
+          playSound('Repair_impossible_when_under_attack', 1.0, 30, true)
           
           // Set up delayed repair with countdown
           if (!gameState.buildingsAwaitingRepair) {
@@ -190,7 +190,7 @@ export function buildingRepairHandler(e, gameState, gameCanvas, mapGrid, units, 
         savePlayerBuildPatterns(buildingType)
       } else {
         // Play error sound for invalid placement
-        playSound('construction_obstructed')
+        playSound('construction_obstructed', 1.0, 0, true)
       }
     } catch (error) {
       console.error('Error during building placement:', error)

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -639,7 +639,7 @@ export function updateBuildingsUnderRepair(gameState, currentTime) {
       // Repair is complete
       repairInfo.building.health = repairInfo.targetHealth
       gameState.buildingsUnderRepair.splice(i, 1)
-      playSound('constructionComplete')
+      playSound('constructionComplete', 1.0, 0, true)
     } else {
       // Repair in progress - update health proportionally
       const newHealth = repairInfo.startHealth + (repairInfo.healthToRepair * progress)
@@ -714,7 +714,7 @@ function actuallyPauseRepair(building, gameState, currentTime) {
           factoryCost: isFactory ? 5000 : undefined
         })
         
-        playSound('construction_paused')
+        playSound('construction_paused', 1.0, 0, true)
         showNotification('Repair paused due to attack!')
       }
     }
@@ -736,7 +736,7 @@ export function updateBuildingsAwaitingRepair(gameState, currentTime) {
     if (building.lastAttackedTime && building.lastAttackedTime > awaitingRepair.lastAttackedTime) {
       // Building was attacked again - reset the countdown
       awaitingRepair.lastAttackedTime = building.lastAttackedTime
-      playSound('Repair_impossible_when_under_attack', 1.0, 30)
+      playSound('Repair_impossible_when_under_attack', 1.0, 30, true)
       showNotification('Repair countdown reset - building under attack!')
     }
     
@@ -773,7 +773,7 @@ export function updateBuildingsAwaitingRepair(gameState, currentTime) {
           })
 
           showNotification(`Factory repair started for $${awaitingRepair.repairCost}`)
-          playSound('construction_started')
+          playSound('construction_started', 1.0, 0, true)
         } else {
           // Start building repair manually (don't use repairBuilding as it starts immediately)
           if (!gameState.buildingsUnderRepair) {
@@ -798,7 +798,7 @@ export function updateBuildingsAwaitingRepair(gameState, currentTime) {
           })
 
           showNotification(`Building repair started for $${awaitingRepair.repairCost}`)
-          playSound('construction_started')
+          playSound('construction_started', 1.0, 0, true)
         }
       }
       

--- a/src/game/buildingSystem.js
+++ b/src/game/buildingSystem.js
@@ -31,7 +31,7 @@ export function updateBuildings(gameState, units, bullets, factories, mapGrid, d
         } else if (building.owner !== gameState.humanPlayer) {
           gameState.enemyBuildingsDestroyed++
           // Play enemy building destroyed sound when an enemy building is killed
-          playSound('enemyBuildingDestroyed', 1.0)
+          playSound('enemyBuildingDestroyed', 1.0, 0, true)
         }
 
         // Remove building from selected units if it was selected

--- a/src/game/bulletSystem.js
+++ b/src/game/bulletSystem.js
@@ -169,7 +169,7 @@ export function updateBullets(bullets, units, factories, gameState, mapGrid) {
             }
             // Play unit lost sound if player unit dies
             if (unit.owner === gameState.humanPlayer) {
-              playSound('unitLost', 1.0)
+              playSound('unitLost', 1.0, 0, true)
             }
           }
 

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -148,7 +148,7 @@ export function cleanupDestroyedUnits(units, gameState) {
       } else {
         gameState.enemyUnitsDestroyed++
         // Play enemy unit destroyed sound when an enemy unit is killed
-        playSound('enemyUnitDestroyed', 1.0)
+        playSound('enemyUnitDestroyed', 1.0, 0, true)
       }
       
       // Remove unit from cheat system tracking if it exists
@@ -187,7 +187,7 @@ export function cleanupDestroyedFactories(factories, mapGrid, gameState) {
       } else {
         gameState.enemyBuildingsDestroyed++
         // Play enemy building destroyed sound when an enemy factory is destroyed
-        playSound('enemyBuildingDestroyed', 1.0)
+        playSound('enemyBuildingDestroyed', 1.0, 0, true)
       }
       
       // Play explosion sound with reduced volume (0.5)
@@ -252,7 +252,7 @@ export function checkGameEndConditions(factories, gameState) {
     gameState.gameOverMessage = 'DEFEAT - All your buildings have been destroyed!'
     gameState.losses++
     // Play battle lost sound and human player defeat sound
-    playSound('battleLost', 1.0)
+    playSound('battleLost', 1.0, 0, true)
     return true
   }
 
@@ -284,7 +284,7 @@ export function checkGameEndConditions(factories, gameState) {
   // Play defeat sounds for newly defeated AI players
   defeatedAiPlayers.forEach((playerId, index) => {
     setTimeout(() => {
-      playSound(getPlayerDefeatSound(playerId), 1.0)
+      playSound(getPlayerDefeatSound(playerId), 1.0, 0, true)
     }, index * 500) // Stagger the defeat sounds by 500ms each
   })
 
@@ -295,7 +295,7 @@ export function checkGameEndConditions(factories, gameState) {
     gameState.gameOverMessage = 'VICTORY - All enemy buildings destroyed!'
     gameState.wins++
     // Play battle won sound
-    playSound('battleWon', 0.8)
+    playSound('battleWon', 0.8, 0, true)
     return true
   }
 

--- a/src/input/cheatSystem.js
+++ b/src/input/cheatSystem.js
@@ -345,7 +345,7 @@ export class CheatSystem {
     })
 
     showNotification('🛡️ God mode ENABLED - All player units are now invincible!', 4000)
-    playSound('constructionComplete', 0.7)
+    playSound('constructionComplete', 0.7, 0, true)
   }
 
   disableGodMode() {

--- a/src/main.js
+++ b/src/main.js
@@ -524,6 +524,11 @@ document.addEventListener('DOMContentLoaded', () => {
 // Debug helper to access selectedUnits
 window.debugGetSelectedUnits = () => selectedUnits
 
+// Debug helper to test narrated sound stacking
+import { testNarratedSounds, playSound } from './sound.js'
+window.testNarratedSounds = testNarratedSounds
+window.debugPlaySound = playSound
+
 // Export functions for backward compatibility - these are now handled by ProductionController
 export function updateVehicleButtonStates() {
   // This function is now handled by ProductionController

--- a/src/productionQueue.js
+++ b/src/productionQueue.js
@@ -164,7 +164,7 @@ export const productionQueue = {
 
     // Mark button as active
     item.button.classList.add('active')
-    playSound('productionStart')
+    playSound('productionStart', 1.0, 0, true)
 
     // Show notification about production speed if multiple factories exist
     if (vehicleUnitTypes.includes(item.type) && vehicleMultiplier > 1) {
@@ -264,7 +264,7 @@ export const productionQueue = {
 
     // Mark button as active
     item.button.classList.add('active')
-    playSound('productionStart')
+    playSound('productionStart', 1.0, 0, true)
 
     // Show notification about construction speed if we have construction yards
     if (constructionMultiplier > 1) {
@@ -403,7 +403,7 @@ export const productionQueue = {
         // Play random unit ready sound
         const readySounds = ['unitReady01', 'unitReady02', 'unitReady03']
         const randomSound = readySounds[Math.floor(Math.random() * readySounds.length)]
-        playSound(randomSound, 1.0)
+        playSound(randomSound, 1.0, 0, true)
 
         // If the produced unit is a harvester, automatically send it to harvest
         if (newUnit.type === 'harvester') {
@@ -493,7 +493,7 @@ export const productionQueue = {
       progressBar.style.width = '0%'
     }
 
-    playSound('constructionComplete')
+    playSound('constructionComplete', 1.0, 0, true)
 
     this.currentBuilding = null
 
@@ -509,10 +509,10 @@ export const productionQueue = {
     this.pausedUnit = !this.pausedUnit
     if (this.pausedUnit) {
       this.currentUnit.button.classList.add('paused')
-      playSound('productionPaused')
+      playSound('productionPaused', 1.0, 0, true)
     } else {
       this.currentUnit.button.classList.remove('paused')
-      playSound('productionStart')
+      playSound('productionStart', 1.0, 0, true)
     }
   },
 
@@ -522,10 +522,10 @@ export const productionQueue = {
     this.pausedBuilding = !this.pausedBuilding
     if (this.pausedBuilding) {
       this.currentBuilding.button.classList.add('paused')
-      playSound('productionPaused')
+      playSound('productionPaused', 1.0, 0, true)
     } else {
       this.currentBuilding.button.classList.remove('paused')
-      playSound('productionStart')
+      playSound('productionStart', 1.0, 0, true)
     }
   },
 
@@ -536,7 +536,7 @@ export const productionQueue = {
     const type = this.currentUnit.type
 
     // Play cancel sound before cancelling
-    playSound('productionCancelled')
+    playSound('productionCancelled', 1.0, 0, true)
 
     // Return money for the current production (refund only paid amount)
     gameState.money += this.unitPaid || 0
@@ -573,7 +573,7 @@ export const productionQueue = {
     const type = this.currentBuilding.type
 
     // Play cancel sound before cancelling
-    playSound('productionCancelled')
+    playSound('productionCancelled', 1.0, 0, true)
 
     // Return money for the current production (refund only paid amount)
     gameState.money += this.buildingPaid || 0
@@ -618,7 +618,7 @@ export const productionQueue = {
     const type = completedBuilding.type
 
     // Play cancel sound
-    playSound('productionCancelled')
+    playSound('productionCancelled', 1.0, 0, true)
 
     // Return money for the building
     gameState.money += buildingCosts[type] || 0
@@ -734,7 +734,7 @@ export const productionQueue = {
     const completedBuilding = this.completedBuildings[completedBuildingIndex]
 
     // Play cancel sound
-    playSound('productionCancelled')
+    playSound('productionCancelled', 1.0, 0, true)
 
     // Return money for the building
     gameState.money += buildingCosts[buildingType] || 0

--- a/src/ui/eventHandlers.js
+++ b/src/ui/eventHandlers.js
@@ -304,7 +304,7 @@ export class EventHandlers {
           }
         } else {
           // Play error sound for invalid placement
-          playSound('construction_obstructed')
+          playSound('construction_obstructed', 1.0, 0, true)
         }
       } catch (error) {
         console.error('Error during building placement:', error)

--- a/src/ui/productionController.js
+++ b/src/ui/productionController.js
@@ -412,7 +412,7 @@ export class ProductionController {
         if (label) label.style.display = 'block'
       }
       if (!skipSound) {
-        playSound('new_units_types_available', 1.0, 5) // Throttle for 5 seconds
+        playSound('new_units_types_available', 1.0, 5, true) // Throttle for 5 seconds
       }
       // Update button states to ensure unlocked units are not disabled
       this.updateVehicleButtonStates()
@@ -432,7 +432,7 @@ export class ProductionController {
         if (label) label.style.display = 'block'
       }
       if (!skipSound) {
-        playSound('new_building_types_available', 1.0, 5) // Throttle for 5 seconds
+        playSound('new_building_types_available', 1.0, 5, true) // Throttle for 5 seconds
       }
       // Update button states to ensure unlocked buildings are not disabled
       this.updateBuildingButtonStates()
@@ -489,13 +489,13 @@ export class ProductionController {
     // Play appropriate sound based on what was unlocked
     if (unlockedUnits > 0 && unlockedBuildings > 0) {
       // Both units and buildings unlocked
-      playSound('new_production_options', 1.0, 5)
+      playSound('new_production_options', 1.0, 5, true)
     } else if (unlockedUnits > 0) {
       // Only units unlocked
-      playSound('new_units_types_available', 1.0, 5)
+      playSound('new_units_types_available', 1.0, 5, true)
     } else if (unlockedBuildings > 0) {
       // Only buildings unlocked
-      playSound('new_building_types_available', 1.0, 5)
+      playSound('new_building_types_available', 1.0, 5, true)
     }
 
     // Update tab states after batch unlock


### PR DESCRIPTION
## Summary
- update sound system to queue narrated sounds
- queue key narration events so they don't overlap

## Testing
- `npm run lint` *(fails: 2513 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68723c483a4c8328aa1464d35aad1247