### PR TITLE
Add ore spreading toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,19 @@
             Seed:
             <input type="number" class="sidebar-input" id="mapSeed" value="1" style="width: 70px; margin-left: 10px;">
           </label>
-          <button id="shuffleMapBtn" class="action-button" style="margin: 10px 0;">Shuffle Map</button>
+          <div style="display: flex; gap: 5px; margin: 10px 0;">
+            <button id="shuffleMapBtn" class="action-button">Shuffle Map</button>
+            <button id="mapSettingsBtn" class="action-button icon-button" title="Map Settings">
+              <span class="button-icon settings-icon">⚙</span>
+            </button>
+          </div>
+        </div>
+
+        <div id="mapSettingsMenu" style="display:none; margin-bottom:10px;">
+          <label style="display:flex; align-items:center; gap:5px; margin: 10px 0;">
+            <input type="checkbox" id="oreSpreadCheckbox">
+            <span>ORE_SPREAD_ENABLED</span>
+          </label>
         </div>
         
         <div id="playerCountControl">

--- a/src/config.js
+++ b/src/config.js
@@ -112,6 +112,8 @@ export const WIND_STRENGTH = 0.008 // How much wind affects particle movement
 
 export const ORE_SPREAD_INTERVAL = 30000  // 30 seconds (3x faster than before)
 export const ORE_SPREAD_PROBABILITY = 0.06
+// Toggle ore spreading to improve performance when disabled
+export const ORE_SPREAD_ENABLED = true
 
 // New: Path recalculation interval (in milliseconds)
 export const PATH_CALC_INTERVAL = 2000

--- a/src/config.js
+++ b/src/config.js
@@ -113,7 +113,11 @@ export const WIND_STRENGTH = 0.008 // How much wind affects particle movement
 export const ORE_SPREAD_INTERVAL = 30000  // 30 seconds (3x faster than before)
 export const ORE_SPREAD_PROBABILITY = 0.06
 // Toggle ore spreading to improve performance when disabled
-export const ORE_SPREAD_ENABLED = true
+export let ORE_SPREAD_ENABLED = true
+
+export function setOreSpreadEnabled(value) {
+  ORE_SPREAD_ENABLED = value
+}
 
 // New: Path recalculation interval (in milliseconds)
 export const PATH_CALC_INTERVAL = 2000

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -1,5 +1,5 @@
 // Game State Management Module - Handles win/loss conditions, cleanup, and map scrolling
-import { INERTIA_DECAY, TILE_SIZE, ORE_SPREAD_INTERVAL, ORE_SPREAD_PROBABILITY } from '../config.js'
+import { INERTIA_DECAY, TILE_SIZE, ORE_SPREAD_INTERVAL, ORE_SPREAD_PROBABILITY, ORE_SPREAD_ENABLED } from '../config.js'
 import { resolveUnitCollisions, removeUnitOccupancy } from '../units.js'
 import { explosions } from '../logic.js'
 import { playSound, playPositionalSound } from '../sound.js'
@@ -29,6 +29,10 @@ export function updateMapScrolling(gameState, mapGrid) {
  */
 export function updateOreSpread(gameState, mapGrid, factories = []) {
   const now = performance.now()
+
+  if (!ORE_SPREAD_ENABLED) {
+    return
+  }
   
   if (now - gameState.lastOreUpdate >= ORE_SPREAD_INTERVAL) {
     const directions = [

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import { unitCosts, initializeOccupancyMap, rebuildOccupancyMapWithTextures } fr
 import { gameState } from './gameState.js'
 import { buildingData } from './buildings.js'
 import { productionQueue } from './productionQueue.js'
-import { TILE_SIZE, MAP_TILES_X, MAP_TILES_Y } from './config.js'
+import { TILE_SIZE, MAP_TILES_X, MAP_TILES_Y, ORE_SPREAD_ENABLED, setOreSpreadEnabled } from './config.js'
 import { initFactories } from './factories.js'
 import { initializeGameAssets, generateMap as generateMapFromSetup, cleanupOreFromBuildings } from './gameSetup.js'
 import { initSaveGameSystem } from './saveGame.js'
@@ -190,6 +190,9 @@ class Game {
     // Setup map shuffle
     this.setupMapShuffle()
 
+    // Setup map settings
+    this.setupMapSettings()
+
     // Setup production tabs and buttons
     this.productionController.initProductionTabs()
     this.productionController.setupAllProductionButtons()
@@ -253,6 +256,23 @@ class Game {
       const seedInput = document.getElementById('mapSeed')
       const seed = seedInput.value || '1'
       this.resetGameWithNewMap(seed)
+    })
+  }
+
+  setupMapSettings() {
+    const settingsBtn = document.getElementById('mapSettingsBtn')
+    const settingsMenu = document.getElementById('mapSettingsMenu')
+    const oreCheckbox = document.getElementById('oreSpreadCheckbox')
+
+    if (!settingsBtn || !settingsMenu || !oreCheckbox) return
+
+    oreCheckbox.checked = ORE_SPREAD_ENABLED
+    settingsBtn.addEventListener('click', () => {
+      settingsMenu.style.display = settingsMenu.style.display === 'none' ? 'block' : 'none'
+    })
+
+    oreCheckbox.addEventListener('change', (e) => {
+      setOreSpreadEnabled(e.target.checked)
     })
   }
 

--- a/style.css
+++ b/style.css
@@ -203,7 +203,7 @@ html, body {
   filter: brightness(0) invert(1); /* Makes the SVG white */
 }
 
-.play-pause-icon, .restart-icon, .music-icon {
+.play-pause-icon, .restart-icon, .music-icon, .settings-icon {
   font-weight: bold;
   font-size: 20px;
 }
@@ -697,4 +697,11 @@ html, body {
 
 .fps-overlay.fps-bad {
   color: #ff0000; /* Red for <15 FPS */
+}
+
+/* Map Settings Menu */
+#mapSettingsMenu {
+  background-color: #333;
+  color: #fff;
+  padding: 10px;
 }


### PR DESCRIPTION
## Summary
- add an `ORE_SPREAD_ENABLED` switch in `config.js`
- skip ore spread logic when the switch is off

## Testing
- `npm run lint` *(fails: 2771 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d49f7cbac83288a348b775c0475da