### PR TITLE
Enable tanker trucks to show moveInto cursor over workshops

### DIFF
--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -251,27 +251,31 @@ export class CursorManager {
       }
     }
 
-    // Check if mouse is over player vehicle workshop when damaged units or
-    // tanker trucks are selected
+    // Check if mouse is over player vehicle workshop when a repairable unit is
+    // selected (damaged or tanker truck)
     this.isOverPlayerWorkshop = false
-    if (this.isOverGameCanvas &&
-        gameState.buildings && Array.isArray(gameState.buildings) &&
-        tileX >= 0 && tileY >= 0 &&
-        tileX < mapGrid[0].length && tileY < mapGrid.length) {
-      const hasDamagedUnits = selectedUnits.some(
-        unit => unit.health < unit.maxHealth
+    if (
+      this.isOverGameCanvas &&
+      gameState.buildings &&
+      Array.isArray(gameState.buildings) &&
+      tileX >= 0 &&
+      tileY >= 0 &&
+      tileX < mapGrid[0].length &&
+      tileY < mapGrid.length
+    ) {
+      const needsWorkshop = selectedUnits.some(
+        unit => unit.health < unit.maxHealth || unit.type === 'tankerTruck'
       )
-      const hasSelectedTankers = selectedUnits.some(
-        unit => unit.type === 'tankerTruck'
-      )
-      if (hasDamagedUnits || hasSelectedTankers) {
+      if (needsWorkshop) {
         for (const building of gameState.buildings) {
           if (
             building.type === 'vehicleWorkshop' &&
             building.owner === gameState.humanPlayer &&
             building.health > 0 &&
-            tileX >= building.x && tileX < building.x + building.width &&
-            tileY >= building.y && tileY < building.y + building.height
+            tileX >= building.x &&
+            tileX < building.x + building.width &&
+            tileY >= building.y &&
+            tileY < building.y + building.height
           ) {
             this.isOverPlayerWorkshop = true
             break

--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -400,6 +400,11 @@ export class CursorManager {
         gameCanvas.style.cursor = 'none'
         gameCanvas.classList.add('move-into-mode')
         return // Exit early - recovery tank interaction takes priority
+      } else if (this.isOverPlayerWorkshop) {
+        // Damaged units or tankers over workshop - highest priority move-into cursor
+        gameCanvas.style.cursor = 'none'
+        gameCanvas.classList.add('move-into-mode')
+        return
       }
 
       // If AGF capable and no recovery tank interactions, use AGF behavior
@@ -530,10 +535,6 @@ export class CursorManager {
         // Over enemy - use attack cursor
         gameCanvas.style.cursor = 'none'
         gameCanvas.classList.add('attack-mode')
-      } else if (this.isOverPlayerWorkshop) {
-        // Over vehicle workshop with damaged units selected - special move cursor
-        gameCanvas.style.cursor = 'none'
-        gameCanvas.classList.add('move-into-mode')
       } else if (this.isOverHealableUnit) {
         // Over healable unit with ambulances selected - show move into cursor
         gameCanvas.style.cursor = 'none'

--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -251,16 +251,28 @@ export class CursorManager {
       }
     }
 
-    // Check if mouse is over player vehicle workshop when damaged units selected
+    // Check if mouse is over player vehicle workshop when damaged units or
+    // tanker trucks are selected
     this.isOverPlayerWorkshop = false
-    if (this.isOverGameCanvas && gameState.buildings && Array.isArray(gameState.buildings) &&
-        tileX >= 0 && tileY >= 0 && tileX < mapGrid[0].length && tileY < mapGrid.length) {
-      const hasDamagedUnits = selectedUnits.some(unit => unit.health < unit.maxHealth)
-      if (hasDamagedUnits) {
+    if (this.isOverGameCanvas &&
+        gameState.buildings && Array.isArray(gameState.buildings) &&
+        tileX >= 0 && tileY >= 0 &&
+        tileX < mapGrid[0].length && tileY < mapGrid.length) {
+      const hasDamagedUnits = selectedUnits.some(
+        unit => unit.health < unit.maxHealth
+      )
+      const hasSelectedTankers = selectedUnits.some(
+        unit => unit.type === 'tankerTruck'
+      )
+      if (hasDamagedUnits || hasSelectedTankers) {
         for (const building of gameState.buildings) {
-          if (building.type === 'vehicleWorkshop' && building.owner === gameState.humanPlayer && building.health > 0 &&
-              tileX >= building.x && tileX < building.x + building.width &&
-              tileY >= building.y && tileY < building.y + building.height) {
+          if (
+            building.type === 'vehicleWorkshop' &&
+            building.owner === gameState.humanPlayer &&
+            building.health > 0 &&
+            tileX >= building.x && tileX < building.x + building.width &&
+            tileY >= building.y && tileY < building.y + building.height
+          ) {
             this.isOverPlayerWorkshop = true
             break
           }


### PR DESCRIPTION
## Summary
- check for selected tanker trucks when determining if cursor is over a vehicle workshop

## Testing
- `npm run lint` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688151176da083289b21e5bac73218d7