### PR TITLE
Replace water tile with animated GIF

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -57,7 +57,8 @@ export const TILE_IMAGES = {
     useGrassTileDiscovery: true
   },
   water: {
-    paths: ['images/map/water01']
+    // Use animated water texture
+    paths: ['images/map/water_animation']
   },
   rock: {
     paths: ['images/map/rock_on_grass01', 'images/map/rock01', 'images/map/rock02', 'images/map/rock03', 'images/map/rock04', 'images/map/rock05']

--- a/src/rendering/mapRenderer.js
+++ b/src/rendering/mapRenderer.js
@@ -13,6 +13,27 @@ export class MapRenderer {
     const useTexture = USE_TEXTURES && this.textureManager.allTexturesLoaded
     const sotApplied = new Set()
 
+    const drawFromInfo = (info, x, y, size = TILE_SIZE + 1) => {
+      if (!info) return
+      if (info.x !== undefined) {
+        ctx.drawImage(
+          this.textureManager.spriteImage,
+          info.x,
+          info.y,
+          info.width,
+          info.height,
+          x,
+          y,
+          size,
+          size
+        )
+      } else if (info instanceof HTMLCanvasElement || info instanceof Image) {
+        ctx.drawImage(info, x, y, size, size)
+      } else if (info.image) {
+        ctx.drawImage(info.image, x, y, size, size)
+      }
+    }
+
     const drawTile = (x, y, type) => {
       const screenX = Math.floor(x * TILE_SIZE - scrollOffset.x)
       const screenY = Math.floor(y * TILE_SIZE - scrollOffset.y)
@@ -21,17 +42,7 @@ export class MapRenderer {
         const idx = this.textureManager.getTileVariation(type, x, y)
         if (idx >= 0 && idx < this.textureManager.tileTextureCache[type].length) {
           const info = this.textureManager.tileTextureCache[type][idx]
-          ctx.drawImage(
-            this.textureManager.spriteImage,
-            info.x,
-            info.y,
-            info.width,
-            info.height,
-            screenX,
-            screenY,
-            TILE_SIZE + 1,
-            TILE_SIZE + 1
-          )
+          drawFromInfo(info, screenX, screenY)
         } else {
           ctx.fillStyle = TILE_COLORS[type]
           ctx.fillRect(screenX, screenY, TILE_SIZE + 1, TILE_SIZE + 1)
@@ -49,17 +60,7 @@ export class MapRenderer {
         const idx = this.textureManager.getTileVariation('ore', x, y)
         if (idx >= 0 && idx < this.textureManager.tileTextureCache.ore.length) {
           const info = this.textureManager.tileTextureCache.ore[idx]
-          ctx.drawImage(
-            this.textureManager.spriteImage,
-            info.x,
-            info.y,
-            info.width,
-            info.height,
-            screenX,
-            screenY,
-            TILE_SIZE + 1,
-            TILE_SIZE + 1
-          )
+          drawFromInfo(info, screenX, screenY)
         } else {
           ctx.fillStyle = TILE_COLORS.ore
           ctx.fillRect(screenX, screenY, TILE_SIZE + 1, TILE_SIZE + 1)
@@ -77,17 +78,7 @@ export class MapRenderer {
         const idx = this.textureManager.getTileVariation('seedCrystal', x, y)
         if (idx >= 0 && idx < this.textureManager.tileTextureCache.seedCrystal.length) {
           const info = this.textureManager.tileTextureCache.seedCrystal[idx]
-          ctx.drawImage(
-            this.textureManager.spriteImage,
-            info.x,
-            info.y,
-            info.width,
-            info.height,
-            screenX,
-            screenY,
-            TILE_SIZE + 1,
-            TILE_SIZE + 1
-          )
+          drawFromInfo(info, screenX, screenY)
         } else {
           ctx.fillStyle = TILE_COLORS.seedCrystal
           ctx.fillRect(screenX, screenY, TILE_SIZE + 1, TILE_SIZE + 1)
@@ -204,17 +195,7 @@ export class MapRenderer {
       const idx = this.textureManager.getTileVariation(type, tileX, tileY)
       if (idx >= 0 && idx < this.textureManager.tileTextureCache[type].length) {
         const info = this.textureManager.tileTextureCache[type][idx]
-        ctx.drawImage(
-          this.textureManager.spriteImage,
-          info.x,
-          info.y,
-          info.width,
-          info.height,
-          screenX,
-          screenY,
-          size,
-          size
-        )
+        drawFromInfo(info, screenX, screenY, size)
       } else {
         ctx.fillStyle = TILE_COLORS[type]
         ctx.fill()

--- a/src/rendering/textureManager.js
+++ b/src/rendering/textureManager.js
@@ -140,6 +140,9 @@ export class TextureManager {
       const info = this.spriteMap[key]
       if (info) {
         this.tileTextureCache[type].push({ key, ...info })
+      } else {
+        // Fall back to loading standalone image (e.g. GIF animation)
+        this.loadSingleTexture(p, type, () => {})
       }
     }
 
@@ -170,6 +173,10 @@ export class TextureManager {
     // For grass tiles, try png first since they're png files
     else if (imagePath.includes('grass_tiles') || tileType === 'land') {
       extensions = ['png', 'jpg', 'webp']
+    }
+    // For water animation GIFs
+    else if (imagePath.includes('water_animation') || tileType === 'water') {
+      extensions = ['gif', 'jpg', 'webp', 'png']
     }
     
     this.getOrLoadImage(imagePath, extensions, (img) => {


### PR DESCRIPTION
## Summary
- load `water_animation.gif` for water tiles instead of the static JPG
- fall back to loading standalone images when not found in the sprite sheet
- support GIF textures in the texture manager
- update map renderer to handle canvas or image textures

## Testing
- `npm run lint` *(fails: trailing spaces and other issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68819371187c8328a69230310621ef72