### PR TITLE
Add danger zone map overlay

### DIFF
--- a/src/ai/enemyAIPlayer.js
+++ b/src/ai/enemyAIPlayer.js
@@ -4,6 +4,7 @@ import { resetAttackDirections, manageAICrewHealing } from './enemyStrategies.js
 import { getUnitCost } from '../utils.js'
 import { updateAIUnit } from './enemyUnitBehavior.js'
 import { findBuildingPosition } from './enemyBuilding.js'
+import { updateDangerZoneMaps } from '../game/dangerZoneMap.js'
 import { logPerformance } from '../performanceUtils.js'
 
 function findSimpleBuildingPosition(buildingType, mapGrid, factories, aiPlayerId) {
@@ -320,6 +321,7 @@ const updateAIPlayer = logPerformance(function updateAIPlayer(aiPlayerId, units,
         const newBuilding = createBuilding(buildingType, position.x, position.y)
         newBuilding.owner = aiPlayerId
         gameState.buildings.push(newBuilding)
+        updateDangerZoneMaps(gameState)
         placeBuilding(newBuilding, mapGrid)
 
         if (DEBUG_AI_BUILDING) {
@@ -344,6 +346,7 @@ const updateAIPlayer = logPerformance(function updateAIPlayer(aiPlayerId, units,
           const newBuilding = createBuilding(buildingType, alternativePosition.x, alternativePosition.y)
           newBuilding.owner = aiPlayerId
           gameState.buildings.push(newBuilding)
+          updateDangerZoneMaps(gameState)
           placeBuilding(newBuilding, mapGrid)
           
           if (DEBUG_AI_BUILDING) {

--- a/src/ai/enemyBuilding.js
+++ b/src/ai/enemyBuilding.js
@@ -1,6 +1,7 @@
 import { buildingData, createBuilding, canPlaceBuilding, placeBuilding, isNearExistingBuilding, isTileValid, updatePowerSupply } from '../buildings.js'
 import { gameState } from '../gameState.js'
 import { isPartOfFactory } from './enemyUtils.js'
+import { updateDangerZoneMaps } from '../game/dangerZoneMap.js'
 
 // Let's improve this function to fix issues with enemy building placement
 // Modified to improve building placement with better spacing and factory avoidance
@@ -685,6 +686,7 @@ function completeEnemyBuilding(gameState, mapGrid) {
 
     // Add to game state
     gameState.buildings.push(newBuilding)
+    updateDangerZoneMaps(gameState)
 
     // Update map grid
     placeBuilding(newBuilding, mapGrid)

--- a/src/buildingRepairHandler.js
+++ b/src/buildingRepairHandler.js
@@ -3,6 +3,7 @@ import { canPlaceBuilding, createBuilding, placeBuilding, updatePowerSupply, cal
 import { playSound } from './sound.js'
 import { showNotification } from './ui/notifications.js'
 import { buildingData } from './buildings.js'
+import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 import { savePlayerBuildPatterns } from './savePlayerBuildPatterns.js'
 
 export function buildingRepairHandler(e, gameState, gameCanvas, mapGrid, units, factories, productionQueue, moneyEl) {
@@ -141,6 +142,7 @@ export function buildingRepairHandler(e, gameState, gameCanvas, mapGrid, units, 
           gameState.buildings = []
         }
         gameState.buildings.push(newBuilding)
+        updateDangerZoneMaps(gameState)
 
         // Mark building tiles in the map grid
         placeBuilding(newBuilding, mapGrid)

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -4,6 +4,7 @@ import { showNotification } from './ui/notifications.js'
 import { gameState } from './gameState.js'
 import { logPerformance } from './performanceUtils.js'
 import { PLAYER_POSITIONS, MAP_TILES_X, MAP_TILES_Y } from './config.js'
+import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 
 // Building dimensions and costs
 export const buildingData = {
@@ -644,6 +645,9 @@ export function clearBuildingFromMapGrid(building, mapGrid, occupancyMap = gameS
 
 // Update the game's power supply
 export function updatePowerSupply(buildings, gameState) {
+  const prevPlayerPower = gameState.playerPowerSupply || 0
+  const prevEnemyPower = gameState.enemyPowerSupply || 0
+
   // Player power calculation
   let playerTotalPower = 0
   let playerTotalProduction = 0
@@ -712,6 +716,13 @@ export function updatePowerSupply(buildings, gameState) {
   gameState.enemyPowerSupply = enemyTotalPower
   gameState.enemyTotalPowerProduction = enemyTotalProduction
   gameState.enemyPowerConsumption = enemyTotalConsumption
+
+  const playerCross = (prevPlayerPower >= 0 && playerTotalPower < 0) || (prevPlayerPower < 0 && playerTotalPower >= 0)
+  const enemyCross = (prevEnemyPower >= 0 && enemyTotalPower < 0) || (prevEnemyPower < 0 && enemyTotalPower >= 0)
+  
+  if (playerCross || enemyCross) {
+    updateDangerZoneMaps(gameState)
+  }
 
   // Calculate energy percentage for UI display
   // Calculate energy percentage for informational purposes

--- a/src/game/buildingSystem.js
+++ b/src/game/buildingSystem.js
@@ -6,6 +6,7 @@ import { triggerExplosion } from '../logic.js'
 import { updatePowerSupply, clearBuildingFromMapGrid } from '../buildings.js'
 import { checkGameEndConditions } from './gameStateManager.js'
 import { updateUnitSpeedModifier } from '../utils.js'
+import { updateDangerZoneMaps } from './dangerZoneMap.js'
 import { smoothRotateTowardsAngle, angleDiff } from '../logic.js'
 import { getTurretImageConfig, turretImagesAvailable } from '../rendering/turretImageRenderer.js'
 import { logPerformance } from '../performanceUtils.js'
@@ -42,6 +43,7 @@ export const updateBuildings = logPerformance(function updateBuildings(gameState
           gameState.buildings.splice(i, 1)
           gameState.pendingButtonUpdate = true
           updatePowerSupply(gameState.buildings, gameState)
+          updateDangerZoneMaps(gameState)
           checkGameEndConditions(factories, gameState)
           continue
         } else {
@@ -82,6 +84,7 @@ export const updateBuildings = logPerformance(function updateBuildings(gameState
 
         // Update power supply after building is destroyed
         updatePowerSupply(gameState.buildings, gameState)
+        updateDangerZoneMaps(gameState)
 
         // Calculate building center for explosion effects
         const buildingCenterX = building.x * TILE_SIZE + (building.width * TILE_SIZE / 2)

--- a/src/game/dangerZoneMap.js
+++ b/src/game/dangerZoneMap.js
@@ -1,0 +1,51 @@
+export function computeBuildingDps(building) {
+  const shots = building.burstFire ? (building.burstCount || 1) : 1
+  const cooldownSec = (building.fireCooldown || 1000) / 1000
+  return (building.damage * shots) / (cooldownSec || 1)
+}
+
+export function generateDangerZoneMapForPlayer(playerId, mapGrid, buildings, gameState) {
+  if (!mapGrid || mapGrid.length === 0) return []
+  const h = mapGrid.length
+  const w = mapGrid[0].length
+  const map = Array.from({ length: h }, () => Array(w).fill(0))
+
+  buildings.forEach(b => {
+    if (!b || !b.fireRange || b.health <= 0) return
+    if (!(b.type && (b.type.startsWith('turretGun') || b.type === 'rocketTurret' || b.type === 'teslaCoil' || b.type === 'artilleryTurret'))) return
+    if (b.owner === playerId) return
+
+    const supply = b.owner === gameState.humanPlayer ? gameState.playerPowerSupply : gameState.enemyPowerSupply
+    if ((b.type === 'rocketTurret' || b.type === 'teslaCoil') && supply < 0) return
+
+    const dps = computeBuildingDps(b)
+    const cx = b.x + (b.width || 1) / 2
+    const cy = b.y + (b.height || 1) / 2
+    const r = b.fireRange
+    const minY = Math.max(0, Math.floor(cy - r))
+    const maxY = Math.min(h - 1, Math.ceil(cy + r))
+    const minX = Math.max(0, Math.floor(cx - r))
+    const maxX = Math.min(w - 1, Math.ceil(cx + r))
+    for (let y = minY; y <= maxY; y++) {
+      for (let x = minX; x <= maxX; x++) {
+        const dx = (x + 0.5) - cx
+        const dy = (y + 0.5) - cy
+        if (Math.hypot(dx, dy) <= r) {
+          map[y][x] += dps
+        }
+      }
+    }
+  })
+
+  return map
+}
+
+export function updateDangerZoneMaps(gameState) {
+  if (!gameState || !gameState.mapGrid) return
+  const players = []
+  for (let i = 1; i <= (gameState.playerCount || 2); i++) players.push(`player${i}`)
+  gameState.dangerZoneMaps = {}
+  players.forEach(id => {
+    gameState.dangerZoneMaps[id] = generateDangerZoneMapForPlayer(id, gameState.mapGrid, gameState.buildings || [], gameState)
+  })
+}

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -83,6 +83,9 @@ export const gameState = {
   // Performance dialog visibility toggle
   performanceVisible: false,
 
+  dangerZoneMaps: {},
+  dzmOverlayIndex: -1,
+
   // FPS display toggle and tracking
   fpsVisible: false,
   fpsCounter: {

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -143,6 +143,10 @@ export class KeyboardHandler {
         e.preventDefault()
         this.handleOccupancyMapToggle()
       }
+      else if (e.key.toLowerCase() === 'z') {
+        e.preventDefault()
+        this.handleDzmToggle()
+      }
       // T key to toggle tank image rendering
       else if (e.key.toLowerCase() === 't') {
         e.preventDefault()
@@ -687,6 +691,25 @@ export class KeyboardHandler {
     this.showNotification(`Occupancy map: ${status}`, 2000)
     
     // Play a sound for feedback
+    playSound('confirmed', 0.5)
+  }
+
+  handleDzmToggle() {
+    const ids = Object.keys(gameState.dangerZoneMaps || {})
+    if (ids.length === 0) return
+    if (gameState.dzmOverlayIndex === -1) {
+      gameState.dzmOverlayIndex = 0
+    } else {
+      gameState.dzmOverlayIndex++
+      if (gameState.dzmOverlayIndex >= ids.length) {
+        gameState.dzmOverlayIndex = -1
+        this.showNotification('Danger zone map: OFF', 2000)
+        playSound('confirmed', 0.5)
+        return
+      }
+    }
+    const pid = ids[gameState.dzmOverlayIndex]
+    this.showNotification(`Danger zone map: ${pid}`, 2000)
     playSound('confirmed', 0.5)
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import { showNotification } from './ui/notifications.js'
 import { resetAttackDirections } from './ai/enemyStrategies.js'
 import { getTextureManager, preloadTileTextures } from './rendering.js'
 import { milestoneSystem } from './game/milestoneSystem.js'
+import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 
 // Import new modules
 import { CanvasManager } from './rendering/canvasManager.js'
@@ -166,6 +167,8 @@ class Game {
     })
 
     gameState.occupancyMap = initializeOccupancyMap(units, mapGrid, getTextureManager())
+    updateDangerZoneMaps(gameState)
+    updateDangerZoneMaps(gameState)
   }
 
   centerOnPlayerFactory() {
@@ -354,6 +357,7 @@ class Game {
     bullets.length = 0
 
     gameState.occupancyMap = initializeOccupancyMap(units, mapGrid, getTextureManager())
+    updateDangerZoneMaps(gameState)
 
     this.centerOnPlayerFactory()
 
@@ -373,6 +377,7 @@ class Game {
     productionQueue.resumeProductionAfterUnpause()
 
     gameState.occupancyMap = initializeOccupancyMap(units, mapGrid, getTextureManager())
+    updateDangerZoneMaps(gameState)
   }
 
   async resetGame() {

--- a/src/productionQueue.js
+++ b/src/productionQueue.js
@@ -7,6 +7,7 @@ import { buildingData, createBuilding, placeBuilding, canPlaceBuilding, updatePo
 import { unitCosts } from './units.js'
 import { playSound } from './sound.js'
 import { assignHarvesterToOptimalRefinery } from './game/harvesterLogic.js'
+import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 
 // List of unit types considered vehicles requiring a Vehicle Factory
 // Ambulance should spawn from the vehicle factory as well
@@ -491,6 +492,7 @@ export const productionQueue = {
         newBuilding.owner = gameState.humanPlayer
         if (!gameState.buildings) gameState.buildings = []
         gameState.buildings.push(newBuilding)
+        updateDangerZoneMaps(gameState)
         placeBuilding(newBuilding, gameState.mapGrid)
         updatePowerSupply(gameState.buildings, gameState)
         playSound('buildingPlaced')

--- a/src/rendering/dangerZoneRenderer.js
+++ b/src/rendering/dangerZoneRenderer.js
@@ -1,0 +1,50 @@
+import { TILE_SIZE, PARTY_COLORS } from '../config.js'
+
+export class DangerZoneRenderer {
+  render(ctx, dzm, scrollOffset, playerId) {
+    if (!dzm || !playerId) return
+
+    const startX = Math.max(0, Math.floor(scrollOffset.x / TILE_SIZE))
+    const startY = Math.max(0, Math.floor(scrollOffset.y / TILE_SIZE))
+    const tilesX = Math.ceil(ctx.canvas.width / TILE_SIZE) + 1
+    const tilesY = Math.ceil(ctx.canvas.height / TILE_SIZE) + 1
+    const endX = Math.min(dzm[0].length, startX + tilesX)
+    const endY = Math.min(dzm.length, startY + tilesY)
+
+    ctx.save()
+    ctx.strokeStyle = 'rgba(255,0,0,0.5)'
+    ctx.lineWidth = 1
+    for (let y = startY; y < endY; y++) {
+      for (let x = startX; x < endX; x++) {
+        const dps = dzm[y][x]
+        if (dps <= 0) continue
+        const spacing = Math.max(2, 32 / Math.max(1, dps))
+        const lines = Math.floor(TILE_SIZE / spacing)
+        const baseX = x * TILE_SIZE - scrollOffset.x
+        const baseY = y * TILE_SIZE - scrollOffset.y
+        for (let i = 1; i <= lines; i++) {
+          const off = i * spacing
+          if (off >= TILE_SIZE) break
+          ctx.beginPath()
+          ctx.moveTo(baseX, baseY + off)
+          ctx.lineTo(baseX + TILE_SIZE, baseY + off)
+          ctx.stroke()
+        }
+      }
+    }
+    ctx.restore()
+
+    ctx.save()
+    ctx.fillStyle = 'rgba(0,0,0,0.7)'
+    ctx.fillRect(ctx.canvas.width - 110, 10, 100, 18)
+    ctx.strokeStyle = PARTY_COLORS[playerId] || '#fff'
+    ctx.strokeRect(ctx.canvas.width - 110, 10, 100, 18)
+    ctx.fillStyle = '#fff'
+    ctx.font = '12px Arial'
+    ctx.textAlign = 'center'
+    const names = { player1: 'Green', player2: 'Red', player3: 'Blue', player4: 'Yellow' }
+    const label = names[playerId] ? `Player ${names[playerId]}` : playerId
+    ctx.fillText(label, ctx.canvas.width - 60, 23)
+    ctx.restore()
+  }
+}

--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -11,6 +11,7 @@ import { PathPlanningRenderer } from "./pathPlanningRenderer.js"
 import { UIRenderer } from './uiRenderer.js'
 import { MinimapRenderer } from './minimapRenderer.js'
 import { HarvesterHUD } from '../ui/harvesterHUD.js'
+import { DangerZoneRenderer } from './dangerZoneRenderer.js'
 import { preloadTankImages } from './tankImageRenderer.js'
 import { preloadHarvesterImage } from './harvesterImageRenderer.js'
 import { preloadRocketTankImage } from './rocketTankImageRenderer.js'
@@ -32,6 +33,7 @@ export class Renderer {
     this.guardRenderer = new GuardRenderer()
     this.pathPlanningRenderer = new PathPlanningRenderer()
     this.harvesterHUD = new HarvesterHUD()
+    this.dangerZoneRenderer = new DangerZoneRenderer()
   }
 
   // Initialize texture loading
@@ -133,6 +135,12 @@ export class Renderer {
     }
     
     this.mapRenderer.render(gameCtx, mapGrid, scrollOffset, gameCanvas, gameState, occupancyMap)
+    if (gameState.dzmOverlayIndex !== -1) {
+      const ids = Object.keys(gameState.dangerZoneMaps || {})
+      const pid = ids[gameState.dzmOverlayIndex]
+      const dzm = pid ? gameState.dangerZoneMaps[pid] : null
+      if (dzm) this.dangerZoneRenderer.render(gameCtx, dzm, scrollOffset, pid)
+    }
     this.buildingRenderer.renderBases(gameCtx, buildings, mapGrid, scrollOffset)
     // Render initial construction yards using the same renderer
     this.buildingRenderer.renderBases(gameCtx, factories, mapGrid, scrollOffset)

--- a/src/saveGame.js
+++ b/src/saveGame.js
@@ -14,6 +14,7 @@ import { getTextureManager } from './rendering.js'
 import { assignHarvesterToOptimalRefinery } from './game/harvesterLogic.js'
 import { productionQueue } from './productionQueue.js'
 import { getCurrentGame } from './main.js'
+import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 import { getKeyboardHandler } from './inputHandler.js'
 
 // === Save/Load Game Logic ===
@@ -450,6 +451,7 @@ export function loadGame(key) {
     cleanupOreFromBuildings(mapGrid, gameState.buildings, factories)
 
     gameState.occupancyMap = initializeOccupancyMap(units, mapGrid, getTextureManager())
+    updateDangerZoneMaps(gameState)
 
     // Restore targeted ore tiles for harvester system
     if (loaded.targetedOreTiles) {

--- a/src/ui/eventHandlers.js
+++ b/src/ui/eventHandlers.js
@@ -18,6 +18,7 @@ import {
   buildingData,
   isTileValid
 } from '../buildings.js'
+import { updateDangerZoneMaps } from '../game/dangerZoneMap.js'
 import { playSound } from '../sound.js'
 import { savePlayerBuildPatterns } from '../savePlayerBuildPatterns.js'
 import { TILE_SIZE } from '../config.js'
@@ -253,6 +254,7 @@ export class EventHandlers {
             gameState.buildings = []
           }
           gameState.buildings.push(newBuilding)
+          updateDangerZoneMaps(gameState)
 
           // Mark building tiles in the map grid
           placeBuilding(newBuilding, this.mapGrid)


### PR DESCRIPTION
## Summary
- create DangerZoneMap utilities for enemy AI
- render Danger Zone Maps with new DangerZoneRenderer
- compute and update DZM when buildings change or game loads
- allow cycling DZM overlay with the Z key
- track overlay state in gameState

## Testing
- `npm run lint` *(fails: 2986 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688109902638832886439c0cdf0f7f08