### PR TITLE
Use image for rocket tank

### DIFF
--- a/src/game/bulletSystem.js
+++ b/src/game/bulletSystem.js
@@ -11,6 +11,7 @@ import { markBuildingForRepairPause } from '../buildings.js'
 import { removeUnitOccupancy } from '../units.js'
 import { handleAttackNotification } from './attackNotifications.js'
 import { emitSmokeParticles } from '../utils/smokeUtils.js'
+import { getRocketSpawnPoint } from '../rendering/rocketTankImageRenderer.js'
 
 /**
  * Updates all bullets in the game including movement, collision detection, and cleanup
@@ -409,16 +410,17 @@ export function fireBullet(unit, target, bullets, now) {
       target
     }
   } else if (unit.type === 'rocketTank') {
-    const dx = targetCenterX - unitCenterX
-    const dy = targetCenterY - unitCenterY
+    const spawn = getRocketSpawnPoint(unit, unitCenterX, unitCenterY)
+    const dx = targetCenterX - spawn.x
+    const dy = targetCenterY - spawn.y
     const distance = Math.hypot(dx, dy)
     const speed = 6
     const flightDuration = distance / speed
 
     bullet = {
       id: Date.now() + Math.random(),
-      x: unitCenterX,
-      y: unitCenterY,
+      x: spawn.x,
+      y: spawn.y,
       speed,
       baseDamage: BULLET_DAMAGES.rocketTank,
       active: true,
@@ -426,8 +428,8 @@ export function fireBullet(unit, target, bullets, now) {
       homing: false,
       target,
       ballistic: true,
-      startX: unitCenterX,
-      startY: unitCenterY,
+      startX: spawn.x,
+      startY: spawn.y,
       targetX: targetCenterX,
       targetY: targetCenterY,
       dx,

--- a/src/game/unitCombat.js
+++ b/src/game/unitCombat.js
@@ -6,6 +6,7 @@ import { findPath } from '../units.js'
 import { stopUnitMovement } from './unifiedMovement.js'
 import { gameState } from '../gameState.js'
 import { updateUnitSpeedModifier } from '../utils.js'
+import { getRocketSpawnPoint } from '../rendering/rocketTankImageRenderer.js'
 
 /**
  * Check if the turret is properly aimed at the target
@@ -235,14 +236,15 @@ function handleTankFiring(unit, target, bullets, now, fireRate, targetCenterX, t
             const isRocketTankRocket = projectileType === 'rocket' && unit.type === 'rocketTank';
             const bulletSpeed = isRocketTankRocket ? 6 : (projectileType === 'rocket' ? 3 : TANK_BULLET_SPEED);
 
-            const muzzleOffset = TILE_SIZE * 0.4;
-            const muzzleX = unitCenterX + Math.cos(unit.direction) * muzzleOffset;
-            const muzzleY = unitCenterY + Math.sin(unit.direction) * muzzleOffset;
+            let rocketSpawn = null;
+            if (isRocketTankRocket) {
+                rocketSpawn = getRocketSpawnPoint(unit, unitCenterX, unitCenterY);
+            }
 
             const bullet = {
                 id: Date.now() + Math.random(),
-                x: isRocketTankRocket ? muzzleX : unitCenterX,
-                y: isRocketTankRocket ? muzzleY : unitCenterY,
+                x: isRocketTankRocket ? rocketSpawn.x : unitCenterX,
+                y: isRocketTankRocket ? rocketSpawn.y : unitCenterY,
                 speed: bulletSpeed,
                 baseDamage: getDamageForUnitType(unit.type),
                 active: true,
@@ -254,12 +256,12 @@ function handleTankFiring(unit, target, bullets, now, fireRate, targetCenterX, t
             };
 
             if (isRocketTankRocket) {
-                const dx = finalTarget.x - muzzleX;
-                const dy = finalTarget.y - muzzleY;
+                const dx = finalTarget.x - rocketSpawn.x;
+                const dy = finalTarget.y - rocketSpawn.y;
                 const distance = Math.hypot(dx, dy);
                 bullet.ballistic = true;
-                bullet.startX = muzzleX;
-                bullet.startY = muzzleY;
+                bullet.startX = rocketSpawn.x;
+                bullet.startY = rocketSpawn.y;
                 bullet.targetX = finalTarget.x;
                 bullet.targetY = finalTarget.y;
                 bullet.dx = dx;

--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -13,6 +13,7 @@ import { MinimapRenderer } from './minimapRenderer.js'
 import { HarvesterHUD } from '../ui/harvesterHUD.js'
 import { preloadTankImages } from './tankImageRenderer.js'
 import { preloadHarvesterImage } from './harvesterImageRenderer.js'
+import { preloadRocketTankImage } from './rocketTankImageRenderer.js'
 
 export class Renderer {
   constructor() {
@@ -36,9 +37,10 @@ export class Renderer {
     let texturesLoaded = false
     let tankImagesLoaded = false
     let harvesterLoaded = false
+    let rocketTankLoaded = false
 
     const checkAllLoaded = () => {
-      if (texturesLoaded && tankImagesLoaded && harvesterLoaded) {
+      if (texturesLoaded && tankImagesLoaded && harvesterLoaded && rocketTankLoaded) {
         if (callback) callback()
       }
     }
@@ -63,6 +65,14 @@ export class Renderer {
         console.warn('Harvester image failed to load')
       }
       harvesterLoaded = true
+      checkAllLoaded()
+    })
+
+    preloadRocketTankImage((success) => {
+      if (!success) {
+        console.warn('Rocket tank image failed to load')
+      }
+      rocketTankLoaded = true
       checkAllLoaded()
     })
   }

--- a/src/rendering/rocketTankImageRenderer.js
+++ b/src/rendering/rocketTankImageRenderer.js
@@ -1,0 +1,105 @@
+// rocketTankImageRenderer.js - render rocket tanks using a single image asset
+import { TILE_SIZE, MUZZLE_FLASH_DURATION, MUZZLE_FLASH_SIZE } from '../config.js'
+
+let rocketTankImg = null
+let rocketTankLoaded = false
+let rocketTankLoading = false
+
+// Spawn point relative to the asset (pixels from top-left)
+const SPAWN_POINT = { x: 42, y: 10 }
+
+export function preloadRocketTankImage(callback) {
+  if (rocketTankLoaded) {
+    if (callback) callback(true)
+    return
+  }
+  if (rocketTankLoading) return
+
+  rocketTankLoading = true
+  rocketTankImg = new Image()
+  rocketTankImg.onload = () => {
+    rocketTankLoaded = true
+    rocketTankLoading = false
+    if (callback) callback(true)
+  }
+  rocketTankImg.onerror = () => {
+    console.error('Failed to load rocket tank image')
+    rocketTankLoaded = false
+    rocketTankLoading = false
+    if (callback) callback(false)
+  }
+  rocketTankImg.src = 'images/map/units/rocket_tank.webp'
+}
+
+export function isRocketTankImageLoaded() {
+  return rocketTankLoaded && rocketTankImg && rocketTankImg.complete
+}
+
+export function renderRocketTankWithImage(ctx, unit, centerX, centerY) {
+  if (!isRocketTankImageLoaded()) return false
+
+  const now = performance.now()
+
+  ctx.save()
+  ctx.translate(centerX, centerY)
+
+  // Image faces downwards by default. Rotate so unit.direction=0 faces right.
+  const rotation = unit.direction - Math.PI / 2
+  ctx.rotate(rotation)
+
+  const scale = TILE_SIZE / Math.max(rocketTankImg.width, rocketTankImg.height)
+  const width = rocketTankImg.width * scale
+  const height = rocketTankImg.height * scale
+
+  ctx.drawImage(rocketTankImg, -width / 2, -height / 2, width, height)
+
+  // Render muzzle flash when firing
+  if (unit.muzzleFlashStartTime && now - unit.muzzleFlashStartTime <= MUZZLE_FLASH_DURATION) {
+    const flashProgress = (now - unit.muzzleFlashStartTime) / MUZZLE_FLASH_DURATION
+    const flashAlpha = 1 - flashProgress
+    const flashSize = MUZZLE_FLASH_SIZE * (1 - flashProgress * 0.5)
+
+    ctx.save()
+    ctx.globalAlpha = flashAlpha
+
+    const localX = (SPAWN_POINT.x - rocketTankImg.width / 2) * scale
+    const localY = (SPAWN_POINT.y - rocketTankImg.height / 2) * scale
+    const rotatedX = localX
+    const rotatedY = localY
+
+    const gradient = ctx.createRadialGradient(rotatedX, rotatedY, 0, rotatedX, rotatedY, flashSize)
+    gradient.addColorStop(0, '#FFF')
+    gradient.addColorStop(0.3, '#FF0')
+    gradient.addColorStop(1, 'rgba(255, 165, 0, 0)')
+
+    ctx.fillStyle = gradient
+    ctx.beginPath()
+    ctx.arc(rotatedX, rotatedY, flashSize, 0, Math.PI * 2)
+    ctx.fill()
+    ctx.restore()
+  }
+
+  ctx.restore()
+  return true
+}
+
+export function getRocketSpawnPoint(unit, centerX, centerY) {
+  if (!isRocketTankImageLoaded()) {
+    const muzzleOffset = TILE_SIZE * 0.4
+    return {
+      x: centerX + Math.cos(unit.direction) * muzzleOffset,
+      y: centerY + Math.sin(unit.direction) * muzzleOffset
+    }
+  }
+
+  const rotation = unit.direction - Math.PI / 2
+  const scale = TILE_SIZE / Math.max(rocketTankImg.width, rocketTankImg.height)
+  const localX = (SPAWN_POINT.x - rocketTankImg.width / 2) * scale
+  const localY = (SPAWN_POINT.y - rocketTankImg.height / 2) * scale
+  const rotatedX = localX * Math.cos(rotation) - localY * Math.sin(rotation)
+  const rotatedY = localX * Math.sin(rotation) + localY * Math.cos(rotation)
+  return {
+    x: centerX + rotatedX,
+    y: centerY + rotatedY
+  }
+}

--- a/src/rendering/textureManager.js
+++ b/src/rendering/textureManager.js
@@ -12,7 +12,7 @@ const unitImageMap = {
   tank_v2: 'images/tank_v2.png',
   'tank-v3': 'images/tank_v3.png',
   tank_v3: 'images/tank_v3.png',
-  rocketTank: 'images/rocket_tank.webp',
+  rocketTank: 'images/map/units/rocket_tank.webp',
   harvester: 'images/harvester.webp',
   artilleryTank: 'images/artillery_tank.jpg'
 }

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -4,6 +4,7 @@ import { gameState } from '../gameState.js'
 import { selectedUnits } from '../inputHandler.js'
 import { renderTankWithImages, areTankImagesLoaded } from './tankImageRenderer.js'
 import { renderHarvesterWithImage, isHarvesterImageLoaded } from './harvesterImageRenderer.js'
+import { renderRocketTankWithImage, isRocketTankImageLoaded } from './rocketTankImageRenderer.js'
 import { getExperienceProgress, initializeUnitLeveling } from '../utils.js'
 
 export class UnitRenderer {
@@ -49,8 +50,8 @@ export class UnitRenderer {
 
     const now = performance.now()
     
-    // Special handling for rocket tanks - render 3 static tubes instead of turret
-    if (unit.type === 'rocketTank') {
+    // Special handling for rocket tanks - render fallback tubes only if image not loaded
+    if (unit.type === 'rocketTank' && !isRocketTankImageLoaded()) {
       this.renderRocketTubes(ctx, unit, centerX, centerY, now)
       return
     }
@@ -407,6 +408,15 @@ export class UnitRenderer {
 
     if (unit.type === 'harvester' && isHarvesterImageLoaded()) {
       const ok = renderHarvesterWithImage(ctx, unit, centerX, centerY)
+      if (ok) {
+        this.renderSelection(ctx, unit, centerX, centerY)
+        this.renderAlertMode(ctx, unit, centerX, centerY)
+        return
+      }
+    }
+
+    if (unit.type === 'rocketTank' && isRocketTankImageLoaded()) {
+      const ok = renderRocketTankWithImage(ctx, unit, centerX, centerY)
       if (ok) {
         this.renderSelection(ctx, unit, centerX, centerY)
         this.renderAlertMode(ctx, unit, centerX, centerY)


### PR DESCRIPTION
## Summary
- add new renderer for rocket tank image
- load rocket tank asset during renderer initialization
- adjust bullet spawn logic to use image-relative coordinates
- update texture path for rocket tank

## Testing
- `npm run lint` *(fails: many pre-existing style errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d3d5f8ab08328861d36b978e1e308