### PR TITLE
Add gas station building and fuel mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,15 @@
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
               </button>
+              <button class="production-button" data-building-type="gasStation">
+                <img draggable="true" src="images/sidebar/gas_station.webp" onerror="this.style.display='none'">
+                <span class="building-name">Gas Station</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
+                <div class="production-progress"></div>
+                <div class="batch-counter" style="display:none">0</div>
+                <div class="new-label" style="display:none">NEW</div>
+              </button>
               <button class="production-button" data-building-type="turretGunV1">
                 <img draggable="true" src="images/sidebar/turret_gun_v1.webp" onerror="this.style.display='none'">
                 <span class="building-name">Turret Gun V1</span>

--- a/src/ai/enemyAIPlayer.js
+++ b/src/ai/enemyAIPlayer.js
@@ -140,6 +140,7 @@ const updateAIPlayer = logPerformance(function updateAIPlayer(aiPlayerId, units,
     const radarStations = aiBuildings.filter(b => b.type === 'radarStation')
     const teslaCoils = aiBuildings.filter(b => b.type === 'teslaCoil')
     const hospitals = aiBuildings.filter(b => b.type === 'hospital')
+    const gasStations = aiBuildings.filter(b => b.type === 'gasStation')
     const vehicleWorkshops = aiBuildings.filter(b => b.type === 'vehicleWorkshop')
     const aiHarvesters = units.filter(u => u.owner === aiPlayerId && u.type === 'harvester')
 
@@ -159,6 +160,9 @@ const updateAIPlayer = logPerformance(function updateAIPlayer(aiPlayerId, units,
     } else if (oreRefineries.length === 0 && aiFactory.budget >= buildingData.oreRefinery.cost) {
       buildingType = 'oreRefinery'
       cost = buildingData.oreRefinery.cost
+    } else if (oreRefineries.length > 0 && gasStations.length === 0 && aiFactory.budget >= buildingData.gasStation.cost) {
+      buildingType = 'gasStation'
+      cost = buildingData.gasStation.cost
 
     // Production - Vehicle Factory for unit production
     } else if (vehicleFactories.length === 0 && aiFactory.budget >= buildingData.vehicleFactory.cost) {

--- a/src/buildingImageMap.js
+++ b/src/buildingImageMap.js
@@ -12,6 +12,7 @@ export const buildingImageMap = {
   vehicleWorkshop: 'images/map/buildings/vehicle_workshop.webp',
   radarStation: 'images/map/buildings/radar_station.webp',
   hospital: 'images/map/buildings/hospital.webp',
+  gasStation: 'images/map/buildings/gas_station.webp',
   turretGunV1: 'images/map/buildings/turret01_base.webp', // Use base image as fallback when turret images are disabled
   turretGunV2: 'images/map/buildings/turret02_base.webp',
   turretGunV3: 'images/map/buildings/turret03_base.webp',

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -84,6 +84,16 @@ export const buildingData = {
     health: 200,
     smokeSpots: []
   },
+  gasStation: {
+    width: 3,
+    height: 3,
+    cost: 2000,
+    power: -30,
+    image: 'gas_station.webp',
+    displayName: 'Gas Station',
+    health: 50,
+    smokeSpots: []
+  },
   turretGunV1: {
     width: 1,
     height: 1,

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,8 @@ export const MAP_TILES_X = 100
 export const MAP_TILES_Y = 100
 export const MAP_WIDTH = MAP_TILES_X * TILE_SIZE
 export const MAP_HEIGHT = MAP_TILES_Y * TILE_SIZE
+// Approximate real world length of one tile in meters
+export const TILE_LENGTH_METERS = 1000
 export const SAFE_RANGE_ENABLED = false
 export const CREW_KILL_CHANCE = 0.25 // 25% chance to kill a crew member on hit
 
@@ -299,3 +301,16 @@ export const PLAYER_POSITIONS = {
 
 // Default number of players
 export const DEFAULT_PLAYER_COUNT = 2
+
+// Gas system configuration
+export const GAS_REFILL_TIME = 7000 // ms to fully refill at station
+export const GAS_REFILL_COST = 50
+
+export const UNIT_GAS_PROPERTIES = {
+  tank_v1: { tankSize: 1900, consumption: 450 },
+  'tank-v2': { tankSize: 1900, consumption: 450 },
+  'tank-v3': { tankSize: 1900, consumption: 450 },
+  rocketTank: { tankSize: 1900, consumption: 450 },
+  harvester: { tankSize: 2650, consumption: 30, harvestConsumption: 100 },
+  ambulance: { tankSize: 75, consumption: 25 }
+}

--- a/src/factories.js
+++ b/src/factories.js
@@ -27,7 +27,7 @@ export function initFactories(factories, mapGrid) {
     factory.constructionFinished = true
     factory.constructionStartTime = performance.now() - 5000
     factory.productionCountdown = 0
-    factory.budget = 10000
+    factory.budget = 12000
     // Keep legacy compatibility
     factory.isHuman = playerId === gameState.humanPlayer
 

--- a/src/game/gasStationLogic.js
+++ b/src/game/gasStationLogic.js
@@ -7,37 +7,40 @@ export const updateGasStationLogic = logPerformance(function(units, buildings, g
   if (stations.length === 0) return
 
   stations.forEach(station => {
-    const refillYStart = station.y + station.height
-    const refillYEnd = refillYStart + 2
+    const areaStartX = station.x - 1
+    const areaEndX = station.x + station.width
+    const areaStartY = station.y - 1
+    const areaEndY = station.y + station.height
+
     units.forEach(unit => {
       if (typeof unit.maxGas !== 'number' || unit.health <= 0) return
 
-      if (
-        unit.tileY >= refillYStart &&
-        unit.tileY <= refillYEnd &&
-        unit.tileX >= station.x &&
-        unit.tileX < station.x + station.width
-      ) {
+      const inArea =
+        unit.tileX >= areaStartX &&
+        unit.tileX <= areaEndX &&
+        unit.tileY >= areaStartY &&
+        unit.tileY <= areaEndY
+
+      if (inArea) {
         if (unit.gas < unit.maxGas) {
           if (!unit.refueling) {
             unit.refueling = true
-            if (unit.owner === gameState.humanPlayer) playSound('unitRefules')
+            // if (unit.owner === gameState.humanPlayer) playSound('unitRefules')
           }
+
+          const fillRate = unit.maxGas / GAS_REFILL_TIME
           unit.gasRefillTimer = (unit.gasRefillTimer || 0) + delta
-          if (unit.gasRefillTimer >= GAS_REFILL_TIME) {
-            unit.gas = unit.maxGas
-            unit.gasRefillTimer = 0
-            unit.outOfGasPlayed = false
-            if (unit.owner === gameState.humanPlayer) {
-              if (gameState.money >= GAS_REFILL_COST) gameState.money -= GAS_REFILL_COST
-            } else {
-              const aiFactory = gameState.factories?.find(f => f.id === unit.owner)
-              if (aiFactory) aiFactory.budget -= GAS_REFILL_COST
-            }
+          unit.gas = Math.min(unit.maxGas, unit.gas + fillRate * delta)
+          if (unit.owner === gameState.humanPlayer) {
+            if (gameState.money >= GAS_REFILL_COST) gameState.money -= GAS_REFILL_COST
+          } else {
+            const aiFactory = gameState.factories?.find(f => f.id === unit.owner)
+            if (aiFactory) aiFactory.budget -= GAS_REFILL_COST
           }
         } else {
           unit.gasRefillTimer = 0
           unit.refueling = false
+          unit.outOfGasPlayed = false
         }
       } else {
         unit.gasRefillTimer = 0

--- a/src/game/gasStationLogic.js
+++ b/src/game/gasStationLogic.js
@@ -1,21 +1,28 @@
 import { GAS_REFILL_TIME, GAS_REFILL_COST } from '../config.js'
 import { logPerformance } from '../performanceUtils.js'
+import { playSound } from '../sound.js'
 
 export const updateGasStationLogic = logPerformance(function(units, buildings, gameState, delta) {
   const stations = buildings.filter(b => b.type === 'gasStation')
   if (stations.length === 0) return
 
   stations.forEach(station => {
+    const refillYStart = station.y + station.height
+    const refillYEnd = refillYStart + 2
     units.forEach(unit => {
       if (typeof unit.maxGas !== 'number' || unit.health <= 0) return
 
-      const nearestX = Math.max(station.x, Math.min(unit.tileX, station.x + station.width - 1))
-      const nearestY = Math.max(station.y, Math.min(unit.tileY, station.y + station.height - 1))
-      const dx = Math.abs(unit.tileX - nearestX)
-      const dy = Math.abs(unit.tileY - nearestY)
-
-      if (dx <= 1 && dy <= 1) {
+      if (
+        unit.tileY >= refillYStart &&
+        unit.tileY <= refillYEnd &&
+        unit.tileX >= station.x &&
+        unit.tileX < station.x + station.width
+      ) {
         if (unit.gas < unit.maxGas) {
+          if (!unit.refueling) {
+            unit.refueling = true
+            if (unit.owner === gameState.humanPlayer) playSound('unitRefules')
+          }
           unit.gasRefillTimer = (unit.gasRefillTimer || 0) + delta
           if (unit.gasRefillTimer >= GAS_REFILL_TIME) {
             unit.gas = unit.maxGas
@@ -30,9 +37,11 @@ export const updateGasStationLogic = logPerformance(function(units, buildings, g
           }
         } else {
           unit.gasRefillTimer = 0
+          unit.refueling = false
         }
       } else {
         unit.gasRefillTimer = 0
+        unit.refueling = false
       }
     })
   })

--- a/src/game/gasStationLogic.js
+++ b/src/game/gasStationLogic.js
@@ -1,0 +1,34 @@
+import { TILE_SIZE, GAS_REFILL_TIME, GAS_REFILL_COST } from '../config.js'
+import { logPerformance } from '../performanceUtils.js'
+
+export const updateGasStationLogic = logPerformance(function(units, buildings, gameState, delta) {
+  const stations = buildings.filter(b => b.type === 'gasStation')
+  if (stations.length === 0) return
+
+  stations.forEach(station => {
+    const refillRow = station.y + station.height
+    units.forEach(unit => {
+      if (typeof unit.maxGas !== 'number' || unit.health <= 0) return
+
+      if (unit.tileY === refillRow && unit.tileX >= station.x && unit.tileX < station.x + station.width) {
+        if (unit.gas < unit.maxGas) {
+          unit.gasRefillTimer = (unit.gasRefillTimer || 0) + delta
+          if (unit.gasRefillTimer >= GAS_REFILL_TIME) {
+            unit.gas = unit.maxGas
+            unit.gasRefillTimer = 0
+            if (unit.owner === gameState.humanPlayer) {
+              if (gameState.money >= GAS_REFILL_COST) gameState.money -= GAS_REFILL_COST
+            } else {
+              const aiFactory = gameState.factories?.find(f => f.id === unit.owner)
+              if (aiFactory) aiFactory.budget -= GAS_REFILL_COST
+            }
+          }
+        } else {
+          unit.gasRefillTimer = 0
+        }
+      } else {
+        unit.gasRefillTimer = 0
+      }
+    })
+  })
+})

--- a/src/game/gasStationLogic.js
+++ b/src/game/gasStationLogic.js
@@ -1,4 +1,4 @@
-import { TILE_SIZE, GAS_REFILL_TIME, GAS_REFILL_COST } from '../config.js'
+import { GAS_REFILL_TIME, GAS_REFILL_COST } from '../config.js'
 import { logPerformance } from '../performanceUtils.js'
 
 export const updateGasStationLogic = logPerformance(function(units, buildings, gameState, delta) {
@@ -6,16 +6,21 @@ export const updateGasStationLogic = logPerformance(function(units, buildings, g
   if (stations.length === 0) return
 
   stations.forEach(station => {
-    const refillRow = station.y + station.height
     units.forEach(unit => {
       if (typeof unit.maxGas !== 'number' || unit.health <= 0) return
 
-      if (unit.tileY === refillRow && unit.tileX >= station.x && unit.tileX < station.x + station.width) {
+      const nearestX = Math.max(station.x, Math.min(unit.tileX, station.x + station.width - 1))
+      const nearestY = Math.max(station.y, Math.min(unit.tileY, station.y + station.height - 1))
+      const dx = Math.abs(unit.tileX - nearestX)
+      const dy = Math.abs(unit.tileY - nearestY)
+
+      if (dx <= 1 && dy <= 1) {
         if (unit.gas < unit.maxGas) {
           unit.gasRefillTimer = (unit.gasRefillTimer || 0) + delta
           if (unit.gasRefillTimer >= GAS_REFILL_TIME) {
             unit.gas = unit.maxGas
             unit.gasRefillTimer = 0
+            unit.outOfGasPlayed = false
             if (unit.owner === gameState.humanPlayer) {
               if (gameState.money >= GAS_REFILL_COST) gameState.money -= GAS_REFILL_COST
             } else {

--- a/src/game/harvesterLogic.js
+++ b/src/game/harvesterLogic.js
@@ -122,6 +122,9 @@ export const updateHarvesterLogic = logPerformance(function updateHarvesterLogic
       }
       if (now - unit.harvestTimer > 10000) {
         unit.oreCarried++
+        if (typeof unit.gas === 'number') {
+          unit.gas = Math.max(0, unit.gas - (unit.harvestGasConsumption || 0))
+        }
         unit.harvesting = false
         const tileKey = `${unit.oreField.x},${unit.oreField.y}`
         harvestedTiles.delete(tileKey) // Free up the tile

--- a/src/game/unifiedMovement.js
+++ b/src/game/unifiedMovement.js
@@ -1,5 +1,5 @@
 // unifiedMovement.js - Unified movement system for all ground units
-import { TILE_SIZE, STUCK_CHECK_INTERVAL, STUCK_THRESHOLD, STUCK_HANDLING_COOLDOWN, DODGE_ATTEMPT_COOLDOWN, STREET_SPEED_MULTIPLIER } from '../config.js'
+import { TILE_SIZE, STUCK_CHECK_INTERVAL, STUCK_THRESHOLD, STUCK_HANDLING_COOLDOWN, DODGE_ATTEMPT_COOLDOWN, STREET_SPEED_MULTIPLIER, TILE_LENGTH_METERS } from '../config.js'
 import { clearStuckHarvesterOreField, handleStuckHarvester } from './harvesterLogic.js'
 import { updateUnitOccupancy, findPath } from '../units.js'
 import { playPositionalSound } from '../sound.js'
@@ -306,8 +306,10 @@ export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [],
   unit.y += movement.velocity.y;
 
   if (typeof unit.gas === 'number') {
-    const dist = Math.hypot(unit.x - prevX, unit.y - prevY) / TILE_SIZE
-    unit.gas = Math.max(0, unit.gas - (unit.gasConsumption || 0) * dist / 100)
+    const distTiles = Math.hypot(unit.x - prevX, unit.y - prevY) / TILE_SIZE
+    const distMeters = distTiles * TILE_LENGTH_METERS
+    const usage = (unit.gasConsumption || 0) * distMeters / 100000
+    unit.gas = Math.max(0, unit.gas - usage)
   }
   
   // Handle collisions

--- a/src/game/unifiedMovement.js
+++ b/src/game/unifiedMovement.js
@@ -41,6 +41,16 @@ export function initializeUnitMovement(unit) {
  */
 export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [], gameState = null, factories = null) {
   initializeUnitMovement(unit);
+
+  if (typeof unit.gas === 'number' && unit.gas <= 0) {
+    unit.path = []
+    unit.moveTarget = null
+    unit.movement.velocity = { x: 0, y: 0 }
+    unit.movement.targetVelocity = { x: 0, y: 0 }
+    unit.movement.isMoving = false
+    unit.movement.currentSpeed = 0
+    return
+  }
   
   // **HARVESTER MOVEMENT RESTRICTIONS** - Prevent movement during critical operations
   if (unit.type === 'harvester') {
@@ -294,6 +304,11 @@ export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [],
   // Always apply velocity to position - tanks should move even when decelerating
   unit.x += movement.velocity.x;
   unit.y += movement.velocity.y;
+
+  if (typeof unit.gas === 'number') {
+    const dist = Math.hypot(unit.x - prevX, unit.y - prevY) / TILE_SIZE
+    unit.gas = Math.max(0, unit.gas - (unit.gasConsumption || 0) * dist / 100)
+  }
   
   // Handle collisions
   if (checkUnitCollision(unit, mapGrid, occupancyMap, units)) {

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -117,7 +117,7 @@ export const gameState = {
 
   // Initially no units are available (require vehicle factory), only basic buildings
   availableUnitTypes: new Set([]),
-  availableBuildingTypes: new Set(['constructionYard', 'oreRefinery', 'powerPlant', 'vehicleFactory', 'vehicleWorkshop', 'radarStation', 'hospital', 'turretGunV1', 'concreteWall']),
+  availableBuildingTypes: new Set(['constructionYard', 'oreRefinery', 'powerPlant', 'vehicleFactory', 'vehicleWorkshop', 'radarStation', 'hospital', 'gasStation', 'turretGunV1', 'concreteWall']),
   newUnitTypes: new Set(),
   newBuildingTypes: new Set(),
 

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -1,6 +1,6 @@
 // gameState.js
 export const gameState = {
-  money: 10000,
+  money: 12000,
   gameTime: 0,
   frameCount: 0, // Add frame counter for milestone checking
   wins: 0,

--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -14,6 +14,7 @@ export class CursorManager {
     this.isOverOreTile = false
     this.isOverPlayerRefinery = false
     this.isOverHealableUnit = false
+    this.isOverPlayerGasStation = false
     this.isForceAttackMode = false
     this.isGuardMode = false
     this.lastMouseEvent = null
@@ -94,6 +95,7 @@ export class CursorManager {
     this.isOverPlayerRefinery = false
     // Check if mouse is over a healable unit when ambulances are selected
     this.isOverHealableUnit = false
+    this.isOverPlayerGasStation = false
     // Check if mouse is over a hospital when ambulances are selected and not fully loaded
     this.isOverPlayerHospital = false
     if (this.isOverGameCanvas && gameState.buildings && Array.isArray(gameState.buildings) &&
@@ -127,6 +129,22 @@ export class CursorManager {
               tileX >= building.x && tileX < building.x + building.width &&
               tileY >= building.y && tileY < building.y + building.height) {
             this.isOverPlayerHospital = true
+            break
+          }
+        }
+      }
+
+      const hasUnitsNeedingGas = selectedUnits.some(
+        u => typeof u.maxGas === 'number' && u.gas < u.maxGas * 0.75
+      )
+      if (hasUnitsNeedingGas) {
+        for (const building of gameState.buildings) {
+          if (building.type === 'gasStation' &&
+              building.owner === gameState.humanPlayer &&
+              building.health > 0 &&
+              tileX >= building.x && tileX < building.x + building.width &&
+              tileY >= building.y && tileY < building.y + building.height) {
+            this.isOverPlayerGasStation = true
             break
           }
         }
@@ -389,6 +407,9 @@ export class CursorManager {
         gameCanvas.classList.add('move-into-mode')
       } else if (this.isOverPlayerHospital) {
         // Over hospital with not fully loaded ambulances selected - show move into cursor
+        gameCanvas.style.cursor = 'none'
+        gameCanvas.classList.add('move-into-mode')
+      } else if (this.isOverPlayerGasStation) {
         gameCanvas.style.cursor = 'none'
         gameCanvas.classList.add('move-into-mode')
       } else if (this.isOverPlayerRefinery) {

--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -724,7 +724,7 @@ export class MouseHandler {
       if (hasSelectedNotFullyLoadedAmbulances) {
         // Check if clicking on a player hospital
         for (const building of gameState.buildings) {
-          if (building.type === 'hospital' && 
+          if (building.type === 'hospital' &&
               building.owner === gameState.humanPlayer &&
               building.health > 0 &&
               tileX >= building.x && tileX < building.x + building.width &&
@@ -732,6 +732,22 @@ export class MouseHandler {
             // Handle ambulance refill command
             unitCommands.handleAmbulanceRefillCommand(selectedUnits, building, mapGrid)
             return // Exit early, don't process building selection
+          }
+        }
+      }
+
+      const needsGas = selectedUnits.some(
+        u => typeof u.maxGas === 'number' && u.gas < u.maxGas * 0.75
+      )
+      if (needsGas) {
+        for (const building of gameState.buildings) {
+          if (building.type === 'gasStation' &&
+              building.owner === gameState.humanPlayer &&
+              building.health > 0 &&
+              tileX >= building.x && tileX < building.x + building.width &&
+              tileY >= building.y && tileY < building.y + building.height) {
+            unitCommands.handleGasStationRefillCommand(selectedUnits, building, mapGrid)
+            return
           }
         }
       }
@@ -839,6 +855,7 @@ export class MouseHandler {
 
       let workshopTarget = null
       let hospitalTarget = null
+      let gasStationTarget = null
       if (gameState.buildings && Array.isArray(gameState.buildings)) {
         for (const building of gameState.buildings) {
           if (building.type === 'vehicleWorkshop' && building.owner === gameState.humanPlayer && building.health > 0 &&
@@ -861,6 +878,18 @@ export class MouseHandler {
             }
           }
         }
+
+        const needsGas = selectedUnits.some(u => typeof u.maxGas === 'number' && u.gas < u.maxGas * 0.75)
+        if (needsGas) {
+          for (const building of gameState.buildings) {
+            if (building.type === 'gasStation' && building.owner === gameState.humanPlayer && building.health > 0 &&
+                tileX >= building.x && tileX < building.x + building.width &&
+                tileY >= building.y && tileY < building.y + building.height) {
+              gasStationTarget = building
+              break
+            }
+          }
+        }
       }
 
       if (refineryTarget) {
@@ -869,6 +898,8 @@ export class MouseHandler {
         unitCommands.handleRepairWorkshopCommand(selectedUnits, workshopTarget, mapGrid)
       } else if (hospitalTarget) {
         unitCommands.handleAmbulanceRefillCommand(selectedUnits, hospitalTarget, mapGrid)
+      } else if (gasStationTarget) {
+        unitCommands.handleGasStationRefillCommand(selectedUnits, gasStationTarget, mapGrid)
       } else if (oreTarget) {
         unitCommands.handleHarvesterCommand(selectedUnits, oreTarget, mapGrid)
       } else {

--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -137,6 +137,29 @@ export class MouseHandler {
     gameState.attackGroupStart = { x: 0, y: 0 }
     gameState.attackGroupEnd = { x: 0, y: 0 }
     gameState.disableAGFRendering = false
+
+    // If cursor is over a player gas station for refueling, disable selection/AGF
+    const tileX = Math.floor(worldX / TILE_SIZE)
+    const tileY = Math.floor(worldY / TILE_SIZE)
+    const needsGas = selectedUnits.some(
+      u => typeof u.maxGas === 'number' && u.gas < u.maxGas * 0.75
+    )
+    if (needsGas && gameState.buildings && Array.isArray(gameState.buildings)) {
+      for (const building of gameState.buildings) {
+        if (
+          building.type === 'gasStation' &&
+          building.owner === gameState.humanPlayer &&
+          building.health > 0 &&
+          tileX >= building.x && tileX < building.x + building.width &&
+          tileY >= building.y && tileY < building.y + building.height
+        ) {
+          this.isSelecting = false
+          gameState.selectionActive = false
+          gameState.disableAGFRendering = true
+          break
+        }
+      }
+    }
   }
 
 

--- a/src/input/unitCommands.js
+++ b/src/input/unitCommands.js
@@ -470,7 +470,12 @@ export class UnitCommandsHandler {
       let destinationFound = false
       for (const pos of refillPositions) {
         if (pos.x >= 0 && pos.y >= 0 && pos.x < mapGrid[0].length && pos.y < mapGrid.length) {
-          const path = this.findPath(ambulance, pos.x, pos.y, mapGrid)
+      const path = findPath(
+        { x: ambulance.tileX, y: ambulance.tileY },
+        { x: pos.x, y: pos.y },
+        mapGrid,
+        gameState.occupancyMap
+      )
           if (path && path.length > 0) {
             ambulance.path = path
             ambulance.moveTarget = { x: pos.x * TILE_SIZE, y: pos.y * TILE_SIZE }
@@ -501,15 +506,10 @@ export class UnitCommandsHandler {
     }
 
     const positions = []
-    for (let x = station.x - 1; x <= station.x + station.width; x++) {
-      for (let y = station.y - 1; y <= station.y + station.height; y++) {
-        if (
-          x >= 0 &&
-          y >= 0 &&
-          x < mapGrid[0].length &&
-          y < mapGrid.length &&
-          !(x >= station.x && x < station.x + station.width && y >= station.y && y < station.y + station.height)
-        ) {
+    const startY = station.y + station.height
+    for (let x = station.x; x < station.x + station.width; x++) {
+      for (let y = startY; y <= startY + 2; y++) {
+        if (x >= 0 && y >= 0 && x < mapGrid[0].length && y < mapGrid.length) {
           positions.push({ x, y })
         }
       }
@@ -517,7 +517,12 @@ export class UnitCommandsHandler {
 
     unitsNeedingGas.forEach((unit, index) => {
       const pos = positions[index % positions.length]
-      const path = this.findPath(unit, pos.x, pos.y, mapGrid)
+      const path = findPath(
+        { x: unit.tileX, y: unit.tileY },
+        { x: pos.x, y: pos.y },
+        mapGrid,
+        gameState.occupancyMap
+      )
       if (path && path.length > 0) {
         unit.path = path
         unit.moveTarget = { x: pos.x * TILE_SIZE, y: pos.y * TILE_SIZE }

--- a/src/input/unitCommands.js
+++ b/src/input/unitCommands.js
@@ -506,9 +506,11 @@ export class UnitCommandsHandler {
     }
 
     const positions = []
-    const startY = station.y + station.height
-    for (let x = station.x; x < station.x + station.width; x++) {
-      for (let y = startY; y <= startY + 2; y++) {
+    for (let x = station.x - 1; x <= station.x + station.width; x++) {
+      for (let y = station.y - 1; y <= station.y + station.height; y++) {
+        const insideX = x >= station.x && x < station.x + station.width
+        const insideY = y >= station.y && y < station.y + station.height
+        if (insideX && insideY) continue
         if (x >= 0 && y >= 0 && x < mapGrid[0].length && y < mapGrid.length) {
           positions.push({ x, y })
         }

--- a/src/main.js
+++ b/src/main.js
@@ -391,7 +391,7 @@ class Game {
     const preservedLosses = gameState.losses
     
     // Reset game state
-    gameState.money = 10000
+    gameState.money = 12000
     gameState.gameTime = 0
     gameState.frameCount = 0
     gameState.gameStarted = true  // Auto-start the game

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -295,6 +295,32 @@ export class UnitRenderer {
     }
   }
 
+  renderGasBar(ctx, unit, scrollOffset) {
+    if (typeof unit.maxGas !== 'number') return
+
+    const ratio = unit.gas / unit.maxGas
+    const healthBarWidth = TILE_SIZE * 0.8
+    const healthBarHeight = 4
+    const healthBarX = unit.x + TILE_SIZE / 2 - scrollOffset.x - healthBarWidth / 2
+    const healthBarY = unit.y - 10 - scrollOffset.y
+
+    const barHeight = healthBarWidth * 0.9
+    const barWidth = 3
+    const bottom = healthBarY + healthBarHeight
+    const barX = healthBarX + healthBarWidth + 2
+    const barTop = bottom - barHeight
+
+    ctx.fillStyle = '#333'
+    ctx.fillRect(barX, barTop, barWidth, barHeight)
+
+    const fillHeight = barHeight * ratio
+    ctx.fillStyle = '#4A90E2'
+    ctx.fillRect(barX, bottom - fillHeight, barWidth, fillHeight)
+
+    ctx.strokeStyle = '#000'
+    ctx.strokeRect(barX, barTop, barWidth, barHeight)
+  }
+
   renderQueueNumber(ctx, unit, scrollOffset) {
     // Queue numbers are now handled by the HarvesterHUD overlay
     // This function is kept for compatibility but no longer renders anything
@@ -503,6 +529,7 @@ export class UnitRenderer {
     const centerY = unit.y + TILE_SIZE / 2 - scrollOffset.y
 
     this.renderHealthBar(ctx, unit, scrollOffset)
+    this.renderGasBar(ctx, unit, scrollOffset)
     this.renderLevelStars(ctx, unit, scrollOffset)
     this.renderHarvesterProgress(ctx, unit, scrollOffset)
     this.renderQueueNumber(ctx, unit, scrollOffset)

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -296,26 +296,31 @@ export class UnitRenderer {
   }
 
   renderGasBar(ctx, unit, scrollOffset) {
-    if (typeof unit.maxGas !== 'number') return
+    if (!unit.selected || typeof unit.maxGas !== 'number') return
 
     const ratio = unit.gas / unit.maxGas
-    const healthBarWidth = TILE_SIZE * 0.8
-    const healthBarHeight = 4
-    const healthBarX = unit.x + TILE_SIZE / 2 - scrollOffset.x - healthBarWidth / 2
-    const healthBarY = unit.y - 10 - scrollOffset.y
 
-    const barHeight = healthBarWidth * 0.9
+    const centerX = unit.x + TILE_SIZE / 2 - scrollOffset.x
+    const centerY = unit.y + TILE_SIZE / 2 - scrollOffset.y
+    const halfTile = TILE_SIZE / 2
+    const cornerSize = 8
+    const offset = 2
+
+    const right = centerX + halfTile + offset
+    const top = centerY - halfTile - offset
+    const bottom = centerY + halfTile + offset
+
     const barWidth = 3
-    const bottom = healthBarY + healthBarHeight
-    const barX = healthBarX + healthBarWidth + 2
-    const barTop = bottom - barHeight
+    const barHeight = bottom - top - cornerSize * 2
+    const barX = right - barWidth - 1
+    const barTop = top + cornerSize
 
     ctx.fillStyle = '#333'
     ctx.fillRect(barX, barTop, barWidth, barHeight)
 
     const fillHeight = barHeight * ratio
     ctx.fillStyle = '#4A90E2'
-    ctx.fillRect(barX, bottom - fillHeight, barWidth, fillHeight)
+    ctx.fillRect(barX, barTop + barHeight - fillHeight, barWidth, fillHeight)
 
     ctx.strokeStyle = '#000'
     ctx.strokeRect(barX, barTop, barWidth, barHeight)

--- a/src/saveGame.js
+++ b/src/saveGame.js
@@ -58,6 +58,11 @@ export function saveGame(label) {
     health: u.health,
     maxHealth: u.maxHealth,
     id: u.id,
+    gas: u.gas,
+    maxGas: u.maxGas,
+    gasRefillTimer: u.gasRefillTimer,
+    refueling: u.refueling,
+    outOfGasPlayed: u.outOfGasPlayed,
     // Harvester-specific properties
     oreCarried: u.oreCarried,
     assignedRefinery: u.assignedRefinery,
@@ -253,6 +258,11 @@ export function loadGame(key) {
       hydrated.tileY = tileY
       hydrated.x = u.x
       hydrated.y = u.y
+      hydrated.gas = u.gas
+      hydrated.maxGas = u.maxGas
+      hydrated.gasRefillTimer = u.gasRefillTimer
+      hydrated.refueling = u.refueling
+      hydrated.outOfGasPlayed = u.outOfGasPlayed
       // Ensure path is always an array
       if (!Array.isArray(hydrated.path)) hydrated.path = []
       

--- a/src/sound.js
+++ b/src/sound.js
@@ -90,6 +90,7 @@ const soundFiles = {
   ourCommanderIsOut: ['ourCommanderIsOut.mp3'],
   ourGunnerIsOut: ['ourGunnerIsOut.mp3'],
   outOfGas: ['IAmOutOfGas.mp3'],
+  unitRefules: ['unitRefules.mp3'],
 
   // New waypoint and attack notification sounds
   movingAlongThePath: ['movingAlongThePath.mp3'],

--- a/src/sound.js
+++ b/src/sound.js
@@ -89,6 +89,7 @@ const soundFiles = {
   ourDriverIsOut: ['ourDriverIsOut.mp3'],
   ourCommanderIsOut: ['ourCommanderIsOut.mp3'],
   ourGunnerIsOut: ['ourGunnerIsOut.mp3'],
+  outOfGas: ['IAmOutOfGas.mp3'],
 
   // New waypoint and attack notification sounds
   movingAlongThePath: ['movingAlongThePath.mp3'],

--- a/src/units.js
+++ b/src/units.js
@@ -6,7 +6,8 @@ import {
   PATHFINDING_LIMIT,
   DIRECTIONS,
   MAX_SPAWN_SEARCH_DISTANCE,
-  STREET_PATH_COST
+  STREET_PATH_COST,
+  UNIT_GAS_PROPERTIES
 } from './config.js'
 import { logPerformance } from './performanceUtils.js'
 import { getUniqueId, updateUnitSpeedModifier } from './utils.js'
@@ -656,6 +657,15 @@ export function createUnit(factory, unitType, x, y) {
     // Command queue for path planning feature
     commandQueue: [],
     currentCommand: null
+  }
+
+  // Gas system
+  const gasProps = UNIT_GAS_PROPERTIES[actualType]
+  if (gasProps) {
+    unit.maxGas = gasProps.tankSize
+    unit.gas = gasProps.tankSize
+    unit.gasConsumption = gasProps.consumption
+    unit.harvestGasConsumption = gasProps.harvestConsumption || 0
   }
 
   // Add unit-specific properties

--- a/src/units.js
+++ b/src/units.js
@@ -666,6 +666,7 @@ export function createUnit(factory, unitType, x, y) {
     unit.gas = gasProps.tankSize
     unit.gasConsumption = gasProps.consumption
     unit.harvestGasConsumption = gasProps.harvestConsumption || 0
+    unit.outOfGasPlayed = false
   }
 
   // Add unit-specific properties

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -23,6 +23,7 @@ import { updateWorkshopLogic } from './game/workshopLogic.js'
 import { updateBullets } from './game/bulletSystem.js'
 import { updateHospitalLogic } from './game/hospitalLogic.js'
 import { updateAmbulanceLogic } from './game/ambulanceSystem.js'
+import { updateGasStationLogic } from './game/gasStationLogic.js'
 import { updateBuildings, updateTeslaCoilEffects } from './game/buildingSystem.js'
 import { cleanupSoundCooldowns } from './game/soundCooldownManager.js'
 import { processCommandQueues } from './game/commandQueue.js'
@@ -80,6 +81,7 @@ export const updateGame = logPerformance(function updateGame(delta, mapGrid, fac
 
     updateHospitalLogic(units, gameState.buildings, gameState, delta)
     updateAmbulanceLogic(units, gameState, delta)
+    updateGasStationLogic(units, gameState.buildings, gameState, delta)
     // Handle self-repair for level 3 units
     units.forEach(unit => {
       handleSelfRepair(unit, now)


### PR DESCRIPTION
## Summary
- add gas station building definitions and images
- display new gas station button in sidebar
- add fuel system and gas bar for units
- implement gas station refueling logic
- update enemy AI to build gas stations

## Testing
- `npm run lint` *(fails: trailing spaces and other issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68801355a84c832889c60a55848d890a