### PR TITLE
Fix street movement bonus

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -138,6 +138,10 @@ export const STUCK_THRESHOLD = 500  // Consider units stuck after 0.5 seconds
 export const STUCK_HANDLING_COOLDOWN = 1250  // Cooldown between stuck handling attempts
 export const DODGE_ATTEMPT_COOLDOWN = 500  // Cooldown between dodge attempts
 
+// Street movement and pathfinding modifiers
+export const STREET_SPEED_MULTIPLIER = 1.5  // Units move 50% faster on streets
+export const STREET_PATH_COST = 1 / STREET_SPEED_MULTIPLIER  // Prefer streets in pathfinding
+
 // Unit costs
 export const UNIT_COSTS = {
   tank: 1000,

--- a/src/game/unifiedMovement.js
+++ b/src/game/unifiedMovement.js
@@ -1,5 +1,5 @@
 // unifiedMovement.js - Unified movement system for all ground units
-import { TILE_SIZE, STUCK_CHECK_INTERVAL, STUCK_THRESHOLD, STUCK_HANDLING_COOLDOWN, DODGE_ATTEMPT_COOLDOWN } from '../config.js'
+import { TILE_SIZE, STUCK_CHECK_INTERVAL, STUCK_THRESHOLD, STUCK_HANDLING_COOLDOWN, DODGE_ATTEMPT_COOLDOWN, STREET_SPEED_MULTIPLIER } from '../config.js'
 import { clearStuckHarvesterOreField, handleStuckHarvester } from './harvesterLogic.js'
 import { updateUnitOccupancy, findPath } from '../units.js'
 
@@ -67,7 +67,11 @@ export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [],
   
   const movement = unit.movement;
   const speedModifier = unit.speedModifier || 1;
-  const effectiveMaxSpeed = MOVEMENT_CONFIG.MAX_SPEED * speedModifier;
+  const tileX = Math.floor((unit.x + TILE_SIZE / 2) / TILE_SIZE);
+  const tileY = Math.floor((unit.y + TILE_SIZE / 2) / TILE_SIZE);
+  const onStreet = mapGrid[tileY] && mapGrid[tileY][tileX] && mapGrid[tileY][tileX].type === 'street';
+  const terrainMultiplier = onStreet ? STREET_SPEED_MULTIPLIER : 1;
+  const effectiveMaxSpeed = MOVEMENT_CONFIG.MAX_SPEED * speedModifier * terrainMultiplier;
   
   // Handle path following
   if (unit.path && unit.path.length > 0) {

--- a/src/units.js
+++ b/src/units.js
@@ -5,7 +5,8 @@ import {
   UNIT_PROPERTIES,
   PATHFINDING_LIMIT,
   DIRECTIONS,
-  MAX_SPAWN_SEARCH_DISTANCE
+  MAX_SPAWN_SEARCH_DISTANCE,
+  STREET_PATH_COST
 } from './config.js'
 import { getUniqueId, updateUnitSpeedModifier } from './utils.js'
 import { initializeUnitMovement } from './game/unifiedMovement.js'
@@ -292,7 +293,10 @@ export function findPath(start, end, mapGrid, occupancyMap = null, pathFindingLi
       // Skip if occupancyMap is provided and the tile is occupied.
       if (occupancyMap && occupancyMap[neighbor.y][neighbor.x]) continue
 
-      const gScore = currentNode.g + Math.hypot(neighbor.x - currentNode.x, neighbor.y - currentNode.y)
+      const baseCost = Math.hypot(neighbor.x - currentNode.x, neighbor.y - currentNode.y)
+      const tileType = mapGrid[neighbor.y][neighbor.x].type
+      const terrainCost = tileType === 'street' ? STREET_PATH_COST : 1
+      const gScore = currentNode.g + baseCost * terrainCost
       let foundInHeap = false
       for (const node of openHeap.content) {
         if (node.x === neighbor.x && node.y === neighbor.y) {


### PR DESCRIPTION
## Summary
- add constants for street bonuses
- boost unit speed when on street tiles
- make pathfinder prefer streets

## Testing
- `npm run lint` *(fails: trailing spaces etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68750f4907a88328811a16382c38c6db