### PR TITLE
Maintain selection when setting rally point

### DIFF
--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -476,10 +476,9 @@ export class MouseHandler {
       }
       playPositionalSound('movement', worldX, worldY, 0.5)
 
-      selectedBuilding.selected = false
-      const buildingIndex = selectedUnits.indexOf(selectedBuilding)
-      if (buildingIndex > -1) {
-        selectedUnits.splice(buildingIndex, 1)
+      // Keep the building selected so the rally point flag remains visible
+      if (selectedUnits.indexOf(selectedBuilding) === -1) {
+        selectedUnits.push(selectedBuilding)
       }
       this.updateAGFCapability(selectedUnits)
 


### PR DESCRIPTION
## Summary
- keep vehicle factories and workshops selected when setting rally points so the flag remains visible

## Testing
- `npm run lint` *(fails: 2986 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880d8bfe7fc8328aa74f1f5d6c132bd