### PR TITLE
Move AI loop into web worker

### DIFF
--- a/src/aiWorker.js
+++ b/src/aiWorker.js
@@ -1,0 +1,29 @@
+import { updateEnemyAI } from './enemy.js'
+
+let currentState = null
+
+self.onmessage = (e) => {
+  if (e.data.type === 'init' || e.data.type === 'state') {
+    currentState = e.data.state
+    if (e.data.type === 'init') {
+      aiLoop()
+    }
+  }
+}
+
+function aiLoop() {
+  const start = performance.now()
+  if (currentState) {
+    updateEnemyAI(
+      currentState.units,
+      currentState.factories,
+      currentState.bullets,
+      currentState.mapGrid,
+      currentState.gameState
+    )
+  }
+  const elapsed = performance.now() - start
+  self.postMessage({ type: 'update', state: currentState })
+  const interval = Math.max(300, Math.ceil(elapsed / 300) * 300)
+  setTimeout(aiLoop, interval)
+}

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -7,7 +7,6 @@ import {
 import { emitSmokeParticles } from './utils/smokeUtils.js'
 import { getBuildingImage } from './buildingImageMap.js'
 
-import { updateEnemyAI } from './enemy.js'
 import { cleanupDestroyedSelectedUnits } from './inputHandler.js'
 import { updateBuildingsUnderRepair, updateBuildingsAwaitingRepair, buildingData } from './buildings.js'
 import { handleSelfRepair } from './utils.js'
@@ -185,8 +184,7 @@ export function updateGame(delta, mapGrid, factories, units, bullets, gameState)
     // Check for game end conditions after factory/building destruction
     checkGameEndConditions(factories, gameState)
 
-    // Enemy AI updates
-    updateEnemyAI(units, factories, bullets, mapGrid, gameState)
+
 
     // Update buildings under repair
     if (gameState.buildingsUnderRepair && gameState.buildingsUnderRepair.length > 0) {


### PR DESCRIPTION
## Summary
- create `aiWorker` for running enemy AI off the main thread
- launch the worker from `Game` and sync game state with it
- remove direct AI updates from the render loop

## Testing
- `npm run lint` *(fails: trailing spaces and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68754e3e89888328bf60bf03bd814cc4