### PR TITLE
Reserve refinery exit areas

### DIFF
--- a/src/ai/enemyBuilding.js
+++ b/src/ai/enemyBuilding.js
@@ -184,7 +184,8 @@ function ensurePathsAroundBuilding(x, y, width, height, mapGrid, buildings, fact
     if (mapGrid[checkY][checkX].building ||
         mapGrid[checkY][checkX].type === 'water' ||
         mapGrid[checkY][checkX].type === 'rock' ||
-        mapGrid[checkY][checkX].seedCrystal) {
+        mapGrid[checkY][checkX].seedCrystal ||
+        mapGrid[checkY][checkX].noBuild) {
       northClear = false
       break
     }
@@ -207,7 +208,8 @@ function ensurePathsAroundBuilding(x, y, width, height, mapGrid, buildings, fact
     if (mapGrid[checkY][checkX].building ||
         mapGrid[checkY][checkX].type === 'water' ||
         mapGrid[checkY][checkX].type === 'rock' ||
-        mapGrid[checkY][checkX].seedCrystal) {
+        mapGrid[checkY][checkX].seedCrystal ||
+        mapGrid[checkY][checkX].noBuild) {
       southClear = false
       break
     }
@@ -230,7 +232,8 @@ function ensurePathsAroundBuilding(x, y, width, height, mapGrid, buildings, fact
     if (mapGrid[checkY][checkX].building ||
         mapGrid[checkY][checkX].type === 'water' ||
         mapGrid[checkY][checkX].type === 'rock' ||
-        mapGrid[checkY][checkX].seedCrystal) {
+        mapGrid[checkY][checkX].seedCrystal ||
+        mapGrid[checkY][checkX].noBuild) {
       westClear = false
       break
     }
@@ -253,7 +256,8 @@ function ensurePathsAroundBuilding(x, y, width, height, mapGrid, buildings, fact
     if (mapGrid[checkY][checkX].building ||
         mapGrid[checkY][checkX].type === 'water' ||
         mapGrid[checkY][checkX].type === 'rock' ||
-        mapGrid[checkY][checkX].seedCrystal) {
+        mapGrid[checkY][checkX].seedCrystal ||
+        mapGrid[checkY][checkX].noBuild) {
       eastClear = false
       break
     }
@@ -409,7 +413,8 @@ function checkSimplePath(start, end, mapGrid, maxSteps) {
       if (mapGrid[nextY][nextX].building ||
           mapGrid[nextY][nextX].type === 'water' ||
           mapGrid[nextY][nextX].type === 'rock' ||
-          mapGrid[nextY][nextX].seedCrystal) {
+          mapGrid[nextY][nextX].seedCrystal ||
+          mapGrid[nextY][nextX].noBuild) {
         continue
       }
 

--- a/src/gameSetup.js
+++ b/src/gameSetup.js
@@ -134,7 +134,7 @@ export function generateMap(seed, mapGrid, MAP_TILES_X, MAP_TILES_Y) {
     mapGrid[y] = []
     for (let x = 0; x < MAP_TILES_X; x++) {
       // Initially all land with no ore overlay
-      mapGrid[y][x] = { type: 'land', ore: false, seedCrystal: false }
+      mapGrid[y][x] = { type: 'land', ore: false, seedCrystal: false, noBuild: 0 }
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent building on refinery/vehicle factory exit tiles
- avoid building around refineries to keep them accessible
- initialise map tiles with `noBuild` flag
- update enemy building logic to respect reserved tiles

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874d4aecf3c8328b3ad90f40d83258d