### PR TITLE
Add hospital building and ambulance unit

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,14 @@
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
               </button>
+              <button class="production-button" data-unit-type="ambulance">
+                <img src="images/sidebar/ambulance.webp" onerror="this.style.display='none'">
+                <span class="unit-name">Ambulance</span>
+                <span class="unit-cost"></span>
+                <div class="production-progress"></div>
+                <div class="batch-counter" style="display:none">0</div>
+                <div class="new-label" style="display:none">NEW</div>
+              </button>
             </div>
             <div id="buildingsTabContent" class="tab-content active">
               <button class="production-button" data-building-type="constructionYard">
@@ -162,6 +170,15 @@
               <button class="production-button" data-building-type="radarStation">
                 <img draggable="true" src="images/sidebar/radar_station.webp" onerror="this.style.display='none'">
                 <span class="building-name">Radar Station</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
+                <div class="production-progress"></div>
+                <div class="batch-counter" style="display:none">0</div>
+                <div class="new-label" style="display:none">NEW</div>
+              </button>
+              <button class="production-button" data-building-type="hospital">
+                <img draggable="true" src="images/sidebar/hospital.webp" onerror="this.style.display='none'">
+                <span class="building-name">Hospital</span>
                 <span class="building-cost"></span>
                 <span class="building-power"></span>
                 <div class="production-progress"></div>

--- a/src/buildingImageMap.js
+++ b/src/buildingImageMap.js
@@ -17,6 +17,7 @@ export const buildingImageMap = {
   rocketTurret: 'images/map/buildings/rocket_gun.webp',
   teslaCoil: 'images/map/buildings/teslacoil.webp',
   constructionYard: 'images/map/buildings/construction_yard.webp',
+  hospital: 'images/map/buildings/hospital.webp',
   concreteWallCross: 'images/map/buildings/concrete_wall_cross.webp',
   concreteWallHorizontal: 'images/map/buildings/concrete_wall_horizontal.webp',
   concreteWallVertical: 'images/map/buildings/concrete_wall_vertical.webp',

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -74,6 +74,16 @@ export const buildingData = {
     health: 200,
     smokeSpots: []
   },
+  hospital: {
+    width: 3,
+    height: 3,
+    cost: 4000,
+    power: -50,
+    image: 'hospital.webp',
+    displayName: 'Hospital',
+    health: 200,
+    smokeSpots: []
+  },
   turretGunV1: {
     width: 1,
     height: 1,

--- a/src/config.js
+++ b/src/config.js
@@ -158,6 +158,7 @@ export const UNIT_COSTS = {
   tank: 1000,
   rocketTank: 2000,
   harvester: 500,
+  ambulance: 500,
   'tank-v2': 2000,
   'tank-v3': 3000
 }
@@ -213,6 +214,13 @@ export const UNIT_PROPERTIES = {
     speed: 0.35,  // 50% slower: 0.7 * 0.5 = 0.35
     rotationSpeed: TANK_WAGON_ROT,
     turretRotationSpeed: TANK_TURRET_ROT
+  },
+  ambulance: {
+    health: 25,
+    maxHealth: 25,
+    speed: 0.99,
+    rotationSpeed: TANK_WAGON_ROT,
+    turretRotationSpeed: 0
   }
 }
 

--- a/src/game/bulletSystem.js
+++ b/src/game/bulletSystem.js
@@ -191,6 +191,21 @@ export const updateBullets = logPerformance(function updateBullets(bullets, unit
             
             // Update speed modifier based on new health level
             updateUnitSpeedModifier(unit)
+
+            if (unit.crewStatus) {
+              const soundMap = {
+                loader: 'outLoaderIsOut',
+                driver: 'outDriverIsOut',
+                commander: 'outCommanderIsOut',
+                gunner: 'outGunnerIsOut'
+              }
+              Object.keys(unit.crewStatus).forEach(role => {
+                if (unit.crewStatus[role] && Math.random() < 0.15) {
+                  unit.crewStatus[role] = false
+                  playSound(soundMap[role])
+                }
+              })
+            }
           }
 
           // Play critical damage sound for rear hits on player's units only (with cooldown)

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -117,7 +117,7 @@ export const gameState = {
 
   // Initially no units are available (require vehicle factory), only basic buildings
   availableUnitTypes: new Set([]),
-  availableBuildingTypes: new Set(['constructionYard', 'oreRefinery', 'powerPlant', 'vehicleFactory', 'vehicleWorkshop', 'radarStation', 'turretGunV1', 'concreteWall']),
+  availableBuildingTypes: new Set(['constructionYard', 'oreRefinery', 'powerPlant', 'vehicleFactory', 'vehicleWorkshop', 'radarStation', 'turretGunV1', 'concreteWall', 'hospital']),
   newUnitTypes: new Set(),
   newBuildingTypes: new Set(),
 

--- a/src/ui/eventHandlers.js
+++ b/src/ui/eventHandlers.js
@@ -303,6 +303,11 @@ export class EventHandlers {
           // Save player building patterns
           savePlayerBuildPatterns(buildingType)
 
+          // Unlock ambulance when hospital is built
+          if (buildingType === 'hospital' && this.productionController) {
+            this.productionController.unlockUnitType('ambulance')
+          }
+
           // UPDATE: Update button states after successful placement
           if (this.productionController) {
             this.productionController.updateVehicleButtonStates()

--- a/src/units.js
+++ b/src/units.js
@@ -658,6 +658,15 @@ export function createUnit(factory, unitType, x, y) {
     currentCommand: null
   }
 
+  if (['tank_v1', 'tank-v2', 'tank-v3', 'rocketTank'].includes(actualType)) {
+    unit.crewStatus = {
+      driver: true,
+      gunner: true,
+      loader: true,
+      commander: true
+    }
+  }
+
   // Add unit-specific properties
   if (unitType === 'tank-v2' || unitType === 'tank-v3') {
     unit.alertMode = unitProps.alertMode


### PR DESCRIPTION
## Summary
- add hospital to building data and image map
- show hospital build button
- add ambulance unit definitions and unlock logic
- track tank crew members and randomly kill them on damage
- unlock ambulance production when a hospital is built

## Testing
- `npm run lint` *(fails: trailing spaces in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_687ee0128724832894090ff56206e31b