### PR TITLE
Update crew indicator rendering

### DIFF
--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -316,23 +316,39 @@ export class UnitRenderer {
     }
   }
   renderCrewStatus(ctx, unit, scrollOffset) {
-    if (!unit.crew) return;
-    const size = 4;
-    const x = unit.x - scrollOffset.x;
-    const y = unit.y - scrollOffset.y;
-    const colors = { driver: "#00F", gunner: "#F00", loader: "#FF0", commander: "#0F0" };
-    ctx.save();
-    Object.entries(unit.crew).forEach(([role, alive], idx) => {
-      if (!alive) return;
-      let dx = 0, dy = 0;
-      if (role === "driver") { dx = 0; dy = 0; }
-      if (role === "gunner") { dx = TILE_SIZE - size; dy = 0; }
-      if (role === "loader") { dx = 0; dy = TILE_SIZE - size; }
-      if (role === "commander") { dx = TILE_SIZE - size; dy = TILE_SIZE - size; }
-      ctx.fillStyle = colors[role];
-      ctx.fillRect(x + dx, y + dy, size, size);
-    });
-    ctx.restore();
+    if (!unit.selected || !unit.crew) return
+
+    const size = 6
+    const baseX = unit.x - scrollOffset.x
+    const baseY = unit.y + TILE_SIZE - scrollOffset.y
+    const colors = { driver: '#00F', gunner: '#F00', loader: '#FF0', commander: '#0F0' }
+    const letters = { driver: 'D', gunner: 'G', loader: 'L', commander: 'C' }
+
+    ctx.save()
+    let idx = 0
+    Object.entries(unit.crew).forEach(([role, alive]) => {
+      if (!alive) return
+
+      const x = baseX + idx * (size + 2)
+      const y = baseY
+
+      ctx.fillStyle = colors[role]
+      ctx.beginPath()
+      ctx.moveTo(x, y)
+      ctx.lineTo(x + size / 2, y - size)
+      ctx.lineTo(x + size, y)
+      ctx.closePath()
+      ctx.fill()
+
+      ctx.fillStyle = '#FFF'
+      ctx.font = '6px Arial'
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText(letters[role], x + size / 2, y - size / 2)
+
+      idx++
+    })
+    ctx.restore()
   }
 
   renderAttackTargetIndicator(ctx, unit, centerX, centerY) {


### PR DESCRIPTION
## Summary
- show crew status only for selected units
- reposition crew cones to bottom left
- draw colored cones with role letters inside

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fc8e3d0008328b5a66475d886258f