### PR TITLE
Remove milestone overlay frame

### DIFF
--- a/src/rendering/minimapRenderer.js
+++ b/src/rendering/minimapRenderer.js
@@ -169,24 +169,6 @@ export class MinimapRenderer {
       minimapCtx.fillText('Video Error', minimapWidth / 2, minimapHeight / 2)
     }
 
-    // Add a border to indicate video mode
-    minimapCtx.strokeStyle = '#00ff00'
-    minimapCtx.lineWidth = 2
-    minimapCtx.strokeRect(1, 1, minimapWidth - 2, minimapHeight - 2)
-
-    // Add video progress indicator
-    const progress = videoOverlay.getVideoProgress()
-    if (progress >= 0) {
-      const progressBarHeight = 3
-      const progressBarY = minimapHeight - progressBarHeight - 2
-      
-      // Progress background
-      minimapCtx.fillStyle = 'rgba(0, 0, 0, 0.7)'
-      minimapCtx.fillRect(2, progressBarY, minimapWidth - 4, progressBarHeight)
-      
-      // Progress bar
-      minimapCtx.fillStyle = '#00ff00'
-      minimapCtx.fillRect(2, progressBarY, (minimapWidth - 4) * progress, progressBarHeight)
-    }
+    // Draw the video without additional borders or progress bars
   }
 }

--- a/src/ui/videoOverlay.js
+++ b/src/ui/videoOverlay.js
@@ -35,9 +35,6 @@ export class VideoOverlay {
           </div>
           <button class="skip-video-btn">Skip</button>
         </div>
-        <div class="video-progress">
-          <div class="progress-bar"></div>
-        </div>
       </div>
     `
 
@@ -65,9 +62,7 @@ export class VideoOverlay {
         height: 160px;
         z-index: -1;
         background: rgba(0, 0, 0, 0.95);
-        border: 2px solid #00ff00;
         border-radius: 8px;
-        box-shadow: 0 4px 20px rgba(0, 255, 0, 0.3);
         transition: none;
         overflow: hidden;
         pointer-events: none;
@@ -147,22 +142,9 @@ export class VideoOverlay {
         background: rgba(255, 0, 0, 1);
       }
 
-      .video-progress {
-        height: 3px;
-        background: rgba(255, 255, 255, 0.2);
-        position: relative;
-      }
 
-      .progress-bar {
-        height: 100%;
-        background: #00ff00;
-        width: 0%;
-        transition: width 0.1s linear;
-        box-shadow: 0 0 4px rgba(0, 255, 0, 0.5);
-      }
 
       .video-overlay.priority-high {
-        border-color: #ff6600;
         box-shadow: 0 4px 20px rgba(255, 102, 0, 0.5);
       }
 
@@ -172,7 +154,6 @@ export class VideoOverlay {
       }
 
       .video-overlay.priority-medium {
-        border-color: #ffff00;
         box-shadow: 0 4px 20px rgba(255, 255, 0, 0.3);
       }
 
@@ -190,18 +171,8 @@ export class VideoOverlay {
   setupEventListeners() {
     const skipBtn = this.overlayElement.querySelector('.skip-video-btn')
     const video = this.overlayElement.querySelector('.milestone-video')
-    const progressBar = this.overlayElement.querySelector('.progress-bar')
-
     skipBtn.addEventListener('click', () => {
       this.stopCurrentVideo()
-    })
-
-    // Update progress bar during video playback
-    video.addEventListener('timeupdate', () => {
-      if (video.duration) {
-        const progress = (video.currentTime / video.duration) * 100
-        progressBar.style.width = `${progress}%`
-      }
     })
 
     // Handle video end
@@ -252,7 +223,6 @@ export class VideoOverlay {
       const video = this.overlayElement.querySelector('.milestone-video')
       const titleElement = this.overlayElement.querySelector('.milestone-title')
       const descriptionElement = this.overlayElement.querySelector('.milestone-description')
-      const progressBar = this.overlayElement.querySelector('.progress-bar')
 
       // Set milestone info
       titleElement.textContent = milestoneInfo.title || 'Milestone Achieved'
@@ -374,9 +344,6 @@ export class VideoOverlay {
       this.isPlaying = true
       this.currentVideo = video
 
-      // Reset progress
-      progressBar.style.width = '0%'
-
       // Start video playback with error handling
       try {
         await video.play()
@@ -455,11 +422,6 @@ export class VideoOverlay {
       }
     }
 
-    // Reset progress bar
-    const progressBar = this.overlayElement.querySelector('.progress-bar')
-    if (progressBar) {
-      progressBar.style.width = '0%'
-    }
 
     // Play next video in queue with improved error handling
     if (this.videoQueue.length > 0) {


### PR DESCRIPTION
## Summary
- strip HTML progress bar from milestone video overlay
- drop border styling and frame drawing

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875529fa28083288458e8f6d019c63e