### PR TITLE
Fix control group persistence after load

### DIFF
--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -638,6 +638,20 @@ export class KeyboardHandler {
     this.cheatSystem.cleanupDestroyedUnit(unitId)
   }
 
+  // Rebuild control groups from units after loading a save game
+  rebuildControlGroupsFromUnits(units) {
+    this.controlGroups = {}
+    if (!Array.isArray(units)) return
+    units.forEach(unit => {
+      if (unit && unit.groupNumber) {
+        if (!this.controlGroups[unit.groupNumber]) {
+          this.controlGroups[unit.groupNumber] = []
+        }
+        this.controlGroups[unit.groupNumber].push(unit)
+      }
+    })
+  }
+
   handleStopAttacking() {
     if (!this.selectedUnits || this.selectedUnits.length === 0) {
       this.showNotification('No units selected to stop attacking', 2000)

--- a/src/inputHandler.js
+++ b/src/inputHandler.js
@@ -91,3 +91,8 @@ export function setupInputHandlers(units, factories, mapGrid) {
 export function cleanupDestroyedSelectedUnits() {
   selectionManager.cleanupDestroyedSelectedUnits(selectedUnits)
 }
+
+// Expose keyboard handler instance for modules that need to interact with it
+export function getKeyboardHandler() {
+  return keyboardHandler
+}

--- a/src/saveGame.js
+++ b/src/saveGame.js
@@ -14,6 +14,7 @@ import { getTextureManager } from './rendering.js'
 import { assignHarvesterToOptimalRefinery } from './game/harvesterLogic.js'
 import { productionQueue } from './productionQueue.js'
 import { getCurrentGame } from './main.js'
+import { getKeyboardHandler } from './inputHandler.js'
 
 // === Save/Load Game Logic ===
 export function getSaveGames() {
@@ -227,6 +228,13 @@ export function loadGame(key) {
       
       units.push(hydrated)
     })
+
+    // Rebuild control groups based on restored units
+    const kbHandler = getKeyboardHandler()
+    if (kbHandler && typeof kbHandler.rebuildControlGroupsFromUnits === 'function') {
+      kbHandler.rebuildControlGroupsFromUnits(units)
+    }
+
     gameState.buildings.length = 0
     loaded.buildings.forEach(b => {
       // Rehydrate defensive buildings (turrets) so they work after loading


### PR DESCRIPTION
## Summary
- expose keyboard handler instance via `getKeyboardHandler`
- rebuild control groups from loaded units when loading a save
- add helper method `rebuildControlGroupsFromUnits`

## Testing
- `npm run lint` *(fails: trailing spaces, indentation errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68752346d37083288fcd8db31bb3ef85