### PR TITLE
Show xp bar only when unit selected

### DIFF
--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -252,8 +252,8 @@ export class UnitRenderer {
       initializeUnitLeveling(unit)
       const expProgress = getExperienceProgress(unit)
       
-      // Show experience bar for all combat units below max level
-      if (unit.level < 3) {
+      // Only show experience bar for selected combat units below max level
+      if (unit.level < 3 && unit.selected) {
         shouldShowBar = true
         progress = expProgress
         barColor = '#FFFF00' // Bright yellow for experience


### PR DESCRIPTION
## Summary
- show combat unit experience bars only when the unit is selected

## Testing
- `npm run lint` *(fails: 2457 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687554da7fdc8328a64031fc248a17f3