### PR TITLE
Display ore overlay on minimap

### DIFF
--- a/src/rendering/minimapRenderer.js
+++ b/src/rendering/minimapRenderer.js
@@ -65,6 +65,16 @@ export class MinimapRenderer {
           TILE_SIZE * scaleX,
           TILE_SIZE * scaleY
         )
+        // Overlay ore tiles with semi-transparent orange
+        if (mapGrid[y][x].ore) {
+          minimapCtx.fillStyle = 'rgba(255,165,0,0.5)'
+          minimapCtx.fillRect(
+            x * TILE_SIZE * scaleX,
+            y * TILE_SIZE * scaleY,
+            TILE_SIZE * scaleX,
+            TILE_SIZE * scaleY
+          )
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- render ore on the minimap

## Testing
- `npm run lint` *(fails: 2771 problems)*

------
https://chatgpt.com/codex/tasks/task_e_687d495d7828832888cad528cde728bf