### PR TITLE
Add workshop repair hotkey and waypoint support

### DIFF
--- a/src/game/commandQueue.js
+++ b/src/game/commandQueue.js
@@ -34,6 +34,9 @@ function executeAction(unit, action, mapGrid, unitCommands) {
     case 'retreat':
       initiateRetreat([unit], action.x, action.y, mapGrid);
       break;
+    case 'workshopRepair':
+      unitCommands.handleWorkshopRepairHotkey([unit], mapGrid, false, true);
+      break;
   }
 }
 
@@ -46,6 +49,8 @@ function isActionComplete(unit, action) {
       return (!unit.target || unit.target.health <= 0) && (!unit.attackQueue || unit.attackQueue.length === 0);
     case 'retreat':
       return !unit.isRetreating;
+    case 'workshopRepair':
+      return !unit.targetWorkshop && !unit.repairingAtWorkshop && !unit.returningFromWorkshop && (!unit.moveTarget && (!unit.path || unit.path.length === 0));
   }
   return true;
 }

--- a/src/game/unifiedMovement.js
+++ b/src/game/unifiedMovement.js
@@ -322,9 +322,14 @@ export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [],
   if ((prevTileX !== currentTileX || prevTileY !== currentTileY) && occupancyMap) {
     updateUnitOccupancy(unit, prevTileX, prevTileY, occupancyMap);
   }
-  
+
   // Handle stuck unit detection and recovery for all units (as requested)
   handleStuckUnit(unit, mapGrid, occupancyMap, units, gameState, factories);
+
+  if (unit.returningFromWorkshop && (!unit.path || unit.path.length === 0) && !unit.moveTarget) {
+    unit.returningFromWorkshop = false
+    unit.returnTile = null
+  }
 }
 
 /**

--- a/src/game/workshopLogic.js
+++ b/src/game/workshopLogic.js
@@ -161,7 +161,17 @@ export const updateWorkshopLogic = logPerformance(function updateWorkshopLogic(u
           delete unit.workshopStartHealth
           delete unit.targetWorkshop // Clear workshop assignment
           
-          if (workshop.rallyPoint) {
+          if (unit.returnTile) {
+            const path = findPath({ x: unit.tileX, y: unit.tileY }, unit.returnTile, mapGrid, gameState.occupancyMap)
+            if (path && path.length > 1) {
+              unit.path = path.slice(1)
+              unit.moveTarget = { x: unit.returnTile.x, y: unit.returnTile.y }
+              unit.returningFromWorkshop = true
+            } else {
+              unit.returningFromWorkshop = false
+              unit.returnTile = null
+            }
+          } else if (workshop.rallyPoint) {
             const path = findPath({ x: unit.tileX, y: unit.tileY }, workshop.rallyPoint, mapGrid, gameState.occupancyMap)
             if (path && path.length > 1) {
               unit.path = path.slice(1)

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -21,10 +21,15 @@ export class KeyboardHandler {
     this.helpSystem = new HelpSystem()
     this.playerFactory = null
     this.cheatSystem = new CheatSystem()
+    this.unitCommands = null
   }
 
   setPlayerFactory(factory) {
     this.playerFactory = factory
+  }
+
+  setUnitCommands(unitCommands) {
+    this.unitCommands = unitCommands
   }
 
   setupKeyboardEvents(units, selectedUnits, mapGrid, factories) {
@@ -93,6 +98,15 @@ export class KeyboardHandler {
       else if (e.key.toLowerCase() === 'r') {
         e.preventDefault()
         this.handleRepairMode()
+      }
+      // W key to send damaged units to workshop
+      else if (e.key.toLowerCase() === 'w') {
+        e.preventDefault()
+        const queue = e.altKey
+        if (this.unitCommands) {
+          this.unitCommands.handleWorkshopRepairHotkey(selectedUnits, mapGrid, queue, false)
+        }
+        if (queue) markWaypointsAdded()
       }
       // X key for dodge
       else if (e.key.toLowerCase() === 'x') {

--- a/src/inputHandler.js
+++ b/src/inputHandler.js
@@ -18,6 +18,7 @@ const mouseHandler = new MouseHandler()
 const keyboardHandler = new KeyboardHandler()
 const selectionManager = new SelectionManager()
 const unitCommands = new UnitCommandsHandler()
+keyboardHandler.setUnitCommands(unitCommands)
 
 export function setupInputHandlers(units, factories, mapGrid) {
   // Store human player factory reference for later use

--- a/src/rendering/pathPlanningRenderer.js
+++ b/src/rendering/pathPlanningRenderer.js
@@ -1,4 +1,5 @@
 import { TILE_SIZE, MOVE_TARGET_INDICATOR_SIZE } from "../config.js"
+import { gameState } from "../gameState.js"
 
 export class PathPlanningRenderer {
   render(ctx, units, scrollOffset) {
@@ -51,6 +52,22 @@ export class PathPlanningRenderer {
               targetX = (t.x + t.width / 2) * TILE_SIZE
               targetY = (t.y + t.height / 2) * TILE_SIZE
             }
+            break
+          }
+          case 'workshopRepair': {
+            const workshops = gameState.buildings.filter(b =>
+              b.type === 'vehicleWorkshop' && b.owner === gameState.humanPlayer && b.health > 0
+            )
+            if (workshops.length === 0) return
+            let nearest = null
+            let nearestDist = Infinity
+            workshops.forEach(ws => {
+              const dist = Math.hypot(unit.tileX - ws.x, unit.tileY - ws.y)
+              if (dist < nearestDist) { nearest = ws; nearestDist = dist }
+            })
+            if (!nearest) return
+            targetX = (nearest.x + nearest.width / 2) * TILE_SIZE
+            targetY = (nearest.y + nearest.height) * TILE_SIZE
             break
           }
           default:


### PR DESCRIPTION
## Summary
- implement `workshopRepair` command queue action
- enable W key to send damaged units to the nearest workshop
- return units to original location after repairs complete
- render workshop repair steps in path planning view
- wire up keyboard handler with unit command handler

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880231e45d08328a81e2b5eddfbf96a