### PR TITLE
Fix duplicate defeat sound

### DIFF
--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -245,6 +245,7 @@ function getPlayerDefeatSound(playerId) {
  * @returns {boolean} - True if game should end
  */
 export function checkGameEndConditions(factories, gameState) {
+  if (gameState.gameOver) return true
   if (!gameState.buildings) return false
   
   // Count remaining buildings AND factories for human player


### PR DESCRIPTION
## Summary
- avoid calling defeat logic multiple times in `checkGameEndConditions`

## Testing
- `npm run lint` *(fails: trailing spaces and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68797e590f2c8328941d5f313ebea0f1