### PR TITLE
Fix remote control limitations

### DIFF
--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -73,7 +73,7 @@ export const updateGame = logPerformance(function updateGame(delta, mapGrid, fac
     processCommandQueues(units, mapGrid, unitCommands)
 
     // Apply remote control inputs for selected tanks
-    updateRemoteControlledUnits(units, bullets, mapGrid)
+    updateRemoteControlledUnits(units, bullets, mapGrid, occupancyMap)
 
     // Unit system updates
     units.forEach(unit => {


### PR DESCRIPTION
## Summary
- restrict remote control to player units unless enemy control is enabled
- prevent remote-controlled units from entering occupied tiles

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688197ef50448328a2c69334076ad67a