### PR TITLE
Load background music on demand

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,6 @@ import { buildingData } from './buildings.js'
 import { productionQueue } from './productionQueue.js'
 import { TILE_SIZE, MAP_TILES_X, MAP_TILES_Y } from './config.js'
 import { initFactories } from './factories.js'
-import { initBackgroundMusic } from './sound.js'
 import { initializeGameAssets, generateMap as generateMapFromSetup, cleanupOreFromBuildings } from './gameSetup.js'
 import { initSaveGameSystem } from './saveGame.js'
 import { showNotification } from './ui/notifications.js'
@@ -214,8 +213,7 @@ class Game {
     // Set game state
     gameState.gameStarted = true
 
-    // Initialize background music
-    document.addEventListener('click', initBackgroundMusic, { once: true })
+    // Background music is loaded on demand via the music control button
   }
 
   setupSpeedControl() {

--- a/src/sound.js
+++ b/src/sound.js
@@ -251,19 +251,33 @@ export function testNarratedSounds() {
 const backgroundMusicFiles = ['music01.mp3'] // add more files as needed
 export let bgMusicAudio = null
 
-export function initBackgroundMusic() {
+export async function initBackgroundMusic() {
+  if (bgMusicAudio) return
   if (!backgroundMusicFiles || backgroundMusicFiles.length === 0) return
+
   const file = backgroundMusicFiles[Math.floor(Math.random() * backgroundMusicFiles.length)]
   bgMusicAudio = new Audio('sound/music/' + file)
   bgMusicAudio.loop = true
   bgMusicAudio.volume = masterVolume // Apply master volume to background music
-  // Comment out or remove the auto-play so music does not start on startup.
-  // bgMusicAudio.play().catch(e => {
-  //   console.error("Error playing background music:", e)
-  // })
+
+  return new Promise(resolve => {
+    const cleanup = () => {
+      bgMusicAudio.removeEventListener('canplaythrough', cleanup)
+      bgMusicAudio.removeEventListener('error', cleanup)
+      resolve()
+    }
+
+    bgMusicAudio.addEventListener('canplaythrough', cleanup, { once: true })
+    bgMusicAudio.addEventListener('error', cleanup, { once: true })
+    bgMusicAudio.load()
+  })
 }
 
-export function toggleBackgroundMusic() {
+export async function toggleBackgroundMusic() {
+  if (!bgMusicAudio) {
+    await initBackgroundMusic()
+  }
+
   if (bgMusicAudio) {
     if (bgMusicAudio.paused) {
       bgMusicAudio.play().catch(e => {

--- a/src/ui/eventHandlers.js
+++ b/src/ui/eventHandlers.js
@@ -3,7 +3,7 @@
 
 import { gameState } from '../gameState.js'
 import { productionQueue } from '../productionQueue.js'
-import { initBackgroundMusic, toggleBackgroundMusic, bgMusicAudio, setMasterVolume, getMasterVolume } from '../sound.js'
+import { toggleBackgroundMusic, bgMusicAudio, setMasterVolume, getMasterVolume } from '../sound.js'
 import { buildingRepairHandler } from '../buildingRepairHandler.js'
 import { buildingSellHandler } from '../buildingSellHandler.js'
 import { showNotification } from './notifications.js'
@@ -98,11 +98,9 @@ export class EventHandlers {
     })
 
     // Background music initialization and control
-    document.addEventListener('click', initBackgroundMusic, { once: true })
-
     if (musicControlButton) {
-      musicControlButton.addEventListener('click', () => {
-        toggleBackgroundMusic()
+      musicControlButton.addEventListener('click', async () => {
+        await toggleBackgroundMusic()
 
         // Toggle music icon
         const musicIcon = musicControlButton.querySelector('.music-icon')


### PR DESCRIPTION
## Summary
- defer background music initialization until user interacts with the music button
- update `toggleBackgroundMusic` to initialize music if needed
- remove global click handler that loaded music automatically

## Testing
- `npm run lint` *(fails: trailing spaces, indentation, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68742fb6b4d88328bb9233f622f509d8