### PR TITLE
Add frame time stats to performance overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,7 +282,12 @@
     <canvas id="gameCanvas"></canvas>
     
     <!-- FPS Display Overlay -->
-    <div id="fpsDisplay" class="fps-overlay">FPS: --</div>
+    <div id="fpsDisplay" class="fps-overlay">
+      <div id="fpsValue">FPS: --</div>
+      <div id="frameTimeValue">Frame: -- ms</div>
+      <div id="frameTimeMin">Min: -- ms</div>
+      <div id="frameTimeMax">Max: -- ms</div>
+    </div>
     
     <script src="/src/main.js" type="module"></script>
     <script>

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -72,7 +72,10 @@ export const gameState = {
     frameCount: 0,
     lastTime: 0,
     fps: 0,
-    frameTimes: []  // Store last 60 frame times for smooth averaging
+    frameTimes: [],  // Store last 60 frame times for smooth averaging
+    avgFrameTime: 0,
+    minFrameTime: 0,
+    maxFrameTime: 0
   },
 
   // Tank image rendering toggle - initialize from config


### PR DESCRIPTION
## Summary
- extend FPS overlay to include frame time information
- track frame time stats in `gameState`
- compute avg/min/max frame time each second

## Testing
- `npm run lint` *(fails: 2574 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68745249e0708328b1b66f57e1cd2722