### PR TITLE
Add LOC counting script

### DIFF
--- a/countLocs.js
+++ b/countLocs.js
@@ -1,0 +1,32 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+/* global process */
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+function getAllFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(dirent => {
+    const res = path.join(dir, dirent.name)
+    return dirent.isDirectory() ? getAllFiles(res) : res
+  })
+}
+
+function countLines(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8')
+  if (content === '') return 0
+  return content.split(/\r?\n/).length
+}
+
+const srcDir = path.join(__dirname, 'src')
+const files = getAllFiles(srcDir)
+
+const counts = files.map(file => ({ file, lines: countLines(file) }))
+const total = counts.reduce((sum, { lines }) => sum + lines, 0)
+
+console.log(`Total LOCs: ${total}`)
+counts.forEach(({ file, lines }) => {
+  console.log(`${path.relative(process.cwd(), file)}: ${lines}`)
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src/ *.js",
     "lint:fix": "eslint src/ *.js --fix",
     "map:analyse": "node map_analyse.js",
-    "make:sprites": "node makeSprites.js"
+    "make:sprites": "node makeSprites.js",
+    "count:locs": "node countLocs.js"
   },
   "devDependencies": {
     "eslint": "^9.27.0",


### PR DESCRIPTION
## Summary
- add `countLocs.js` Node script for counting lines of code
- expose script via `npm run count:locs`

## Testing
- `npx eslint countLocs.js`
- `npm run lint` *(fails: Trailing spaces, unused vars, etc.)*
- `npm run count:locs`

------
https://chatgpt.com/codex/tasks/task_e_687fd1fe54848328abe07b43caf2715b