### PR TITLE
Fix building sell glitch

### DIFF
--- a/src/buildingSellHandler.js
+++ b/src/buildingSellHandler.js
@@ -38,6 +38,13 @@ export function buildingSellHandler(e, gameState, gameCanvas, mapGrid, units, fa
         tileX >= building.x && tileX < (building.x + building.width) &&
         tileY >= building.y && tileY < (building.y + building.height)) {
 
+      // Don't allow selling again while the sell animation runs
+      if (building.isBeingSold) {
+        showNotification('Building is already being sold.')
+        playSound('error')
+        return false
+      }
+
       // Calculate sell value (70% of original cost)
       const buildingType = building.type
       const originalCost = buildingCosts[buildingType] || 0

--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -307,8 +307,9 @@ export class CursorManager {
         for (const building of gameState.buildings) {
           if (building.owner === gameState.humanPlayer &&
               tileX >= building.x && tileX < (building.x + building.width) &&
-              tileY >= building.y && tileY < (building.y + building.height)) {
-            // All player buildings can be sold
+              tileY >= building.y && tileY < (building.y + building.height) &&
+              !building.isBeingSold) {
+            // All player buildings can be sold if not currently being sold
             this.isOverSellableBuilding = true
             break
           }


### PR DESCRIPTION
## Summary
- prevent double-selling of buildings by checking if the sell animation is already running
- show blocked sell cursor while a building is being sold

## Testing
- `npm run lint` *(fails: 2981 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68815716fe308328a59c12e095ba9550