### PR TITLE
Prevent enemy selection overriding attack

### DIFF
--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -928,7 +928,11 @@ export class MouseHandler {
       }
     }
 
-    if (clickedUnit) {
+    const friendlySelected = selectedUnits.some(u => selectionManager.isHumanPlayerUnit(u))
+    const clickedIsEnemy = clickedUnit && !selectionManager.isHumanPlayerUnit(clickedUnit)
+
+    if (clickedUnit && !(friendlySelected && clickedIsEnemy)) {
+      // Only allow enemy selection when no friendly units are currently selected
       selectionManager.handleUnitSelection(clickedUnit, e, units, factories, selectedUnits)
       // Update AGF capability after unit selection
       this.updateAGFCapability(selectedUnits)


### PR DESCRIPTION
## Summary
- ensure attacking still works when enemy selection is enabled by blocking enemy unit selection while friendly units remain selected

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881744cd26083289bfb2bff7cdf9165