### PR TITLE
Enable repairs without full funds

### DIFF
--- a/src/buildingRepairHandler.js
+++ b/src/buildingRepairHandler.js
@@ -84,11 +84,6 @@ export function buildingRepairHandler(e, gameState, gameCanvas, mapGrid, units, 
           return
         }
 
-        // Check if player has enough money
-        if (gameState.money < repairCost) {
-          showNotification(`Not enough money for repairs. Cost: $${repairCost}`)
-          return
-        }
 
         // Always use awaiting repair system, even if not under attack
         // This ensures consistent behavior and allows for immediate start if no cooldown


### PR DESCRIPTION
## Summary
- allow building repairs to initiate regardless of available money
- remove upfront money requirement for queued repairs
- pause/resume repairs when money runs out

## Testing
- `npm run lint` *(fails: 2778 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e50cfa77c832890a2b0a580476b6f