### PR TITLE
Add unit status logging toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Develop a fully functional, minimal viable product (MVP) of a real-time strategy
 - **4.1.18** Mount points are configurable via `src/tankImageConfig.json` for fine-tuning positioning.
 - **4.1.19** Original aspect ratios of all 3 images are preserved during rendering.
 - **4.1.20** Image-based rendering automatically falls back to original rendering if images fail to load.
+- **4.1.21** Press **L key** while units are selected to toggle status logging for those units.
 
 ### 4.2 Harvesters
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ export default [
         URLSearchParams: 'readonly',
         Image: 'readonly',
         Audio: 'readonly',
+        Blob: 'readonly',
         performance: 'readonly',
         setTimeout: 'readonly',
         setInterval: 'readonly',

--- a/src/input/helpSystem.js
+++ b/src/input/helpSystem.js
@@ -46,6 +46,7 @@ export class HelpSystem {
           <li><strong>F Key:</strong> Toggle formation mode for selected units</li>
           <li><strong>T Key:</strong> Toggle tank image rendering (3-layer tank graphics)</li>
           <li><strong>P Key:</strong> Toggle FPS display (performance monitor)</li>
+          <li><strong>L Key:</strong> Toggle logging for selected units</li>
         </ul>
         <p>Press I again to close and resume the game</p>
       `

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -6,6 +6,7 @@ import { playSound } from '../sound.js'
 import { HelpSystem } from './helpSystem.js'
 import { CheatSystem } from './cheatSystem.js'
 import { isInputFieldFocused } from '../utils/inputUtils.js'
+import { toggleUnitLogging } from '../utils/logger.js'
 
 export class KeyboardHandler {
   constructor() {
@@ -130,6 +131,11 @@ export class KeyboardHandler {
       else if (e.key.toLowerCase() === 'p') {
         e.preventDefault()
         this.handleFpsDisplayToggle()
+      }
+      // L key to toggle logging for selected units
+      else if (e.key.toLowerCase() === 'l') {
+        e.preventDefault()
+        this.handleLoggingToggle(selectedUnits)
       }
     })
 
@@ -620,6 +626,18 @@ export class KeyboardHandler {
     this.showNotification(`FPS display: ${status}`, 2000)
     
     // Play a sound for feedback
+    playSound('confirmed', 0.5)
+  }
+
+  handleLoggingToggle(selectedUnits) {
+    if (!selectedUnits || selectedUnits.length === 0) return
+
+    selectedUnits.forEach(unit => {
+      toggleUnitLogging(unit)
+    })
+
+    const status = selectedUnits[0].loggingEnabled ? 'ON' : 'OFF'
+    this.showNotification(`Unit logging: ${status}`, 2000)
     playSound('confirmed', 0.5)
   }
 

--- a/src/units.js
+++ b/src/units.js
@@ -581,7 +581,9 @@ export function createUnit(factory, unitType, x, y) {
     turretDirection: 0,
     rotationSpeed: unitProps.rotationSpeed,
     turretRotationSpeed: unitProps.turretRotationSpeed || unitProps.rotationSpeed,
-    isRotating: false
+    isRotating: false,
+    loggingEnabled: false,
+    lastLoggedStatus: null
   }
 
   // Add unit-specific properties

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -32,6 +32,7 @@ import {
   checkGameEndConditions
 } from './game/gameStateManager.js'
 import { updateGlobalPathfinding } from './game/pathfinding.js'
+import { logUnitStatus } from './utils/logger.js'
 
 export function updateGame(delta, mapGrid, factories, units, bullets, gameState) {
   try {
@@ -198,6 +199,13 @@ export function updateGame(delta, mapGrid, factories, units, bullets, gameState)
 
     // Self-repair for level 3 units
     handleSelfRepair(units, now)
+
+    // Log status changes for units with logging enabled
+    units.forEach(unit => {
+      if (unit.loggingEnabled) {
+        logUnitStatus(unit)
+      }
+    })
 
   } catch (error) {
     console.error('Critical error in updateGame:', error)

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,59 @@
+export const logEntries = []
+
+export function log(message) {
+  const timestamp = new Date().toISOString()
+  const entry = `[${timestamp}] ${message}`
+  logEntries.push(entry)
+  console.log(entry)
+}
+
+export function getLogs() {
+  return logEntries.join('\n')
+}
+
+export function downloadLogs(filename = 'game.log') {
+  const blob = new Blob([getLogs()], { type: 'text/plain' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export function enableUnitLogging(unit) {
+  unit.loggingEnabled = true
+  log(`Started logging for unit ${unit.id} (${unit.type})`)
+}
+
+export function disableUnitLogging(unit) {
+  unit.loggingEnabled = false
+  log(`Stopped logging for unit ${unit.id} (${unit.type})`)
+}
+
+export function toggleUnitLogging(unit) {
+  if (unit.loggingEnabled) {
+    disableUnitLogging(unit)
+  } else {
+    enableUnitLogging(unit)
+  }
+}
+
+export function getUnitStatus(unit) {
+  if (unit.isRetreating) return 'retreating'
+  if (unit.isDodging) return 'dodging'
+  if (unit.harvesting) return 'harvesting'
+  if (unit.unloadingAtRefinery) return 'unloading'
+  if (unit.target && unit.isAttacking) return 'attacking target'
+  if (unit.moveTarget) return 'moving to target'
+  if (unit.movement && unit.movement.isMoving) return 'moving'
+  return 'idle'
+}
+
+export function logUnitStatus(unit) {
+  const status = getUnitStatus(unit)
+  if (unit.lastLoggedStatus !== status) {
+    log(`Unit ${unit.id} (${unit.type}) status: ${status}`)
+    unit.lastLoggedStatus = status
+  }
+}


### PR DESCRIPTION
## Summary
- add new logger utility for simple in-browser log files
- support per-unit logging with `L` key
- record unit mode changes during game updates
- expose logging toggle in help overlay
- document `L` key in README
- update ESLint globals for Blob

## Testing
- `npx eslint src/utils/logger.js`
- `npm run lint` *(fails: 2458 errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_6875561d28a48328b982d002b2f171ad