### PR TITLE
Disable building without construction yard

### DIFF
--- a/src/ai/enemyAIPlayer.js
+++ b/src/ai/enemyAIPlayer.js
@@ -82,11 +82,12 @@ function findSimpleBuildingPosition(buildingType, mapGrid, factories, aiPlayerId
 }
 
 function updateAIPlayer(aiPlayerId, units, factories, bullets, mapGrid, gameState, occupancyMap, now, targetedOreTiles) {
-  const aiFactory = factories.find(f => f.id === aiPlayerId)
-  
-  // Check if AI player's construction yard still exists
-  if (!aiFactory || aiFactory.destroyed || aiFactory.health <= 0) {
-    // Construction yard is destroyed, AI can't build anything
+  const aiFactory = factories.find(
+    f => (f.id === aiPlayerId || f.owner === aiPlayerId) && f.health > 0
+  )
+
+  // If no active construction yard remains this AI cannot build
+  if (!aiFactory) {
     return
   }
 

--- a/src/game/buildingSystem.js
+++ b/src/game/buildingSystem.js
@@ -48,6 +48,9 @@ export function updateBuildings(gameState, units, bullets, factories, mapGrid, d
         // Remove the building from the buildings array
         gameState.buildings.splice(i, 1)
 
+        // Trigger UI refresh for production buttons
+        gameState.pendingButtonUpdate = true
+
         // Update power supply after building is destroyed
         updatePowerSupply(gameState.buildings, gameState)
 

--- a/src/game/gameLoop.js
+++ b/src/game/gameLoop.js
@@ -111,6 +111,13 @@ export class GameLoop {
     // Update game elements
     updateGame(delta, this.mapGrid, this.factories, this.units, this.bullets, gameState)
 
+    // Refresh production buttons if a building was destroyed
+    if (gameState.pendingButtonUpdate) {
+      this.productionController.updateVehicleButtonStates()
+      this.productionController.updateBuildingButtonStates()
+      gameState.pendingButtonUpdate = false
+    }
+
     // Get minimap contexts for rendering
     const minimapCtx = this.canvasManager.getMinimapContext()
     const minimapCanvas = this.canvasManager.getMinimapCanvas()
@@ -197,6 +204,12 @@ export class GameLoop {
       if (!gameState.gamePaused) {
         updateGame(deltaTime, gameState, this.units, this.factories, this.bullets, this.mapGrid, this.productionQueue, this.moneyEl, this.gameTimeEl)
         updateBuildingsUnderRepair(gameState, performance.now())
+
+        if (gameState.pendingButtonUpdate) {
+          this.productionController.updateVehicleButtonStates()
+          this.productionController.updateBuildingButtonStates()
+          gameState.pendingButtonUpdate = false
+        }
       }
     }
 

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -187,6 +187,9 @@ export function cleanupDestroyedFactories(factories, mapGrid, gameState) {
       
       // Remove the factory from the factories array
       factories.splice(i, 1)
+
+      // Trigger UI refresh for production buttons
+      if (gameState) gameState.pendingButtonUpdate = true
       
       // Update statistics
       if (factory.id === gameState.humanPlayer || factory.owner === gameState.humanPlayer) {

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -108,5 +108,8 @@ export const gameState = {
   availableUnitTypes: new Set([]),
   availableBuildingTypes: new Set(['constructionYard', 'oreRefinery', 'powerPlant', 'vehicleFactory', 'radarStation', 'turretGunV1', 'concreteWall']),
   newUnitTypes: new Set(),
-  newBuildingTypes: new Set()
+  newBuildingTypes: new Set(),
+
+  // Flag to refresh production buttons after building destruction
+  pendingButtonUpdate: false
 }

--- a/src/ui/productionController.js
+++ b/src/ui/productionController.js
@@ -18,8 +18,12 @@ export class ProductionController {
 
   // Function to update the enabled/disabled state of vehicle production buttons
   updateVehicleButtonStates() {
-    const hasVehicleFactory = gameState.buildings.some(b => b.type === 'vehicleFactory' && b.owner === gameState.humanPlayer)
-    const hasRefinery = gameState.buildings.some(b => b.type === 'oreRefinery' && b.owner === gameState.humanPlayer)
+    const hasVehicleFactory = gameState.buildings.some(
+      b => b.type === 'vehicleFactory' && b.owner === gameState.humanPlayer && b.health > 0
+    )
+    const hasRefinery = gameState.buildings.some(
+      b => b.type === 'oreRefinery' && b.owner === gameState.humanPlayer && b.health > 0
+    )
     const unitButtons = document.querySelectorAll('.production-button[data-unit-type]')
 
     unitButtons.forEach(button => {
@@ -49,7 +53,17 @@ export class ProductionController {
   // Update enabled/disabled state of building production buttons
   updateBuildingButtonStates() {
     const hasRadar = gameState.buildings.some(
-      b => b.type === 'radarStation' && b.owner === gameState.humanPlayer && b.health > 0
+      b =>
+        b.type === 'radarStation' &&
+        b.owner === gameState.humanPlayer &&
+        b.health > 0
+    )
+
+    const hasConstructionYard = gameState.buildings.some(
+      b =>
+        b.type === 'constructionYard' &&
+        b.owner === gameState.humanPlayer &&
+        b.health > 0
     )
 
     const buildingButtons = document.querySelectorAll('.production-button[data-building-type]')
@@ -57,16 +71,21 @@ export class ProductionController {
     buildingButtons.forEach(button => {
       const type = button.getAttribute('data-building-type')
       let disable = false
-      let requirementText = ''
+      const req = []
+
+      if (!hasConstructionYard) {
+        disable = true
+        req.push('Construction Yard')
+      }
 
       if (buildingData[type]?.requiresRadar && !hasRadar) {
         disable = true
-        requirementText = 'Requires Radar Station'
+        req.push('Radar Station')
       }
 
       if (disable) {
         button.classList.add('disabled')
-        button.title = requirementText
+        button.title = 'Requires ' + req.join(' & ')
       } else {
         button.classList.remove('disabled')
         button.title = ''


### PR DESCRIPTION
## Summary
- prevent the player from starting a building if all construction yards are destroyed
- check AI factory list for active construction yards before building

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a962bd0708328b6f9f9cf91da8a6f