### PR TITLE
Add AI artillery turret and directional defense placement

### DIFF
--- a/src/ai/enemyBuilding.js
+++ b/src/ai/enemyBuilding.js
@@ -69,7 +69,11 @@ export function findBuildingPosition(buildingType, mapGrid, units, buildings, fa
 
   // Determine direction vector - prioritize direction toward player for defensive buildings
   let directionVector = { x: 0, y: 0 }
-  const isDefensiveBuilding = buildingType.startsWith('turretGun') || buildingType === 'rocketTurret'
+  const isDefensiveBuilding =
+    buildingType.startsWith('turretGun') ||
+    buildingType === 'rocketTurret' ||
+    buildingType === 'teslaCoil' ||
+    buildingType === 'artilleryTurret'
 
   if (isDefensiveBuilding && humanPlayerFactory) {
     // For defensive buildings, strongly prefer direction toward player
@@ -99,7 +103,12 @@ export function findBuildingPosition(buildingType, mapGrid, units, buildings, fa
     minSpaceBetweenBuildings = 3 // Refineries need extra space for harvester movement
   } else if (buildingType === 'vehicleFactory') {
     minSpaceBetweenBuildings = 3 // Vehicle factories need space for unit spawning
-  } else if (buildingType.startsWith('turretGun') || buildingType === 'rocketTurret' || buildingType === 'teslaCoil') {
+  } else if (
+    buildingType.startsWith('turretGun') ||
+    buildingType === 'rocketTurret' ||
+    buildingType === 'teslaCoil' ||
+    buildingType === 'artilleryTurret'
+  ) {
     minSpaceBetweenBuildings = 2 // Defense buildings standard spacing
   }
 
@@ -486,7 +495,11 @@ function fallbackBuildingPosition(buildingType, mapGrid, units, buildings, facto
 
   // Get human player factory for directional placement of defensive buildings
   const playerFactory = factories.find(f => f.id === gameState.humanPlayer || f.id === 'player1')
-  const isDefensiveBuilding = buildingType.startsWith('turretGun') || buildingType === 'rocketTurret'
+  const isDefensiveBuilding =
+    buildingType.startsWith('turretGun') ||
+    buildingType === 'rocketTurret' ||
+    buildingType === 'teslaCoil' ||
+    buildingType === 'artilleryTurret'
 
   // Calculate player direction for defensive buildings
   let playerDirection = null

--- a/src/ai/enemyStrategies.js
+++ b/src/ai/enemyStrategies.js
@@ -68,6 +68,9 @@ function evaluatePlayerDefenses(target, gameState) {
           case 'teslaCoil':
             defenseScore += 5
             break
+          case 'artilleryTurret':
+            defenseScore += 6
+            break
         }
       }
     })
@@ -165,7 +168,10 @@ function findNearestEnemyBase(unit, gameState) {
     )
     
     // Prioritize defensive buildings
-    const isDefensive = building.type.includes('turret') || building.type === 'teslaCoil'
+    const isDefensive =
+      building.type.includes('turret') ||
+      building.type === 'teslaCoil' ||
+      building.type === 'artilleryTurret'
     const adjustedDistance = isDefensive ? distance * 0.8 : distance
     
     if (adjustedDistance < nearestDistance) {
@@ -294,9 +300,9 @@ function findDefensivePosition(baseBuilding, gameState, mapGrid) {
   if (!gameState.buildings) return null
   
   // Look for defensive buildings near the base
-  const defensiveBuildings = gameState.buildings.filter(b => 
-    b.owner === 'enemy' && 
-    (b.type.includes('turret') || b.type === 'teslaCoil') &&
+  const defensiveBuildings = gameState.buildings.filter(b =>
+    b.owner === 'enemy' &&
+    (b.type.includes('turret') || b.type === 'teslaCoil' || b.type === 'artilleryTurret') &&
     Math.hypot(
       (b.x + b.width / 2) - (baseBuilding.x + baseBuilding.width / 2),
       (b.y + b.height / 2) - (baseBuilding.y + baseBuilding.height / 2)


### PR DESCRIPTION
## Summary
- enable artillery turret construction by AI
- orient all AI defensive structures toward the player's base
- include artillery turret when evaluating defenses

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fc76c0e588328bc608cc2946a263c