### PR TITLE
Disable PPF retreat waypoints

### DIFF
--- a/src/game/commandQueue.js
+++ b/src/game/commandQueue.js
@@ -1,5 +1,3 @@
-import { initiateRetreat } from '../behaviours/retreat.js'
-
 export function processCommandQueues(units, mapGrid, unitCommands) {
   units.forEach(unit => {
     if (!unit.commandQueue || unit.commandQueue.length === 0) return;
@@ -31,9 +29,6 @@ function executeAction(unit, action, mapGrid, unitCommands) {
         unitCommands.handleAttackCommand([unit], unit.attackQueue[0], mapGrid, false, true);
       }
       break;
-    case 'retreat':
-      initiateRetreat([unit], action.x, action.y, mapGrid);
-      break;
     case 'workshopRepair':
       unitCommands.handleWorkshopRepairHotkey([unit], mapGrid, false, true);
       break;
@@ -47,8 +42,6 @@ function isActionComplete(unit, action) {
     case 'attack':
     case 'agf':
       return (!unit.target || unit.target.health <= 0) && (!unit.attackQueue || unit.attackQueue.length === 0);
-    case 'retreat':
-      return !unit.isRetreating;
     case 'workshopRepair':
       return !unit.targetWorkshop && !unit.repairingAtWorkshop && !unit.returningFromWorkshop && (!unit.moveTarget && (!unit.path || unit.path.length === 0));
   }

--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -6,6 +6,7 @@ import { playSound, playPositionalSound } from '../sound.js'
 import { showNotification } from '../ui/notifications.js'
 import { isForceAttackModifierActive, isGuardModifierActive } from '../utils/inputUtils.js'
 import { markWaypointsAdded } from '../game/waypointSounds.js'
+import { initiateRetreat } from '../behaviours/retreat.js'
 import { AttackGroupHandler } from './attackGroupHandler.js'
 
 export class MouseHandler {
@@ -779,12 +780,8 @@ export class MouseHandler {
       // No unit clicked - handle as movement command if units are selected and not in special modes
         if (selectedUnits.length > 0 && !gameState.buildingPlacementMode && !gameState.repairMode && !gameState.sellMode) {
           if (e.shiftKey) {
-            // Queue retreat action instead of immediate execute
-            selectedUnits.forEach(unit => {
-              if (!unit.commandQueue) unit.commandQueue = []
-              unit.commandQueue.push({ type: 'retreat', x: worldX, y: worldY })
-            })
-            markWaypointsAdded() // Mark that waypoints were added during Shift press
+            // Initiate immediate retreat without using path planning
+            initiateRetreat(selectedUnits, worldX, worldY, mapGrid)
           } else if (e.altKey) {
             // Queue planned action using Alt/Option
             this.handleStandardCommands(worldX, worldY, selectedUnits, unitCommands, mapGrid, true)


### PR DESCRIPTION
## Summary
- prevent path planning from queuing retreat commands
- start retreat immediately on Shift-click instead of using command queues

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880314ae52c8328b9b300b9bf9ff740