### PR TITLE
Add danger zone map overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,6 +351,7 @@
       <div id="frameTimeMin">Min: -- ms</div>
       <div id="frameTimeMax">Max: -- ms</div>
     </div>
+    <div id="dzmLabel" class="dzm-overlay"></div>
     <div id="performanceDialog" class="performance-dialog"></div>
     
     <script src="/src/main.js" type="module"></script>

--- a/src/ai/enemyAIPlayer.js
+++ b/src/ai/enemyAIPlayer.js
@@ -5,6 +5,7 @@ import { getUnitCost } from '../utils.js'
 import { updateAIUnit } from './enemyUnitBehavior.js'
 import { findBuildingPosition } from './enemyBuilding.js'
 import { logPerformance } from '../performanceUtils.js'
+import { updateDangerZoneMaps } from '../game/dangerZoneMap.js'
 
 function findSimpleBuildingPosition(buildingType, mapGrid, factories, aiPlayerId) {
   // Validate inputs
@@ -321,6 +322,7 @@ const updateAIPlayer = logPerformance(function updateAIPlayer(aiPlayerId, units,
         newBuilding.owner = aiPlayerId
         gameState.buildings.push(newBuilding)
         placeBuilding(newBuilding, mapGrid)
+        updateDangerZoneMaps(gameState)
 
         if (DEBUG_AI_BUILDING) {
           console.log(`AI ${aiPlayerId} successfully placed ${buildingType} at (${position.x}, ${position.y})`)
@@ -345,6 +347,7 @@ const updateAIPlayer = logPerformance(function updateAIPlayer(aiPlayerId, units,
           newBuilding.owner = aiPlayerId
           gameState.buildings.push(newBuilding)
           placeBuilding(newBuilding, mapGrid)
+          updateDangerZoneMaps(gameState)
           
           if (DEBUG_AI_BUILDING) {
             console.log(`AI ${aiPlayerId} placed ${buildingType} at alternative position (${alternativePosition.x}, ${alternativePosition.y})`)

--- a/src/ai/enemyBuilding.js
+++ b/src/ai/enemyBuilding.js
@@ -1,6 +1,7 @@
 import { buildingData, createBuilding, canPlaceBuilding, placeBuilding, isNearExistingBuilding, isTileValid, updatePowerSupply } from '../buildings.js'
 import { gameState } from '../gameState.js'
 import { isPartOfFactory } from './enemyUtils.js'
+import { updateDangerZoneMaps } from '../game/dangerZoneMap.js'
 
 // Let's improve this function to fix issues with enemy building placement
 // Modified to improve building placement with better spacing and factory avoidance
@@ -688,6 +689,8 @@ function completeEnemyBuilding(gameState, mapGrid) {
 
     // Update map grid
     placeBuilding(newBuilding, mapGrid)
+
+    updateDangerZoneMaps(gameState)
 
     // Update power supply
     updatePowerSupply(gameState.buildings, gameState)

--- a/src/game/buildingSystem.js
+++ b/src/game/buildingSystem.js
@@ -9,6 +9,7 @@ import { updateUnitSpeedModifier } from '../utils.js'
 import { smoothRotateTowardsAngle, angleDiff } from '../logic.js'
 import { getTurretImageConfig, turretImagesAvailable } from '../rendering/turretImageRenderer.js'
 import { logPerformance } from '../performanceUtils.js'
+import { updateDangerZoneMaps } from './dangerZoneMap.js'
 
 /**
  * Updates all buildings including health checks, destruction, and defensive capabilities
@@ -40,6 +41,7 @@ export const updateBuildings = logPerformance(function updateBuildings(gameState
 
           clearBuildingFromMapGrid(building, mapGrid)
           gameState.buildings.splice(i, 1)
+          updateDangerZoneMaps(gameState)
           gameState.pendingButtonUpdate = true
           updatePowerSupply(gameState.buildings, gameState)
           checkGameEndConditions(factories, gameState)
@@ -76,6 +78,7 @@ export const updateBuildings = logPerformance(function updateBuildings(gameState
 
         // Remove the building from the buildings array
         gameState.buildings.splice(i, 1)
+        updateDangerZoneMaps(gameState)
 
         // Trigger UI refresh for production buttons
         gameState.pendingButtonUpdate = true

--- a/src/game/dangerZoneMap.js
+++ b/src/game/dangerZoneMap.js
@@ -1,0 +1,67 @@
+import { MAP_TILES_X, MAP_TILES_Y } from '../config.js'
+
+function isDefensiveBuilding(b) {
+  return (
+    b.type === 'rocketTurret' ||
+    b.type === 'teslaCoil' ||
+    b.type === 'artilleryTurret' ||
+    b.type.startsWith('turretGun')
+  )
+}
+
+function isFriendly(playerId, owner) {
+  if (playerId === owner) return true
+  if (playerId === 'player1' && owner === 'player') return true
+  if (playerId === 'player' && owner === 'player1') return true
+  return false
+}
+
+function createEmptyMap() {
+  const arr = new Array(MAP_TILES_Y)
+  for (let y = 0; y < MAP_TILES_Y; y++) {
+    arr[y] = new Array(MAP_TILES_X).fill(0)
+  }
+  return arr
+}
+
+export function generateDangerZoneMaps(buildings, playerCount) {
+  const players = ['player1', 'player2', 'player3', 'player4'].slice(0, playerCount)
+  const maps = {}
+  players.forEach(p => {
+    maps[p] = createEmptyMap()
+  })
+
+  buildings.forEach(b => {
+    if (!isDefensiveBuilding(b) || !b.fireRange || !b.damage || !b.fireCooldown) return
+    const range = b.fireRange
+    const centerX = b.x + b.width / 2
+    const centerY = b.y + b.height / 2
+    const burst = b.burstFire ? (b.burstCount || 1) : 1
+    const dps = (b.damage * burst) / (b.fireCooldown / 1000)
+    const startX = Math.max(0, Math.floor(centerX - range))
+    const endX = Math.min(MAP_TILES_X - 1, Math.ceil(centerX + range))
+    const startY = Math.max(0, Math.floor(centerY - range))
+    const endY = Math.min(MAP_TILES_Y - 1, Math.ceil(centerY + range))
+
+    players.forEach(pid => {
+      if (isFriendly(pid, b.owner)) return
+      const map = maps[pid]
+      for (let y = startY; y <= endY; y++) {
+        for (let x = startX; x <= endX; x++) {
+          const dx = (x + 0.5) - centerX
+          const dy = (y + 0.5) - centerY
+          const dist = Math.hypot(dx, dy)
+          if (dist <= range) {
+            map[y][x] += dps
+          }
+        }
+      }
+    })
+  })
+
+  return maps
+}
+
+export function updateDangerZoneMaps(gameState) {
+  gameState.dangerZoneMaps = generateDangerZoneMaps(gameState.buildings || [], gameState.playerCount || 2)
+}

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -131,5 +131,9 @@ export const gameState = {
   newBuildingTypes: new Set(),
 
   // Flag to refresh production buttons after building destruction
-  pendingButtonUpdate: false
+  pendingButtonUpdate: false,
+
+  // Danger zone maps generated from defensive structures
+  dangerZoneMaps: {},
+  dzmOverlayIndex: -1
 }

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -143,6 +143,11 @@ export class KeyboardHandler {
         e.preventDefault()
         this.handleOccupancyMapToggle()
       }
+      // Z key to cycle danger zone maps
+      else if (e.key.toLowerCase() === 'z') {
+        e.preventDefault()
+        this.handleDangerZoneToggle()
+      }
       // T key to toggle tank image rendering
       else if (e.key.toLowerCase() === 't') {
         e.preventDefault()
@@ -687,6 +692,31 @@ export class KeyboardHandler {
     this.showNotification(`Occupancy map: ${status}`, 2000)
     
     // Play a sound for feedback
+    playSound('confirmed', 0.5)
+  }
+
+  handleDangerZoneToggle() {
+    const players = ['player1', 'player2', 'player3', 'player4'].slice(0, gameState.playerCount)
+    if (gameState.dzmOverlayIndex === -1) {
+      gameState.dzmOverlayIndex = 0
+    } else {
+      gameState.dzmOverlayIndex++
+      if (gameState.dzmOverlayIndex >= players.length) {
+        gameState.dzmOverlayIndex = -1
+      }
+    }
+
+    const labelEl = document.getElementById('dzmLabel')
+    if (labelEl) {
+      if (gameState.dzmOverlayIndex === -1) {
+        labelEl.classList.remove('visible')
+      } else {
+        const pid = players[gameState.dzmOverlayIndex]
+        labelEl.textContent = `Danger Zones: ${pid}`
+        labelEl.classList.add('visible')
+      }
+    }
+
     playSound('confirmed', 0.5)
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import { showNotification } from './ui/notifications.js'
 import { resetAttackDirections } from './ai/enemyStrategies.js'
 import { getTextureManager, preloadTileTextures } from './rendering.js'
 import { milestoneSystem } from './game/milestoneSystem.js'
+import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 
 // Import new modules
 import { CanvasManager } from './rendering/canvasManager.js'
@@ -166,6 +167,9 @@ class Game {
     })
 
     gameState.occupancyMap = initializeOccupancyMap(units, mapGrid, getTextureManager())
+    updateDangerZoneMaps(gameState)
+    updateDangerZoneMaps(gameState)
+    updateDangerZoneMaps(gameState)
   }
 
   centerOnPlayerFactory() {
@@ -373,6 +377,7 @@ class Game {
     productionQueue.resumeProductionAfterUnpause()
 
     gameState.occupancyMap = initializeOccupancyMap(units, mapGrid, getTextureManager())
+    updateDangerZoneMaps(gameState)
   }
 
   async resetGame() {

--- a/src/productionQueue.js
+++ b/src/productionQueue.js
@@ -7,6 +7,7 @@ import { buildingData, createBuilding, placeBuilding, canPlaceBuilding, updatePo
 import { unitCosts } from './units.js'
 import { playSound } from './sound.js'
 import { assignHarvesterToOptimalRefinery } from './game/harvesterLogic.js'
+import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 
 // List of unit types considered vehicles requiring a Vehicle Factory
 // Ambulance should spawn from the vehicle factory as well
@@ -493,6 +494,7 @@ export const productionQueue = {
         gameState.buildings.push(newBuilding)
         placeBuilding(newBuilding, gameState.mapGrid)
         updatePowerSupply(gameState.buildings, gameState)
+        updateDangerZoneMaps(gameState)
         playSound('buildingPlaced')
         showNotification(`${buildingData[this.currentBuilding.type].displayName} constructed`)
       } else {

--- a/src/rendering/dangerZoneRenderer.js
+++ b/src/rendering/dangerZoneRenderer.js
@@ -1,0 +1,38 @@
+import { TILE_SIZE } from '../config.js'
+
+export class DangerZoneRenderer {
+  render(ctx, canvas, scrollOffset, gameState) {
+    if (!gameState || gameState.dzmOverlayIndex === -1) return
+    if (!gameState.dangerZoneMaps) return
+    const players = ['player1', 'player2', 'player3', 'player4'].slice(0, gameState.playerCount)
+    const playerId = players[gameState.dzmOverlayIndex]
+    const dzm = gameState.dangerZoneMaps[playerId]
+    if (!dzm) return
+
+    const startTileX = Math.max(0, Math.floor(scrollOffset.x / TILE_SIZE))
+    const startTileY = Math.max(0, Math.floor(scrollOffset.y / TILE_SIZE))
+    const tilesX = Math.ceil(canvas.width / TILE_SIZE) + 1
+    const tilesY = Math.ceil(canvas.height / TILE_SIZE) + 1
+    const endTileX = Math.min(dzm[0].length, startTileX + tilesX)
+    const endTileY = Math.min(dzm.length, startTileY + tilesY)
+
+    ctx.strokeStyle = 'rgba(255,0,0,0.5)'
+    ctx.lineWidth = 1
+
+    for (let y = startTileY; y < endTileY; y++) {
+      for (let x = startTileX; x < endTileX; x++) {
+        const dps = dzm[y][x]
+        if (dps <= 0) continue
+        const spacing = Math.max(2, 16 - Math.min(dps, 60) / 60 * 14)
+        const sx = x * TILE_SIZE - scrollOffset.x
+        const sy = y * TILE_SIZE - scrollOffset.y
+        for (let off = 0; off < TILE_SIZE; off += spacing) {
+          ctx.beginPath()
+          ctx.moveTo(sx, sy + off)
+          ctx.lineTo(sx + TILE_SIZE, sy + off)
+          ctx.stroke()
+        }
+      }
+    }
+  }
+}

--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -11,6 +11,7 @@ import { PathPlanningRenderer } from "./pathPlanningRenderer.js"
 import { UIRenderer } from './uiRenderer.js'
 import { MinimapRenderer } from './minimapRenderer.js'
 import { HarvesterHUD } from '../ui/harvesterHUD.js'
+import { DangerZoneRenderer } from './dangerZoneRenderer.js'
 import { preloadTankImages } from './tankImageRenderer.js'
 import { preloadHarvesterImage } from './harvesterImageRenderer.js'
 import { preloadRocketTankImage } from './rocketTankImageRenderer.js'
@@ -32,6 +33,7 @@ export class Renderer {
     this.guardRenderer = new GuardRenderer()
     this.pathPlanningRenderer = new PathPlanningRenderer()
     this.harvesterHUD = new HarvesterHUD()
+    this.dangerZoneRenderer = new DangerZoneRenderer()
   }
 
   // Initialize texture loading
@@ -133,6 +135,7 @@ export class Renderer {
     }
     
     this.mapRenderer.render(gameCtx, mapGrid, scrollOffset, gameCanvas, gameState, occupancyMap)
+    this.dangerZoneRenderer.render(gameCtx, gameCanvas, scrollOffset, gameState)
     this.buildingRenderer.renderBases(gameCtx, buildings, mapGrid, scrollOffset)
     // Render initial construction yards using the same renderer
     this.buildingRenderer.renderBases(gameCtx, factories, mapGrid, scrollOffset)

--- a/src/saveGame.js
+++ b/src/saveGame.js
@@ -8,6 +8,7 @@ import { TILE_SIZE, TANKER_SUPPLY_CAPACITY } from './config.js'
 import { createUnit } from './units.js'
 import { buildingData } from './buildings.js'
 import { showNotification } from './ui/notifications.js'
+import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 import { milestoneSystem } from './game/milestoneSystem.js'
 import { initializeOccupancyMap } from './units.js'
 import { getTextureManager } from './rendering.js'
@@ -450,6 +451,7 @@ export function loadGame(key) {
     cleanupOreFromBuildings(mapGrid, gameState.buildings, factories)
 
     gameState.occupancyMap = initializeOccupancyMap(units, mapGrid, getTextureManager())
+    updateDangerZoneMaps(gameState)
 
     // Restore targeted ore tiles for harvester system
     if (loaded.targetedOreTiles) {

--- a/style.css
+++ b/style.css
@@ -699,6 +699,27 @@ html, body {
   color: #ff0000; /* Red for <15 FPS */
 }
 
+/* Danger Zone Map Overlay */
+.dzm-overlay {
+  position: absolute;
+  top: 10px;
+  right: 140px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 14px;
+  border: 1px solid rgba(255, 0, 0, 0.8);
+  z-index: 999;
+  pointer-events: none;
+  display: none;
+}
+
+.dzm-overlay.visible {
+  display: block;
+}
+
 /* Performance Dialog */
 .performance-dialog {
   position: absolute;


### PR DESCRIPTION
## Summary
- compute danger zone maps per player from defensive buildings
- show/hide DZM overlays with the Z key
- render danger zone contours below buildings
- update DZM when buildings are built or destroyed
- display current player's DZM in top-right overlay

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688109902638832886439c0cdf0f7f08