### PR TITLE
Add vehicle workshop building

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,15 @@
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
               </button>
+              <button class="production-button" data-building-type="vehicleWorkshop">
+                <img draggable="true" src="images/sidebar/vehicle_workshop.webp" onerror="this.style.display='none'">
+                <span class="building-name">Vehicle Workshop</span>
+                <span class="building-cost">$3000</span>
+                <span class="building-power">-20 MW</span>
+                <div class="production-progress"></div>
+                <div class="batch-counter" style="display:none">0</div>
+                <div class="new-label" style="display:none">NEW</div>
+              </button>
               <button class="production-button" data-building-type="radarStation">
                 <img draggable="true" src="images/sidebar/radar_station.webp" onerror="this.style.display='none'">
                 <span class="building-name">Radar Station</span>

--- a/public/cursors/moveInto.svg
+++ b/public/cursors/moveInto.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" viewBox="0 0 64 64"
+     xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Move icon">
+  <title>Move Icon (Yellow)</title>
+  <style>
+    :root { color:#ff0; }
+    /* Keep existing animation logic; this is a sample pulse */
+    @keyframes pulse {
+      0%,100% { transform: scale(1); }
+      50% { transform: scale(1.08); }
+    }
+    #icon {
+      animation: pulse 1.2s ease-in-out infinite;
+      transform-origin: 32px 32px;
+      fill: currentColor;
+      stroke: #000;
+      stroke-width: 2;
+    }
+  </style>
+  <g id="icon">
+    <!-- Up arrow -->
+    <path d="M30 4 L34 4 L34 18 L40 12 L40 20 L32 28 L24 20 L24 12 L30 18 Z"/>
+    <!-- Right arrow -->
+    <path d="M60 30 L60 34 L46 34 L52 40 L44 40 L36 32 L44 24 L52 24 L46 30 Z"/>
+    <!-- Down arrow -->
+    <path d="M34 60 L30 60 L30 46 L24 52 L24 44 L32 36 L40 44 L40 52 L34 46 Z"/>
+    <!-- Left arrow -->
+    <path d="M4 34 L4 30 L18 30 L12 24 L20 24 L28 32 L20 40 L12 40 L18 34 Z"/>
+    <!-- Center square -->
+    <rect x="26" y="26" width="12" height="12" rx="2" ry="2"/>
+  </g>
+</svg>

--- a/src/buildingImageMap.js
+++ b/src/buildingImageMap.js
@@ -9,6 +9,7 @@ export const buildingImageMap = {
   powerPlant: 'images/map/buildings/power_plant.webp',
   oreRefinery: 'images/map/buildings/refinery.webp',
   vehicleFactory: 'images/map/buildings/vehicle_factory.webp',
+  vehicleWorkshop: 'images/map/buildings/vehicle_workshop.webp',
   radarStation: 'images/map/buildings/radar_station.webp',
   turretGunV1: 'images/map/buildings/turret01_base.webp', // Use base image as fallback when turret images are disabled
   turretGunV2: 'images/map/buildings/turret02.webp',

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -42,6 +42,17 @@ export const buildingData = {
     health: 300,
     smokeSpots: []
   },
+  vehicleWorkshop: {
+    width: 3,
+    height: 3,
+    cost: 3000,
+    power: -20,
+    image: 'vehicle_workshop.webp',
+    displayName: 'Vehicle Workshop',
+    health: 300,
+    armor: 3,
+    smokeSpots: []
+  },
   constructionYard: {
     width: 3,
     height: 3,
@@ -198,8 +209,8 @@ export function createBuilding(type, x, y) {
     constructionFinished: false
   }
 
-  // Initialize rally point for vehicle factories only
-  if (type === 'vehicleFactory') {
+  // Initialize rally point for vehicle factories and workshops
+  if (type === 'vehicleFactory' || type === 'vehicleWorkshop') {
     building.rallyPoint = null
   }
 

--- a/src/game/unifiedMovement.js
+++ b/src/game/unifiedMovement.js
@@ -57,7 +57,7 @@ export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [],
     
     // Harvester cannot move while unloading at refinery
     if (unit.unloadingAtRefinery) {
-      unit.path = [] // Clear any pending movement  
+      unit.path = [] // Clear any pending movement
       unit.moveTarget = null
       unit.movement.velocity = { x: 0, y: 0 }
       unit.movement.targetVelocity = { x: 0, y: 0 }
@@ -65,6 +65,17 @@ export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [],
       unit.movement.currentSpeed = 0
       return // Exit early - no movement allowed
     }
+  }
+
+  // Units undergoing repair should not move
+  if (unit.repairingAtWorkshop) {
+    unit.path = []
+    unit.moveTarget = null
+    unit.movement.velocity = { x: 0, y: 0 }
+    unit.movement.targetVelocity = { x: 0, y: 0 }
+    unit.movement.isMoving = false
+    unit.movement.currentSpeed = 0
+    return
   }
   
   const movement = unit.movement;

--- a/src/game/workshopLogic.js
+++ b/src/game/workshopLogic.js
@@ -1,0 +1,81 @@
+import { TILE_SIZE } from '../config.js'
+import { findPath } from '../units.js'
+import { updateUnitSpeedModifier } from '../utils.js'
+import { gameState } from '../gameState.js'
+
+function initWorkshop(workshop) {
+  if (!workshop.repairSlots) {
+    workshop.repairSlots = []
+    for (let i = 0; i < 3; i++) {
+      workshop.repairSlots.push({ x: workshop.x + i, y: workshop.y + workshop.height, unit: null })
+    }
+    workshop.repairQueue = []
+  }
+}
+
+function assignUnitsToSlots(workshop, mapGrid) {
+  initWorkshop(workshop)
+  while (workshop.repairQueue.length > 0) {
+    const slot = workshop.repairSlots.find(s => !s.unit)
+    if (!slot) break
+    const unit = workshop.repairQueue.shift()
+    if (!unit || unit.health <= 0) continue
+    slot.unit = unit
+    unit.repairSlot = slot
+    const path = findPath({ x: unit.tileX, y: unit.tileY }, { x: slot.x, y: slot.y }, mapGrid, gameState.occupancyMap)
+    if (path && path.length > 1) {
+      unit.path = path.slice(1)
+      unit.moveTarget = { x: slot.x, y: slot.y }
+    } else {
+      unit.x = slot.x * TILE_SIZE
+      unit.y = slot.y * TILE_SIZE
+      unit.tileX = slot.x
+      unit.tileY = slot.y
+    }
+  }
+}
+
+export function updateWorkshopLogic(units, buildings, mapGrid, delta) {
+  const workshops = buildings.filter(b => b.type === 'vehicleWorkshop')
+  const now = performance.now()
+  workshops.forEach(workshop => {
+    initWorkshop(workshop)
+    assignUnitsToSlots(workshop, mapGrid)
+    workshop.repairSlots.forEach(slot => {
+      const unit = slot.unit
+      if (!unit) return
+      if (unit.health <= 0) { slot.unit = null; return }
+      const dist = Math.hypot(unit.x - slot.x * TILE_SIZE, unit.y - slot.y * TILE_SIZE)
+      if (!unit.repairingAtWorkshop) {
+        if (dist < TILE_SIZE / 3) {
+          unit.repairingAtWorkshop = true
+          unit.path = []
+          unit.moveTarget = null
+          if (unit.movement) {
+            unit.movement.velocity = { x: 0, y: 0 }
+            unit.movement.targetVelocity = { x: 0, y: 0 }
+            unit.movement.isMoving = false
+            unit.movement.currentSpeed = 0
+          }
+        }
+      } else {
+        if (unit.health < unit.maxHealth) {
+          unit.health = Math.min(unit.health + unit.maxHealth * 0.03 * (delta / 1000), unit.maxHealth)
+          updateUnitSpeedModifier(unit)
+        } else {
+          unit.repairingAtWorkshop = false
+          slot.unit = null
+          unit.repairSlot = null
+          if (workshop.rallyPoint) {
+            const path = findPath({ x: unit.tileX, y: unit.tileY }, workshop.rallyPoint, mapGrid, gameState.occupancyMap)
+            if (path && path.length > 1) {
+              unit.path = path.slice(1)
+              unit.moveTarget = { x: workshop.rallyPoint.x, y: workshop.rallyPoint.y }
+            }
+          }
+          assignUnitsToSlots(workshop, mapGrid)
+        }
+      }
+    })
+  })
+}

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -111,7 +111,7 @@ export const gameState = {
 
   // Initially no units are available (require vehicle factory), only basic buildings
   availableUnitTypes: new Set([]),
-  availableBuildingTypes: new Set(['constructionYard', 'oreRefinery', 'powerPlant', 'vehicleFactory', 'radarStation', 'turretGunV1', 'concreteWall']),
+  availableBuildingTypes: new Set(['constructionYard', 'oreRefinery', 'powerPlant', 'vehicleFactory', 'vehicleWorkshop', 'radarStation', 'turretGunV1', 'concreteWall']),
   newUnitTypes: new Set(),
   newBuildingTypes: new Set(),
 

--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -899,8 +899,22 @@ export class MouseHandler {
         oreTarget = { x: tileX, y: tileY }
       }
 
+      let workshopTarget = null
+      if (gameState.buildings && Array.isArray(gameState.buildings)) {
+        for (const building of gameState.buildings) {
+          if (building.type === 'vehicleWorkshop' && building.owner === gameState.humanPlayer && building.health > 0 &&
+              tileX >= building.x && tileX < building.x + building.width &&
+              tileY >= building.y && tileY < building.y + building.height) {
+            workshopTarget = building
+            break
+          }
+        }
+      }
+
       if (refineryTarget) {
         unitCommands.handleRefineryUnloadCommand(selectedUnits, refineryTarget, mapGrid)
+      } else if (workshopTarget) {
+        unitCommands.handleRepairWorkshopCommand(selectedUnits, workshopTarget, mapGrid)
       } else if (oreTarget) {
         unitCommands.handleHarvesterCommand(selectedUnits, oreTarget, mapGrid)
       } else {

--- a/src/input/unitCommands.js
+++ b/src/input/unitCommands.js
@@ -301,6 +301,22 @@ export class UnitCommandsHandler {
     }
   }
 
+  handleRepairWorkshopCommand(selectedUnits, workshop, mapGrid) {
+    selectedUnits.forEach(u => { u.commandQueue = []; u.currentCommand = null })
+    this.clearAttackGroupState(selectedUnits)
+
+    selectedUnits.forEach(unit => {
+      unit.guardTarget = null
+      unit.guardMode = false
+      if (!workshop.repairQueue) workshop.repairQueue = []
+      if (!workshop.repairQueue.includes(unit)) {
+        workshop.repairQueue.push(unit)
+        unit.targetWorkshop = workshop
+      }
+    })
+    playSound('movement', 0.5)
+  }
+
   /**
    * Calculate semicircle attack formation positions around a target
    */

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -17,6 +17,7 @@ import { updateGuardBehavior } from './behaviours/guard.js'
 import { updateUnitMovement, updateSpawnExit } from './game/unitMovement.js'
 import { updateUnitCombat, cleanupAttackGroupTargets } from './game/unitCombat.js'
 import { updateHarvesterLogic } from './game/harvesterLogic.js'
+import { updateWorkshopLogic } from './game/workshopLogic.js'
 import { updateBullets } from './game/bulletSystem.js'
 import { updateBuildings, updateTeslaCoilEffects } from './game/buildingSystem.js'
 import { cleanupSoundCooldowns } from './game/soundCooldownManager.js'
@@ -71,6 +72,7 @@ export function updateGame(delta, mapGrid, factories, units, bullets, gameState)
     updateSpawnExit(units, factories, mapGrid, occupancyMap)
     updateUnitCombat(units, bullets, mapGrid, gameState, now)
     updateHarvesterLogic(units, mapGrid, occupancyMap, gameState, factories, now)
+    updateWorkshopLogic(units, gameState.buildings, mapGrid, delta)
 
     // Handle self-repair for level 3 units
     units.forEach(unit => {


### PR DESCRIPTION
## Summary
- include new Vehicle Workshop building
- support loading map image for workshop
- allow units to queue for repairs at the workshop and heal 3% per second
- add workshop to buildings menu
- prevent units from moving while being repaired

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d06d7eeac832891f8dd3fb02968f2