### PR TITLE
Fix concrete wall properties

### DIFF
--- a/src/buildingRepairHandler.js
+++ b/src/buildingRepairHandler.js
@@ -23,6 +23,12 @@ export function buildingRepairHandler(e, gameState, gameCanvas, mapGrid, units, 
             tileX >= building.x && tileX < (building.x + building.width) &&
             tileY >= building.y && tileY < (building.y + building.height)) {
 
+        // Walls cannot be repaired
+        if (building.type === 'concreteWall') {
+          showNotification('Concrete walls cannot be repaired.')
+          return
+        }
+
         // Skip if building is at full health
         if (building.health >= building.maxHealth) {
           showNotification('Building is already at full health.')

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -657,6 +657,9 @@ export function calculateRepairCost(building) {
 
 // Repair a building to full health
 export function repairBuilding(building, gameState) {
+  if (building.type === 'concreteWall') {
+    return { success: false, message: 'Concrete walls cannot be repaired' }
+  }
   // Only repair if building is damaged
   if (building.health >= building.maxHealth) {
     return { success: false, message: 'Building already at full health' }
@@ -828,6 +831,11 @@ export function updateBuildingsAwaitingRepair(gameState, currentTime) {
   for (let i = gameState.buildingsAwaitingRepair.length - 1; i >= 0; i--) {
     const awaitingRepair = gameState.buildingsAwaitingRepair[i]
     const building = awaitingRepair.building
+
+    if (building.type === 'concreteWall') {
+      gameState.buildingsAwaitingRepair.splice(i, 1)
+      continue
+    }
     
     // Check if building was attacked more recently than when we started waiting
     // This resets the countdown if the building gets attacked again

--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -136,7 +136,8 @@ export class CursorManager {
               tileX >= building.x && tileX < (building.x + building.width) &&
               tileY >= building.y && tileY < (building.y + building.height)) {
             // Building is repairable if it's not at full health
-            this.isOverRepairableBuilding = building.health < building.maxHealth
+            // Concrete walls cannot be repaired
+            this.isOverRepairableBuilding = (building.health < building.maxHealth) && building.type !== 'concreteWall'
             break
           }
         }

--- a/src/rendering/buildingRenderer.js
+++ b/src/rendering/buildingRenderer.js
@@ -64,7 +64,9 @@ export class BuildingRenderer {
 
     this.renderTurret(ctx, building, screenX, screenY, width, height)
     this.renderSelection(ctx, building, screenX, screenY, width, height)
-    this.renderOwnerIndicator(ctx, building, screenX, screenY)
+    if (building.type !== 'concreteWall') {
+      this.renderOwnerIndicator(ctx, building, screenX, screenY)
+    }
     this.renderRepairAnimation(ctx, building, screenX, screenY, width, height)
     this.renderPendingRepairCountdown(ctx, building, screenX, screenY, width, height)
   }


### PR DESCRIPTION
## Summary
- do not show party flag for concrete walls
- prevent concrete walls from being eligible for repair
- avoid repair cursor when hovering over concrete walls

## Testing
- `npm run lint` *(fails: trailing spaces, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687cd539b95c8328a0d43bf481d3b56d