### PR TITLE
Fix refinery hover cursor

### DIFF
--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -267,9 +267,9 @@ export class CursorManager {
         gameCanvas.style.cursor = 'none'
         gameCanvas.classList.add('move-into-mode')
       } else if (this.isOverPlayerRefinery) {
-        // Over player refinery with harvesters selected - use attack cursor to indicate force unload
+        // Over player refinery with harvesters selected - show move into cursor
         gameCanvas.style.cursor = 'none'
-        gameCanvas.classList.add('attack-mode')
+        gameCanvas.classList.add('move-into-mode')
       } else if (this.isOverOreTile) {
         // Over ore tile with harvesters selected - use attack cursor to indicate harvesting
         gameCanvas.style.cursor = 'none'


### PR DESCRIPTION
## Summary
- use move-into cursor when hovering harvester over refinery

## Testing
- `npm run lint` *(fails: trailing spaces, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687d23ac64bc8328bd8c8b1557473236