### PR TITLE
Render harvester with image

### DIFF
--- a/src/rendering/harvesterImageRenderer.js
+++ b/src/rendering/harvesterImageRenderer.js
@@ -1,0 +1,77 @@
+// harvesterImageRenderer.js - Renders harvesters using a single image asset
+import { TILE_SIZE } from '../config.js'
+
+let harvesterImg = null
+let harvesterLoaded = false
+let harvesterLoading = false
+
+export function preloadHarvesterImage(callback) {
+  if (harvesterLoaded) {
+    if (callback) callback(true)
+    return
+  }
+
+  if (harvesterLoading) {
+    return
+  }
+
+  harvesterLoading = true
+  harvesterImg = new Image()
+  harvesterImg.onload = () => {
+    harvesterLoaded = true
+    harvesterLoading = false
+    if (callback) callback(true)
+  }
+  harvesterImg.onerror = () => {
+    console.error('Failed to load harvester image')
+    harvesterLoaded = false
+    harvesterLoading = false
+    if (callback) callback(false)
+  }
+  harvesterImg.src = 'images/map/units/harvester.webp'
+}
+
+export function isHarvesterImageLoaded() {
+  return harvesterLoaded && harvesterImg && harvesterImg.complete
+}
+
+export function renderHarvesterWithImage(ctx, unit, centerX, centerY) {
+  if (!isHarvesterImageLoaded()) {
+    return false
+  }
+
+  ctx.save()
+  ctx.translate(centerX, centerY)
+
+  // Image faces down by default; rotate so unit.direction=0 faces right
+  const rotation = unit.direction - Math.PI / 2
+  ctx.rotate(rotation)
+
+  const scale = TILE_SIZE / Math.max(harvesterImg.width, harvesterImg.height)
+  const width = harvesterImg.width * scale
+  const height = harvesterImg.height * scale
+
+  ctx.drawImage(harvesterImg, -width / 2, -height / 2, width, height)
+
+  // Draw sparks when harvesting
+  if (unit.harvesting) {
+    renderHarvestingSparks(ctx, width, height)
+  }
+
+  ctx.restore()
+  return true
+}
+
+function renderHarvestingSparks(ctx, width, height) {
+  const now = performance.now()
+  const startX = (14 - harvesterImg.width / 2) * (width / harvesterImg.width)
+  const endX = (50 - harvesterImg.width / 2) * (width / harvesterImg.width)
+  const y = (58 - harvesterImg.height / 2) * (height / harvesterImg.height)
+  const sparkCount = 4
+  ctx.fillStyle = '#FFD700'
+  for (let i = 0; i < sparkCount; i++) {
+    const t = ((now / 100) + i / sparkCount) % 1
+    const x = startX + (endX - startX) * t
+    ctx.fillRect(x - 1, y - 1, 2, 2)
+  }
+}

--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -12,6 +12,7 @@ import { UIRenderer } from './uiRenderer.js'
 import { MinimapRenderer } from './minimapRenderer.js'
 import { HarvesterHUD } from '../ui/harvesterHUD.js'
 import { preloadTankImages } from './tankImageRenderer.js'
+import { preloadHarvesterImage } from './harvesterImageRenderer.js'
 
 export class Renderer {
   constructor() {
@@ -34,9 +35,10 @@ export class Renderer {
     // Load both tile textures and tank images in parallel
     let texturesLoaded = false
     let tankImagesLoaded = false
+    let harvesterLoaded = false
 
     const checkAllLoaded = () => {
-      if (texturesLoaded && tankImagesLoaded) {
+      if (texturesLoaded && tankImagesLoaded && harvesterLoaded) {
         if (callback) callback()
       }
     }
@@ -53,6 +55,14 @@ export class Renderer {
         console.warn('Tank images failed to load, falling back to original rendering')
       }
       tankImagesLoaded = true
+      checkAllLoaded()
+    })
+
+    preloadHarvesterImage((success) => {
+      if (!success) {
+        console.warn('Harvester image failed to load')
+      }
+      harvesterLoaded = true
       checkAllLoaded()
     })
   }

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -3,6 +3,7 @@ import { TILE_SIZE, HARVESTER_CAPPACITY, HARVESTER_UNLOAD_TIME, RECOIL_DISTANCE,
 import { gameState } from '../gameState.js'
 import { selectedUnits } from '../inputHandler.js'
 import { renderTankWithImages, areTankImagesLoaded } from './tankImageRenderer.js'
+import { renderHarvesterWithImage, isHarvesterImageLoaded } from './harvesterImageRenderer.js'
 import { getExperienceProgress, initializeUnitLeveling } from '../utils.js'
 
 export class UnitRenderer {
@@ -38,9 +39,11 @@ export class UnitRenderer {
   }
 
   renderTurret(ctx, unit, centerX, centerY) {
-    // Harvesters have a mining bar instead of a turret
+    // Harvesters use image rendering. Show mining bar only if image not loaded
     if (unit.type === 'harvester') {
-      this.renderHarvesterMiningBar(ctx, unit, centerX, centerY)
+      if (!isHarvesterImageLoaded()) {
+        this.renderHarvesterMiningBar(ctx, unit, centerX, centerY)
+      }
       return
     }
 
@@ -400,9 +403,18 @@ export class UnitRenderer {
 
     // Check if this is a tank type and if image rendering is enabled
     const isTank = ['tank_v1', 'tank-v2', 'tank-v3', 'tank_v2', 'tank_v3'].includes(unit.type)
-    const useImageRendering = gameState.useTankImages && isTank && areTankImagesLoaded(unit.type)
+    const useTankImage = gameState.useTankImages && isTank && areTankImagesLoaded(unit.type)
 
-    if (useImageRendering) {
+    if (unit.type === 'harvester' && isHarvesterImageLoaded()) {
+      const ok = renderHarvesterWithImage(ctx, unit, centerX, centerY)
+      if (ok) {
+        this.renderSelection(ctx, unit, centerX, centerY)
+        this.renderAlertMode(ctx, unit, centerX, centerY)
+        return
+      }
+    }
+
+    if (useTankImage) {
       // Try to render with images
       const imageRenderSuccess = renderTankWithImages(ctx, unit, centerX, centerY)
       

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -82,7 +82,7 @@ export function updateGame(delta, mapGrid, factories, units, bullets, gameState)
       if (
         unit.maxHealth &&
         unit.health / unit.maxHealth < 0.25 &&
-        unit.type.includes('tank')
+        (unit.type.includes('tank') || unit.type === 'harvester')
       ) {
         if (!unit.lastSmokeTime || now - unit.lastSmokeTime > SMOKE_EMIT_INTERVAL) {
           const offsetX = -Math.cos(unit.direction) * TILE_SIZE * 0.4
@@ -96,9 +96,9 @@ export function updateGame(delta, mapGrid, factories, units, bullets, gameState)
             now,
             particleCount
           )
-        unit.lastSmokeTime = now
+          unit.lastSmokeTime = now
+        }
       }
-    }
     })
 
     // Emit smoke for buildings with smoke spots


### PR DESCRIPTION
## Summary
- add harvester image renderer and spark effect
- preload harvester image in the renderer
- integrate harvester image into unit renderer
- emit smoke for damaged harvesters just like tanks

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cf4faca34832896f9af55bb377023