### PR TITLE
Adjust artillery turret rotation

### DIFF
--- a/TURRET_IMPLEMENTATION_SUMMARY.md
+++ b/TURRET_IMPLEMENTATION_SUMMARY.md
@@ -11,7 +11,7 @@ Successfully implemented rotating turret system with separate base and top image
 - Both images maintain original aspect ratios and proportions
 
 ### 2. ✅ **Smooth Turret Rotation**
-- Uses same rotation speed as tanks (`TANK_TURRET_ROT = 0.08` radians per frame)
+- Uses same rotation speed as tanks (`TANK_TURRET_ROT = 0.024` radians per frame)
 - Smooth rotation using `smoothRotateTowardsAngle()` function from tank system
 - **Continuous tracking**: Turret rotates every frame when enemies are in range
 - **Smart firing**: Only fires when properly aligned with target (±5.7° tolerance)
@@ -93,7 +93,7 @@ Successfully implemented rotating turret system with separate base and top image
 - Turret rotation uses same mechanics as tank turrets
 - Images are preloaded at game startup for performance
 - No recoil effect implemented (as requested)
-- Rate of turn (ROT) matches tank turret speed
+- Rate of turn (ROT) reduced to 30% of the original tank turret speed
 - Flash animation duration and style match existing effects
 - Rotation direction corrected with +π/2 offset for proper image orientation
 

--- a/src/config.js
+++ b/src/config.js
@@ -91,7 +91,9 @@ export const CRITICAL_DAMAGE_SOUND_COOLDOWN = 30000
 
 // Separate rotation rates for tank components
 export const TANK_WAGON_ROT = 0.05 // Radians per frame for tank body/wagon movement
-export const TANK_TURRET_ROT = 0.08 // Radians per frame for turret aiming (slightly faster)
+// Reduced turret rotation speed to make artillery tracking more deliberate
+// 70% slower than before (was 0.08)
+export const TANK_TURRET_ROT = 0.024 // Radians per frame for turret aiming
 
 // Aiming precision threshold (in radians) - turret must be within this angle to fire
 export const TURRET_AIMING_THRESHOLD = 0.1 // About 5.7 degrees


### PR DESCRIPTION
## Summary
- slow down turret rotation speed to make artillery tracking more deliberate
- update documentation with the new speed

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d4336476483288eff31af20ecb781