### PR TITLE
Restore stack counter visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,14 +109,14 @@
                 <span class="unit-name">Harvester</span>
                 <span class="unit-cost"></span>
                 <div class="production-progress"></div>
+                <div class="batch-counter" style="display:none">0</div>
+                <div class="new-label" style="display:none">NEW</div>
+              </button>
               <button class="production-button" data-unit-type="ambulance">
                 <img src="images/sidebar/ambulance.webp" onerror="this.style.display='none'">
                 <span class="unit-name">Ambulance</span>
                 <span class="unit-cost"></span>
                 <div class="production-progress"></div>
-                <div class="batch-counter" style="display:none">0</div>
-                <div class="new-label" style="display:none">NEW</div>
-              </button>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
               </button>

--- a/style.css
+++ b/style.css
@@ -306,7 +306,7 @@ html, body {
   border-radius: 50%;
   font-size: 10px;
   font-weight: bold;
-  z-index: 3; /* Ensure counter appears above everything */
+  z-index: 5; /* Ensure counter appears above NEW label */
 }
 
 /* Ready building counter for production buttons */
@@ -488,7 +488,7 @@ html, body {
   align-items: center;
   font-size: 12px;
   font-weight: bold;
-  z-index: 2;
+  z-index: 5;
 }
 
 /* Ready building counter for production buttons */


### PR DESCRIPTION
## Summary
- keep stack counters above NEW labels
- fix incorrect markup for the Harvester production button

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68801d793af08328869e61536b4c5c0a