### PR TITLE
Enable optional enemy unit selection

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,8 @@ export const MAP_HEIGHT = MAP_TILES_Y * TILE_SIZE
 export const TILE_LENGTH_METERS = 1000
 export const SAFE_RANGE_ENABLED = false
 export const CREW_KILL_CHANCE = 0.25 // 25% chance to kill a crew member on hit
+// Allow selecting enemy units to view their HUD
+export const ALLOW_ENEMY_UNIT_SELECTION = false
 
 // Sound configuration
 export const MASTER_VOLUME = 0.25  // Default to 50% volume

--- a/src/input/selectionManager.js
+++ b/src/input/selectionManager.js
@@ -1,5 +1,5 @@
 // selectionManager.js
-import { TILE_SIZE } from '../config.js'
+import { TILE_SIZE, ALLOW_ENEMY_UNIT_SELECTION } from '../config.js'
 import { gameState } from '../gameState.js'
 import { playSound } from '../sound.js'
 import { showNotification } from '../ui/notifications.js'
@@ -25,6 +25,9 @@ export class SelectionManager {
 
   // Helper function to check if a unit belongs to the human player
   isHumanPlayerUnit(unit) {
+    if (ALLOW_ENEMY_UNIT_SELECTION) {
+      return true
+    }
     const humanPlayer = this.getHumanPlayer()
     return unit.owner === humanPlayer || (humanPlayer === 'player1' && unit.owner === 'player')
   }


### PR DESCRIPTION
## Summary
- add `ALLOW_ENEMY_UNIT_SELECTION` option to `config.js`
- let `SelectionManager` honor this option so enemy units can be selected for HUD inspection

## Testing
- `npm run lint` *(fails: trailing spaces, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68810c86a2f48328bca25a9b1f1ab6cf