### PR TITLE
Use config values for build UI costs

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
               <button class="production-button" data-unit-type="tank">
                 <img src="images/sidebar/tank.webp" onerror="this.style.display='none'">
                 <span class="unit-name">Tank V1</span>
-                <span class="unit-cost">$1000</span>
+                <span class="unit-cost"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -83,7 +83,7 @@
               <button class="production-button" data-unit-type="tank-v2">
                 <img src="images/sidebar/tank_v2.webp" onerror="this.style.display='none'">
                 <span class="unit-name">Tank V2</span>
-                <span class="unit-cost">$2000</span>
+                <span class="unit-cost"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -91,7 +91,7 @@
               <button class="production-button" data-unit-type="tank-v3">
                 <img src="images/sidebar/tank_v3.webp" onerror="this.style.display='none'">
                 <span class="unit-name">Tank V3</span>
-                <span class="unit-cost">$3000</span>
+                <span class="unit-cost"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -99,7 +99,7 @@
               <button class="production-button" data-unit-type="rocketTank">
                 <img src="images/sidebar/rocket_tank.webp" onerror="this.style.display='none'">
                 <span class="unit-name">Rocket Tank</span>
-                <span class="unit-cost">$2000</span>
+                <span class="unit-cost"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -107,7 +107,7 @@
               <button class="production-button" data-unit-type="harvester">
                 <img src="images/sidebar/harvester.webp" onerror="this.style.display='none'">
                 <span class="unit-name">Harvester</span>
-                <span class="unit-cost">$500</span>
+                <span class="unit-cost"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -117,8 +117,8 @@
               <button class="production-button" data-building-type="constructionYard">
                 <img draggable="true" src="images/sidebar/construction_yard.png" onerror="this.style.display='none'">
                 <span class="building-name">Construction Yard</span>
-                <span class="building-cost">$2000</span>
-                <span class="building-power">-10 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -126,8 +126,8 @@
               <button class="production-button" data-building-type="oreRefinery">
                 <img draggable="true" src="images/sidebar/ore_refinery.webp" onerror="this.style.display='none'">
                 <span class="building-name">Ore Refinery</span>
-                <span class="building-cost">$2500</span>
-                <span class="building-power">-15 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -135,8 +135,8 @@
               <button class="production-button" data-building-type="powerPlant">
                 <img draggable="true" src="images/sidebar/power_plant.webp" onerror="this.style.display='none'">
                 <span class="building-name">Power Plant</span>
-                <span class="building-cost">$1800</span>
-                <span class="building-power">+200 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -144,8 +144,8 @@
               <button class="production-button" data-building-type="vehicleFactory">
                 <img draggable="true" src="images/sidebar/vehicle_factory.webp" onerror="this.style.display='none'">
                 <span class="building-name">Vehicle Factory</span>
-                <span class="building-cost">$3000</span>
-                <span class="building-power">-30 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -153,8 +153,8 @@
               <button class="production-button" data-building-type="vehicleWorkshop">
                 <img draggable="true" src="images/sidebar/vehicle_workshop.webp" onerror="this.style.display='none'">
                 <span class="building-name">Vehicle Workshop</span>
-                <span class="building-cost">$3000</span>
-                <span class="building-power">-20 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -162,8 +162,8 @@
               <button class="production-button" data-building-type="radarStation">
                 <img draggable="true" src="images/sidebar/radar_station.webp" onerror="this.style.display='none'">
                 <span class="building-name">Radar Station</span>
-                <span class="building-cost">$3500</span>
-                <span class="building-power">-20 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -171,8 +171,8 @@
               <button class="production-button" data-building-type="turretGunV1">
                 <img draggable="true" src="images/sidebar/turret_gun_v1.webp" onerror="this.style.display='none'">
                 <span class="building-name">Turret Gun V1</span>
-                <span class="building-cost">$2000</span>
-                <span class="building-power">-15 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -180,8 +180,8 @@
               <button class="production-button" data-building-type="turretGunV2">
                 <img draggable="true" src="images/sidebar/turret_gun_v2.webp" onerror="this.style.display='none'">
                 <span class="building-name">Turret Gun V2</span>
-                <span class="building-cost">$2500</span>
-                <span class="building-power">-20 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -189,8 +189,8 @@
               <button class="production-button" data-building-type="turretGunV3">
                 <img draggable="true" src="images/sidebar/turret_gun_v3.webp" onerror="this.style.display='none'">
                 <span class="building-name">Turret Gun V3</span>
-                <span class="building-cost">$3000</span>
-                <span class="building-power">-25 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -198,8 +198,8 @@
               <button class="production-button" data-building-type="rocketTurret">
                 <img draggable="true" src="images/sidebar/rocket_turret.webp" onerror="this.style.display='none'">
                 <span class="building-name">Rocket Turret</span>
-                <span class="building-cost">$4000</span>
-                <span class="building-power">-20 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -207,8 +207,8 @@
               <button class="production-button" data-building-type="teslaCoil">
                 <img draggable="true" src="images/sidebar/tesla_coil.webp" onerror="this.style.display='none'">
                 <span class="building-name">Tesla Coil</span>
-                <span class="building-cost">$5000</span>
-                <span class="building-power">-60 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -216,8 +216,8 @@
               <button class="production-button" data-building-type="artilleryTurret">
                 <img draggable="true" src="images/sidebar/artillery_turret.webp" onerror="this.style.display='none'">
                 <span class="building-name">Artillery Turret</span>
-                <span class="building-cost">$3500</span>
-                <span class="building-power">-45 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -225,8 +225,8 @@
               <button class="production-button" data-building-type="concreteWall">
                 <img draggable="true" src="images/sidebar/concrete_wall.webp" onerror="this.style.display='none'">
                 <span class="building-name">Concrete Wall</span>
-                <span class="building-cost">$100</span>
-                <span class="building-power">0 MW</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
@@ -311,6 +311,36 @@
     </div>
     
     <script src="/src/main.js" type="module"></script>
+    <script type="module">
+      import { UNIT_COSTS } from '/src/config.js'
+      import { buildingData } from '/src/buildings.js'
+
+      document.addEventListener('DOMContentLoaded', () => {
+        // Update unit costs
+        Object.entries(UNIT_COSTS).forEach(([type, cost]) => {
+          const btn = document.querySelector(`.production-button[data-unit-type="${type}"]`)
+          if (btn) {
+            const costSpan = btn.querySelector('.unit-cost')
+            if (costSpan) costSpan.textContent = `$${cost}`
+          }
+        })
+
+        // Update building costs and power
+        Object.entries(buildingData).forEach(([type, data]) => {
+          const btn = document.querySelector(`.production-button[data-building-type="${type}"]`)
+          if (btn) {
+            const costSpan = btn.querySelector('.building-cost')
+            if (costSpan) costSpan.textContent = `$${data.cost}`
+
+            const powerSpan = btn.querySelector('.building-power')
+            if (powerSpan) {
+              const val = data.power
+              powerSpan.textContent = `${val > 0 ? '+' : ''}${val} MW`
+            }
+          }
+        })
+      })
+    </script>
     <script>
       // Add this to ensure we have sound functions even if not defined elsewhere
       function playSound(soundName) {


### PR DESCRIPTION
## Summary
- remove hardcoded cost and power labels from production buttons
- dynamically update production button labels using values from `config.js` and `buildings.js`

## Testing
- `npm run lint` *(fails: many existing linter errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e6cf0968c832890babe63aa1795da