### PR TITLE
Add performance metrics overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,6 +309,7 @@
       <div id="frameTimeMin">Min: -- ms</div>
       <div id="frameTimeMax">Max: -- ms</div>
     </div>
+    <div id="performanceDialog" class="performance-dialog"></div>
     
     <script src="/src/main.js" type="module"></script>
     <script>

--- a/src/ai/enemyAIPlayer.js
+++ b/src/ai/enemyAIPlayer.js
@@ -4,6 +4,7 @@ import { resetAttackDirections } from './enemyStrategies.js'
 import { updateAIUnit } from './enemyUnitBehavior.js'
 import { findBuildingPosition } from './enemyBuilding.js'
 import { gameState } from '../gameState.js'
+import { logPerformance } from '../performanceUtils.js'
 
 function findSimpleBuildingPosition(buildingType, mapGrid, factories, aiPlayerId) {
   // Validate inputs
@@ -82,7 +83,7 @@ function findSimpleBuildingPosition(buildingType, mapGrid, factories, aiPlayerId
   return null
 }
 
-function updateAIPlayer(aiPlayerId, units, factories, bullets, mapGrid, gameState, occupancyMap, now, targetedOreTiles) {
+const updateAIPlayer = logPerformance(function _updateAIPlayer(aiPlayerId, units, factories, bullets, mapGrid, gameState, occupancyMap, now, targetedOreTiles) {
   const aiFactory = factories.find(
     f => (f.id === aiPlayerId || f.owner === aiPlayerId) && f.health > 0
   )
@@ -473,6 +474,6 @@ function updateAIPlayer(aiPlayerId, units, factories, bullets, mapGrid, gameStat
 
     updateAIUnit(unit, units, gameState, mapGrid, now, aiPlayerId, targetedOreTiles, bullets)
   })
-}
+}, false)
 
 export { updateAIPlayer }

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -2,6 +2,7 @@
 import { playSound } from './sound.js'
 import { showNotification } from './ui/notifications.js'
 import { gameState } from './gameState.js'
+import { logPerformance } from './performanceUtils.js'
 import { PLAYER_POSITIONS, MAP_TILES_X, MAP_TILES_Y } from './config.js'
 
 // Building dimensions and costs
@@ -195,7 +196,7 @@ export const buildingData = {
     health: 200,
     smokeSpots: []
   }
-}
+}, false)
 
 export function createBuilding(type, x, y) {
   if (!buildingData[type]) return null
@@ -822,7 +823,7 @@ export function pauseActiveRepair(building) {
 }
 
 // Update buildings that are currently under repair
-export function updateBuildingsUnderRepair(gameState, currentTime) {
+export const updateBuildingsUnderRepair = logPerformance(function _updateBuildingsUnderRepair(gameState, currentTime) {
   if (!gameState.buildingsUnderRepair || gameState.buildingsUnderRepair.length === 0) {
     return
   }
@@ -929,7 +930,7 @@ function actuallyPauseRepair(building, gameState, currentTime) {
 }
 
 // Update buildings that are awaiting repair (under attack cooldown)
-export function updateBuildingsAwaitingRepair(gameState, currentTime) {
+export const updateBuildingsAwaitingRepair = logPerformance(function _updateBuildingsAwaitingRepair(gameState, currentTime) {
   if (!gameState.buildingsAwaitingRepair || gameState.buildingsAwaitingRepair.length === 0) {
     return
   }

--- a/src/enemy.js
+++ b/src/enemy.js
@@ -1,8 +1,9 @@
 // enemy orchestrator
 import { updateAIPlayer } from './ai/enemyAIPlayer.js'
+import { logPerformance } from './performanceUtils.js'
 export { spawnEnemyUnit } from './ai/enemySpawner.js'
 
-export function updateEnemyAI(units, factories, bullets, mapGrid, gameState) {
+export const updateEnemyAI = logPerformance(function _updateEnemyAI(units, factories, bullets, mapGrid, gameState) {
   const occupancyMap = gameState.occupancyMap
   const now = performance.now()
   const humanPlayer = gameState.humanPlayer || 'player1'
@@ -14,4 +15,4 @@ export function updateEnemyAI(units, factories, bullets, mapGrid, gameState) {
   aiPlayers.forEach(aiPlayerId => {
     updateAIPlayer(aiPlayerId, units, factories, bullets, mapGrid, gameState, occupancyMap, now, targetedOreTiles)
   })
-}
+}, false)

--- a/src/game/buildingSystem.js
+++ b/src/game/buildingSystem.js
@@ -8,6 +8,7 @@ import { checkGameEndConditions } from './gameStateManager.js'
 import { updateUnitSpeedModifier } from '../utils.js'
 import { smoothRotateTowardsAngle, angleDiff } from '../logic.js'
 import { getTurretImageConfig, turretImagesAvailable } from '../rendering/turretImageRenderer.js'
+import { logPerformance } from '../performanceUtils.js'
 
 /**
  * Updates all buildings including health checks, destruction, and defensive capabilities
@@ -18,7 +19,7 @@ import { getTurretImageConfig, turretImagesAvailable } from '../rendering/turret
  * @param {Array} mapGrid - 2D array representing the map
  * @param {number} delta - Time delta
  */
-export function updateBuildings(gameState, units, bullets, factories, mapGrid, delta) {
+export const updateBuildings = logPerformance(function _updateBuildings(gameState, units, bullets, factories, mapGrid, delta) {
   const now = performance.now()
 
   if (gameState.buildings && gameState.buildings.length > 0) {
@@ -80,7 +81,7 @@ export function updateBuildings(gameState, units, bullets, factories, mapGrid, d
   if (gameState.buildings && gameState.buildings.length > 0) {
     updateDefensiveBuildings(gameState.buildings, units, bullets, delta, gameState)
   }
-}
+}, false)
 
 /**
  * Updates defensive buildings like turrets and Tesla coils
@@ -90,7 +91,7 @@ export function updateBuildings(gameState, units, bullets, factories, mapGrid, d
  * @param {number} delta - Time delta
  * @param {Object} gameState - Game state object
  */
-function updateDefensiveBuildings(buildings, units, bullets, delta, gameState) {
+const updateDefensiveBuildings = logPerformance(function _updateDefensiveBuildings(buildings, units, bullets, delta, gameState) {
   const now = performance.now()
 
   // Debug: Count Tesla coils
@@ -506,4 +507,4 @@ export function updateTeslaCoilEffects(units) {
       unit.teslaSlowed = false
     }
   }
-}
+}, false)

--- a/src/game/bulletSystem.js
+++ b/src/game/bulletSystem.js
@@ -8,6 +8,7 @@ import { calculateHitZoneDamageMultiplier } from './hitZoneCalculator.js'
 import { canPlayCriticalDamageSound, recordCriticalDamageSoundPlayed } from './soundCooldownManager.js'
 import { updateUnitSpeedModifier } from '../utils.js'
 import { markBuildingForRepairPause } from '../buildings.js'
+import { logPerformance } from '../performanceUtils.js'
 import { removeUnitOccupancy } from '../units.js'
 import { handleAttackNotification } from './attackNotifications.js'
 import { emitSmokeParticles } from '../utils/smokeUtils.js'
@@ -21,7 +22,7 @@ import { getRocketSpawnPoint } from '../rendering/rocketTankImageRenderer.js'
  * @param {Object} gameState - Game state object
  * @param {Array} mapGrid - 2D array representing the map
  */
-export function updateBullets(bullets, units, factories, gameState, mapGrid) {
+export const updateBullets = logPerformance(function _updateBullets(bullets, units, factories, gameState, mapGrid) {
   const now = performance.now()
 
   // Update bullet speeds based on game speed multiplier
@@ -364,7 +365,7 @@ export function updateBullets(bullets, units, factories, gameState, mapGrid) {
     }
     }
   }
-}
+}, false)
 
 /**
  * Creates and fires a bullet from a unit

--- a/src/game/gameLoop.js
+++ b/src/game/gameLoop.js
@@ -8,6 +8,7 @@ import { updateBuildingsUnderRepair, updateBuildingsAwaitingRepair } from '../bu
 import { updateEnergyBar } from '../ui/energyBar.js'
 import { milestoneSystem } from './milestoneSystem.js'
 import { FPSDisplay } from '../ui/fpsDisplay.js'
+import { logPerformance } from '../performanceUtils.js'
 
 export class GameLoop {
   constructor(canvasManager, productionController, mapGrid, factories, units, bullets, productionQueue, moneyEl, gameTimeEl) {
@@ -54,7 +55,7 @@ export class GameLoop {
     }
   }
 
-  animate(timestamp) {
+  animate = logPerformance((timestamp) => {
     // Stop if the loop has been stopped
     if (!this.running) {
       return
@@ -160,7 +161,7 @@ export class GameLoop {
     } else {
       this.animationId = requestAnimationFrame((timestamp) => this.animate(timestamp))
     }
-  }
+  }, false)
 
   // Legacy game loop for compatibility (if needed)
   legacyGameLoop(timestamp) {

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -4,6 +4,7 @@ import { resolveUnitCollisions, removeUnitOccupancy } from '../units.js'
 import { explosions } from '../logic.js'
 import { playSound, playPositionalSound } from '../sound.js'
 import { clearFactoryFromMapGrid } from '../factories.js'
+import { logPerformance } from '../performanceUtils.js'
 
 /**
  * Updates map scrolling with inertia
@@ -27,7 +28,7 @@ export function updateMapScrolling(gameState, mapGrid) {
  * @param {Array} mapGrid - 2D array representing the map
  * @param {Array} factories - Array of factory objects
  */
-export function updateOreSpread(gameState, mapGrid, factories = []) {
+export const updateOreSpread = logPerformance(function _updateOreSpread(gameState, mapGrid, factories = []) {
   const now = performance.now()
 
   if (!ORE_SPREAD_ENABLED) {
@@ -74,7 +75,7 @@ export function updateOreSpread(gameState, mapGrid, factories = []) {
     }
     gameState.lastOreUpdate = now
   }
-}
+}, false)
 
 /**
  * Updates explosion effects
@@ -228,9 +229,9 @@ export function cleanupDestroyedFactories(factories, mapGrid, gameState) {
  * @param {Array} units - Array of unit objects
  * @param {Array} mapGrid - 2D array representing the map
  */
-export function updateUnitCollisions(units, mapGrid) {
+export const updateUnitCollisions = logPerformance(function _updateUnitCollisions(units, mapGrid) {
   resolveUnitCollisions(units, mapGrid)
-}
+}, false)
 
 /**
  * Gets the defeat sound for a specific player based on their color

--- a/src/game/harvesterLogic.js
+++ b/src/game/harvesterLogic.js
@@ -3,6 +3,7 @@ import { TILE_SIZE, HARVESTER_CAPPACITY, HARVESTER_UNLOAD_TIME, HARVESTER_PRODUC
 import { findPath, buildOccupancyMap } from '../units.js'
 import { playSound } from '../sound.js'
 import { productionQueue } from '../productionQueue.js'
+import { logPerformance } from '../performanceUtils.js'
 import { 
   findClosestOre, 
   findAdjacentTile, 
@@ -20,7 +21,7 @@ const refineryQueues = {}
 /**
  * Updates all harvester logic including mining, unloading, and pathfinding
  */
-export function updateHarvesterLogic(units, mapGrid, occupancyMap, gameState, factories, now) {
+export const updateHarvesterLogic = logPerformance(function _updateHarvesterLogic(units, mapGrid, occupancyMap, gameState, factories, now) {
   // now parameter is passed from the main game loop
   
   // Initialize refinery status if not exists
@@ -468,7 +469,7 @@ function handleHarvesterUnloading(unit, factories, mapGrid, gameState, now, occu
       }
     }
   }
-}
+}, false)
 
 /**
  * Completes the unloading process at a refinery

--- a/src/game/unitCombat.js
+++ b/src/game/unitCombat.js
@@ -7,6 +7,7 @@ import { stopUnitMovement } from './unifiedMovement.js'
 import { gameState } from '../gameState.js'
 import { updateUnitSpeedModifier } from '../utils.js'
 import { getRocketSpawnPoint } from '../rendering/rocketTankImageRenderer.js'
+import { logPerformance } from '../performanceUtils.js'
 
 /**
  * Check if the turret is properly aimed at the target
@@ -580,7 +581,7 @@ export function cleanupAttackGroupTargets() {
 /**
  * Updates unit combat behavior including targeting and shooting
  */
-export function updateUnitCombat(units, bullets, mapGrid, gameState, now) {
+export const updateUnitCombat = logPerformance(function _updateUnitCombat(units, bullets, mapGrid, gameState, now) {
   const occupancyMap = gameState.occupancyMap
   
   let combatUnitsCount = 0
@@ -614,7 +615,7 @@ export function updateUnitCombat(units, bullets, mapGrid, gameState, now) {
       updateRocketTankCombat(unit, units, bullets, mapGrid, now, occupancyMap)
     }
   })
-}
+}, false)
 
 /**
  * Updates standard tank combat

--- a/src/game/unitMovement.js
+++ b/src/game/unitMovement.js
@@ -7,11 +7,12 @@ import { selectedUnits, cleanupDestroyedSelectedUnits } from '../inputHandler.js
 import { angleDiff, smoothRotateTowardsAngle, findAdjacentTile } from '../logic.js'
 import { updateUnitPosition, initializeUnitMovement, stopUnitMovement } from './unifiedMovement.js'
 import { updateRetreatBehavior, shouldExitRetreat, cancelRetreat } from '../behaviours/retreat.js'
+import { logPerformance } from '../performanceUtils.js'
 
 /**
  * Updates unit movement, pathfinding, and formation handling
  */
-export function updateUnitMovement(units, mapGrid, occupancyMap, gameState, now, factories = null) {
+export const updateUnitMovement = logPerformance(function _updateUnitMovement(units, mapGrid, occupancyMap, gameState, now, factories = null) {
   // Clean up unit selection - prevent null references
   cleanupDestroyedSelectedUnits()
 
@@ -147,7 +148,7 @@ export function updateUnitMovement(units, mapGrid, occupancyMap, gameState, now,
       }
     }
   }
-}
+}, false)
 
 /**
  * Updates unit pathfinding based on movement targets

--- a/src/game/workshopLogic.js
+++ b/src/game/workshopLogic.js
@@ -3,6 +3,7 @@ import { findPath } from '../units.js'
 import { updateUnitSpeedModifier, getUnitCost } from '../utils.js'
 import { gameState } from '../gameState.js'
 import { playSound } from '../sound.js'
+import { logPerformance } from '../performanceUtils.js'
 
 function initWorkshop(workshop) {
   if (!workshop.repairSlots) {
@@ -69,7 +70,7 @@ function assignUnitsToSlots(workshop, mapGrid) {
   }
 }
 
-export function updateWorkshopLogic(units, buildings, mapGrid, delta) {
+export const updateWorkshopLogic = logPerformance(function _updateWorkshopLogic(units, buildings, mapGrid, delta) {
   const workshops = buildings.filter(b => b.type === 'vehicleWorkshop')
   const now = performance.now()
   workshops.forEach(workshop => {
@@ -172,4 +173,4 @@ export function updateWorkshopLogic(units, buildings, mapGrid, delta) {
       }
     })
   })
-}
+}, false)

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -71,6 +71,9 @@ export const gameState = {
   // Occupancy map visibility toggle
   occupancyVisible: false,
 
+  // Performance dialog visibility toggle
+  performanceVisible: false,
+
   // FPS display toggle and tracking
   fpsVisible: false,
   fpsCounter: {

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -9,6 +9,7 @@ import { isInputFieldFocused } from '../utils/inputUtils.js'
 import { toggleUnitLogging } from '../utils/logger.js'
 import { cancelUnitMovement } from '../game/unifiedMovement.js'
 import { handleAltKeyRelease, resetWaypointTracking } from '../game/waypointSounds.js'
+import { performanceDialog } from '../ui/performanceDialog.js'
 
 export class KeyboardHandler {
   constructor() {
@@ -147,6 +148,11 @@ export class KeyboardHandler {
       else if (e.key.toLowerCase() === 'l') {
         e.preventDefault()
         this.handleLoggingToggle(selectedUnits)
+      }
+      // M key to toggle performance dialog
+      else if (e.key.toLowerCase() === 'm') {
+        e.preventDefault()
+        this.handlePerformanceToggle()
       }
     })
 
@@ -655,6 +661,13 @@ export class KeyboardHandler {
     this.showNotification(`FPS display: ${status}`, 2000)
     
     // Play a sound for feedback
+    playSound('confirmed', 0.5)
+  }
+
+  handlePerformanceToggle() {
+    performanceDialog.toggle()
+    const status = gameState.performanceVisible ? 'ON' : 'OFF'
+    this.showNotification(`Performance stats: ${status}`, 2000)
     playSound('confirmed', 0.5)
   }
 

--- a/src/performanceUtils.js
+++ b/src/performanceUtils.js
@@ -31,3 +31,12 @@ export function logPerformance(functionToWrap, printEachCall = false) {
     return result;
   };
 }
+
+export function resetPerformanceStatistics() {
+  const stats = window.performanceStatistics || {};
+  Object.keys(stats).forEach(key => {
+    stats[key].durationMax = 0;
+    stats[key].durationAvg = 0;
+    stats[key].callCount = 0;
+  });
+}

--- a/src/ui/performanceDialog.js
+++ b/src/ui/performanceDialog.js
@@ -1,0 +1,76 @@
+import { gameState } from '../gameState.js'
+import { resetPerformanceStatistics } from '../performanceUtils.js'
+
+class PerformanceDialog {
+  constructor() {
+    this.container = document.getElementById('performanceDialog')
+    this.sortMode = 'duration'
+    this.intervalId = null
+    if (this.container) {
+      this.container.innerHTML = `
+        <div class="perf-controls">
+          <button id="perfSortName">Name</button>
+          <button id="perfSortDuration">Avg</button>
+          <button id="perfReset">Reset</button>
+        </div>
+        <div id="perfContent"></div>
+      `
+      this.contentEl = document.getElementById('perfContent')
+      document.getElementById('perfSortName').addEventListener('click', () => {
+        this.sortMode = 'name'
+        this.render()
+      })
+      document.getElementById('perfSortDuration').addEventListener('click', () => {
+        this.sortMode = 'duration'
+        this.render()
+      })
+      document.getElementById('perfReset').addEventListener('click', () => {
+        resetPerformanceStatistics()
+        this.render()
+      })
+    }
+  }
+
+  toggle() {
+    if (!this.container) return
+    gameState.performanceVisible = !gameState.performanceVisible
+    if (gameState.performanceVisible) {
+      this.container.classList.add('visible')
+      this.start()
+    } else {
+      this.container.classList.remove('visible')
+      this.stop()
+    }
+  }
+
+  start() {
+    this.render()
+    this.intervalId = setInterval(() => this.render(), 2000)
+  }
+
+  stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+    }
+  }
+
+  render() {
+    if (!this.contentEl) return
+    const stats = window.performanceStatistics || {}
+    const entries = Object.entries(stats)
+    if (this.sortMode === 'duration') {
+      entries.sort((a, b) => b[1].durationAvg - a[1].durationAvg)
+    } else {
+      entries.sort((a, b) => a[0].localeCompare(b[0]))
+    }
+    this.contentEl.innerHTML = ''
+    entries.forEach(([name, data]) => {
+      const div = document.createElement('div')
+      div.textContent = `${name}: avg ${data.durationAvg.toFixed(2)}ms max ${data.durationMax.toFixed(2)}ms calls ${data.callCount}`
+      this.contentEl.appendChild(div)
+    })
+  }
+}
+
+export const performanceDialog = new PerformanceDialog()

--- a/src/units.js
+++ b/src/units.js
@@ -8,6 +8,7 @@ import {
   MAX_SPAWN_SEARCH_DISTANCE,
   STREET_PATH_COST
 } from './config.js'
+import { logPerformance } from './performanceUtils.js'
 import { getUniqueId, updateUnitSpeedModifier } from './utils.js'
 import { initializeUnitMovement } from './game/unifiedMovement.js'
 import { gameState } from './gameState.js'
@@ -106,7 +107,7 @@ export function updateUnitOccupancy(unit, prevTileX, prevTileY, occupancyMap) {
     occupancyMap[currentTileY][currentTileX] =
       (occupancyMap[currentTileY][currentTileX] || 0) + 1
   }
-}
+}, false)
 
 export function removeUnitOccupancy(unit, occupancyMap) {
   if (!occupancyMap) return
@@ -218,7 +219,7 @@ function findNearestFreeTile(x, y, mapGrid, occupancyMap, maxDistance = 5) {
 
 // A* pathfinding with diagonal movement and cost advantage for street tiles.
 // Early exits if destination is out of bounds or impassable.
-export function findPath(start, end, mapGrid, occupancyMap = null, pathFindingLimit = PATHFINDING_LIMIT) {
+export const findPath = logPerformance(function _findPath(start, end, mapGrid, occupancyMap = null, pathFindingLimit = PATHFINDING_LIMIT) {
   // Validate input coordinates
   if (!start || !end || 
       typeof start.x !== 'number' || typeof start.y !== 'number' ||

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -7,6 +7,8 @@ import {
 import { emitSmokeParticles } from './utils/smokeUtils.js'
 import { getBuildingImage } from './buildingImageMap.js'
 
+import { logPerformance } from './performanceUtils.js'
+
 import { updateEnemyAI } from './enemy.js'
 import { cleanupDestroyedSelectedUnits, getUnitCommandsHandler } from './inputHandler.js'
 import { updateBuildingsUnderRepair, updateBuildingsAwaitingRepair, buildingData } from './buildings.js'
@@ -37,7 +39,7 @@ import {
 import { updateGlobalPathfinding } from './game/pathfinding.js'
 import { logUnitStatus } from './utils/logger.js'
 
-export function updateGame(delta, mapGrid, factories, units, bullets, gameState) {
+export const updateGame = logPerformance(function _updateGame(delta, mapGrid, factories, units, bullets, gameState) {
   try {
     if (gameState.gamePaused) return
     const now = performance.now()
@@ -223,7 +225,7 @@ export function updateGame(delta, mapGrid, factories, units, bullets, gameState)
     console.trace() // Add stack trace to see exactly where the error occurs
     // Don't allow the game to completely crash
   }
-}
+}, false)
 
 // Re-export Tesla Coil effects for backward compatibility
 export { updateTeslaCoilEffects }

--- a/style.css
+++ b/style.css
@@ -699,6 +699,46 @@ html, body {
   color: #ff0000; /* Red for <15 FPS */
 }
 
+/* Performance Dialog */
+.performance-dialog {
+  position: absolute;
+  top: 60px;
+  right: 10px;
+  width: 260px;
+  max-height: 300px;
+  overflow-y: auto;
+  background: #333;
+  color: #fff;
+  padding: 8px;
+  border-radius: 4px;
+  font-family: sans-serif;
+  font-size: 12px;
+  z-index: 1000;
+  display: none;
+}
+
+.performance-dialog.visible {
+  display: block;
+}
+
+.performance-dialog .perf-controls {
+  margin-bottom: 4px;
+  display: flex;
+}
+
+.performance-dialog button {
+  background: #444;
+  color: #fff;
+  border: none;
+  padding: 2px 6px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
+.performance-dialog #perfReset {
+  margin-left: auto;
+}
+
 /* Map Settings Menu */
 #mapSettingsMenu {
   background-color: #333;


### PR DESCRIPTION
## Summary
- instrument core systems with `logPerformance`
- add performance dialog overlay UI
- toggle overlay using `M` key
- style dialog with dark theme
- add reset button for performance metrics

## Testing
- `npm run lint` *(fails: trailing spaces and quotes)*


------
https://chatgpt.com/codex/tasks/task_e_687d6492b2648328bf89dae3a38814aa