### PR TITLE
Enhance danger zone overlay and AI attack planning

### DIFF
--- a/src/enemy.js
+++ b/src/enemy.js
@@ -1,5 +1,6 @@
 // enemy orchestrator
 import { updateAIPlayer } from './ai/enemyAIPlayer.js'
+import { computeLeastDangerAttackPoint } from './ai/enemyStrategies.js'
 import { logPerformance } from './performanceUtils.js'
 export { spawnEnemyUnit } from './ai/enemySpawner.js'
 
@@ -11,6 +12,14 @@ export const updateEnemyAI = logPerformance(function updateEnemyAI(units, factor
   const allPlayers = ['player1', 'player2', 'player3', 'player4'].slice(0, playerCount)
   const aiPlayers = allPlayers.filter(p => p !== humanPlayer)
   const targetedOreTiles = gameState.targetedOreTiles || {}
+
+  if (!gameState.lastGlobalAttackDecision || now - gameState.lastGlobalAttackDecision > 8000) {
+    const point = computeLeastDangerAttackPoint(gameState)
+    if (point) {
+      gameState.globalAttackPoint = point
+      gameState.lastGlobalAttackDecision = now
+    }
+  }
   
   aiPlayers.forEach(aiPlayerId => {
     updateAIPlayer(aiPlayerId, units, factories, bullets, mapGrid, gameState, occupancyMap, now, targetedOreTiles)

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -120,6 +120,10 @@ export const gameState = {
   attackGroupTargets: [], // Array of enemy units to be attacked
   disableAGFRendering: false, // Flag to temporarily disable AGF rendering
 
+  // Shared AI attack point updated periodically
+  globalAttackPoint: null,
+  lastGlobalAttackDecision: 0,
+
   // Multiplayer settings
   playerCount: 2,  // Number of players (2-4)
   humanPlayer: 'player1',  // Which player is controlled by human

--- a/src/rendering/dangerZoneRenderer.js
+++ b/src/rendering/dangerZoneRenderer.js
@@ -14,22 +14,28 @@ export class DangerZoneRenderer {
     ctx.save()
     ctx.strokeStyle = 'rgba(255,0,0,0.5)'
     ctx.lineWidth = 1
+    ctx.font = '8px Arial'
+    ctx.fillStyle = '#fff'
+    ctx.textAlign = 'right'
+    ctx.textBaseline = 'bottom'
     for (let y = startY; y < endY; y++) {
       for (let x = startX; x < endX; x++) {
         const dps = dzm[y][x]
-        if (dps <= 0) continue
-        const spacing = Math.max(2, 32 / Math.max(1, dps))
-        const lines = Math.floor(TILE_SIZE / spacing)
         const baseX = x * TILE_SIZE - scrollOffset.x
         const baseY = y * TILE_SIZE - scrollOffset.y
-        for (let i = 1; i <= lines; i++) {
-          const off = i * spacing
-          if (off >= TILE_SIZE) break
-          ctx.beginPath()
-          ctx.moveTo(baseX, baseY + off)
-          ctx.lineTo(baseX + TILE_SIZE, baseY + off)
-          ctx.stroke()
+        if (dps > 0) {
+          const spacing = Math.max(2, 32 / Math.max(1, dps))
+          const lines = Math.floor(TILE_SIZE / spacing)
+          for (let i = 1; i <= lines; i++) {
+            const off = i * spacing
+            if (off >= TILE_SIZE) break
+            ctx.beginPath()
+            ctx.moveTo(baseX, baseY + off)
+            ctx.lineTo(baseX + TILE_SIZE, baseY + off)
+            ctx.stroke()
+          }
         }
+        ctx.fillText(dps.toFixed(1), baseX + TILE_SIZE - 1, baseY + TILE_SIZE - 1)
       }
     }
     ctx.restore()


### PR DESCRIPTION
## Summary
- show DPS numbers per tile in the danger zone overlay
- track a global attack point using DZM information
- guide enemy attack groups towards the least dangerous approach

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881492448a48328836cd1bd81c8fff4