### PR TITLE
Throttle AI behavior updates

### DIFF
--- a/src/ai/enemySpawner.js
+++ b/src/ai/enemySpawner.js
@@ -90,6 +90,7 @@ export function spawnEnemyUnit(spawnBuilding, unitType, units, mapGrid, gameStat
     lastPathCalcTime: 0,
     lastPositionCheckTime: 0,
     lastTargetChangeTime: 0,
+    lastDecisionTime: 0,
     direction: 0,
     targetDirection: 0,
     turretDirection: 0,

--- a/src/ai/enemyUnitBehavior.js
+++ b/src/ai/enemyUnitBehavior.js
@@ -1,4 +1,4 @@
-import { TILE_SIZE, TANK_FIRE_RANGE, ATTACK_PATH_CALC_INTERVAL } from '../config.js'
+import { TILE_SIZE, TANK_FIRE_RANGE, ATTACK_PATH_CALC_INTERVAL, AI_DECISION_INTERVAL } from '../config.js'
 import { findPath } from '../units.js'
 import { applyEnemyStrategies, shouldConductGroupAttack, shouldRetreatLowHealth } from './enemyStrategies.js'
 import { getClosestEnemyFactory, isEnemyTo } from './enemyUtils.js'
@@ -31,10 +31,12 @@ function updateAIUnit(unit, units, gameState, mapGrid, now, aiPlayerId, targeted
 
     // Combat unit behavior
     if (unit.type === 'tank' || unit.type === 'tank_v1' || unit.type === 'rocketTank' || unit.type === 'tank-v2' || unit.type === 'tank-v3') {
-      // Target selection throttled to every 2 seconds
+      const allowDecision = !unit.lastDecisionTime || (now - unit.lastDecisionTime >= AI_DECISION_INTERVAL)
+      // Target selection throttled using a separate timer
       const canChangeTarget = !unit.lastTargetChangeTime || (now - unit.lastTargetChangeTime >= 2000)
-      if (canChangeTarget) {
-        let newTarget = null
+      if (allowDecision) {
+        if (canChangeTarget) {
+          let newTarget = null
 
         // Check if unit should retreat due to low health (flee to base mode)
         const shouldFlee = shouldRetreatLowHealth(unit)
@@ -188,6 +190,9 @@ function updateAIUnit(unit, units, gameState, mapGrid, now, aiPlayerId, targeted
           unit.lastPathCalcTime = now
         }
       }
+
+      unit.lastDecisionTime = now
+    }
 
       // --- Dodge Logic: toggled by ENABLE_DODGING ---
       if (ENABLE_DODGING) {

--- a/src/config.js
+++ b/src/config.js
@@ -118,6 +118,9 @@ export const PATH_CALC_INTERVAL = 2000
 // Attack/chase pathfinding interval - throttled to prevent excessive recalculation (in milliseconds)
 export const ATTACK_PATH_CALC_INTERVAL = 3000
 
+// General AI decision interval for heavy logic like target selection (in milliseconds)
+export const AI_DECISION_INTERVAL = 200
+
 // Smoke emission for buildings
 export const BUILDING_SMOKE_EMIT_INTERVAL = 1000 // ms between puffs
 


### PR DESCRIPTION
## Summary
- space out AI decisions by checking `AI_DECISION_INTERVAL`
- add timer storage on spawned units
- expose interval constant in config

## Testing
- `npm run lint` *(fails: trailing spaces etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687287aeaa58832885b9842ad628cf8b