### PR TITLE
Limit full crew to tanks

### DIFF
--- a/src/ai/enemySpawner.js
+++ b/src/ai/enemySpawner.js
@@ -124,20 +124,21 @@ export function spawnEnemyUnit(spawnBuilding, unitType, units, mapGrid, gameStat
       ambulance: 500
     }
     
-    // Initialize crew for combat units (excluding ambulance and rocket tank for AI)
-    if (unitType !== 'ambulance' && unitType !== 'rocketTank') {
-      unit.crew = {
-        driver: true,
-        gunner: true,
-        commander: true,
-        loader: true
-      }
+    const fullCrewTanks = ['tank_v1', 'tank-v2', 'tank-v3']
+    const loaderUnits = ['tankerTruck', 'ambulance', 'recoveryTank', 'harvester', 'rocketTank']
+
+    unit.crew = { driver: true, commander: true }
+
+    if (fullCrewTanks.includes(unitType)) {
+      unit.crew.gunner = true
+      unit.crew.loader = true
+    } else if (loaderUnits.includes(unitType)) {
+      unit.crew.loader = true
     }
-    
-    // Ambulances use numeric crew (number of crew members they carry)
+
     if (unitType === 'ambulance') {
-      unit.crew = UNIT_PROPERTIES.ambulance.crew
-      unit.maxCrew = UNIT_PROPERTIES.ambulance.maxCrew
+      unit.medics = UNIT_PROPERTIES.ambulance.medics
+      unit.maxMedics = UNIT_PROPERTIES.ambulance.maxMedics
     }
     
     unit.baseCost = unitCosts[unitType] || 1000

--- a/src/ai/enemyStrategies.js
+++ b/src/ai/enemyStrategies.js
@@ -859,10 +859,10 @@ export function manageAICrewHealing(units, gameState, now) {
     
     if (hospitals.length === 0) return // No hospitals available
     
-    // Find units with missing crew members (excluding ambulance and rocket tank)
+    // Find units with missing crew members (excluding ambulance)
     const unitsNeedingCrew = aiUnits.filter(unit => {
       if (!unit.crew || typeof unit.crew !== 'object') return false
-      if (unit.type === 'ambulance' || unit.type === 'rocketTank') return false // AI units don't use crew system
+      if (unit.type === 'ambulance') return false
       return Object.values(unit.crew).some(alive => !alive)
     })
     
@@ -881,7 +881,7 @@ export function manageAICrewHealing(units, gameState, now) {
     
     // Manage ambulance refilling
     ambulances.forEach(ambulance => {
-      if (ambulance.crew < 4 && !ambulance.refillingTarget && !ambulance.healingTarget) {
+      if (ambulance.medics < 4 && !ambulance.refillingTarget && !ambulance.healingTarget) {
         sendAmbulanceToHospital(ambulance, hospitals[0], gameState.mapGrid)
       }
     })
@@ -893,9 +893,9 @@ export function manageAICrewHealing(units, gameState, now) {
  */
 function assignAmbulanceToUnit(targetUnit, ambulances, hospital) {
   // Find available ambulance with crew
-  const availableAmbulance = ambulances.find(ambulance => 
-    ambulance.crew > 0 && 
-    !ambulance.healingTarget && 
+  const availableAmbulance = ambulances.find(ambulance =>
+    ambulance.medics > 0 &&
+    !ambulance.healingTarget &&
     !ambulance.refillingTarget &&
     !ambulance.path // Not currently moving
   )

--- a/src/ai/enemyUnitBehavior.js
+++ b/src/ai/enemyUnitBehavior.js
@@ -41,8 +41,8 @@ function updateAIUnit(unit, units, gameState, mapGrid, now, aiPlayerId, _targete
   // Skip further processing if unit is retreating
   if (unit.isRetreating) return
 
-  // PRIORITY: Check crew status and handle hospital returns (exclude ambulance and rocket tank for AI)
-  if (unit.crew && typeof unit.crew === 'object' && unit.type !== 'ambulance' && unit.type !== 'rocketTank') {
+  // PRIORITY: Check crew status and handle hospital returns (exclude ambulance for AI)
+  if (unit.crew && typeof unit.crew === 'object' && unit.type !== 'ambulance') {
     const missingCrew = Object.values(unit.crew).filter(alive => !alive).length
     
     if (missingCrew > 0 && !unit.returningToHospital) {
@@ -774,9 +774,9 @@ function updateAmbulanceAI(unit, units, gameState, mapGrid, now, aiPlayerId) {
   )
   
   if (unitsNeedingHealing.length > 0) {
-    // Prioritize units that cannot move (excluding ambulance and rocket tank which don't use crew system)
-    const immobileUnits = unitsNeedingHealing.filter(u => 
-      u.crew && (u.type !== 'ambulance' && u.type !== 'rocketTank') && (!u.crew.driver || !u.crew.commander)
+    // Prioritize units that cannot move (excluding ambulance which doesn't use the crew system)
+    const immobileUnits = unitsNeedingHealing.filter(u =>
+      u.crew && u.type !== 'ambulance' && (!u.crew.driver || !u.crew.commander)
     )
     const targetUnit = immobileUnits.length > 0 ? immobileUnits[0] : unitsNeedingHealing[0]
     

--- a/src/config.js
+++ b/src/config.js
@@ -252,8 +252,8 @@ export const UNIT_PROPERTIES = {
     streetSpeedMultiplier: 4.0,
     rotationSpeed: TANK_WAGON_ROT,
     turretRotationSpeed: 0,
-    maxCrew: 10,
-    crew: 10 // Initial crew capacity
+    maxMedics: 10,
+    medics: 10 // Initial crew capacity
   },
   tankerTruck: {
     health: 20,

--- a/src/game/ambulanceSystem.js
+++ b/src/game/ambulanceSystem.js
@@ -46,7 +46,7 @@ export const updateAmbulanceLogic = logPerformance(function(units, gameState, de
       }
 
       // Check if ambulance has crew to give
-      if (!ambulance.crew || ambulance.crew <= 0) {
+      if (!ambulance.medics || ambulance.medics <= 0) {
         ambulance.healingTarget = null
         ambulance.healingTimer = 0
         return
@@ -56,7 +56,7 @@ export const updateAmbulanceLogic = logPerformance(function(units, gameState, de
       ambulance.healingTimer = (ambulance.healingTimer || 0) + delta
       const healingInterval = 2000 // 2 seconds per crew member
 
-      while (missingCrew.length > 0 && ambulance.healingTimer >= healingInterval && ambulance.crew > 0) {
+      while (missingCrew.length > 0 && ambulance.healingTimer >= healingInterval && ambulance.medics > 0) {
         const [role] = missingCrew.shift()
         
         // Heal in order: driver, commander, loader, gunner
@@ -72,7 +72,7 @@ export const updateAmbulanceLogic = logPerformance(function(units, gameState, de
         }
         
         if (healedRole) {
-          ambulance.crew -= 1
+          ambulance.medics -= 1
           ambulance.healingTimer -= healingInterval
           
           // Play sound effect
@@ -96,7 +96,7 @@ export function canAmbulanceHealUnit(ambulance, targetUnit) {
   }
 
   // Check if ambulance has crew to give
-  if (!ambulance.crew || ambulance.crew <= 0) {
+  if (!ambulance.medics || ambulance.medics <= 0) {
     return false
   }
 

--- a/src/game/hospitalLogic.js
+++ b/src/game/hospitalLogic.js
@@ -8,8 +8,8 @@ export const updateHospitalLogic = logPerformance(function(units, buildings, gam
     const healRow = hospital.y + hospital.height
     units.forEach(unit=>{
       if(!unit.crew) return
-      // Skip ambulances and rocket tanks for AI players as they don't use crew system
-      if((unit.owner !== gameState.humanPlayer) && (unit.type === 'ambulance' || unit.type === 'rocketTank')) return
+      // Skip ambulances for AI players as they don't use the crew system
+      if((unit.owner !== gameState.humanPlayer) && (unit.type === 'ambulance')) return
       if(unit.tileY===healRow && unit.tileX>=hospital.x && unit.tileX<hospital.x+hospital.width){
         unit.healTimer = (unit.healTimer||0)+delta
         const missing = Object.entries(unit.crew).filter(([_,alive])=>!alive)

--- a/src/game/unifiedMovement.js
+++ b/src/game/unifiedMovement.js
@@ -101,8 +101,8 @@ export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [],
     }
   }
 
-  // **CREW MOVEMENT RESTRICTIONS** - Check crew status for tanks (exclude ambulance and rocket tank for AI)
-  if (unit.crew && typeof unit.crew === 'object' && !unit.crew.driver && unit.type !== 'ambulance' && unit.type !== 'rocketTank') {
+  // **CREW MOVEMENT RESTRICTIONS** - Check crew status (exclude ambulance for AI)
+  if (unit.crew && typeof unit.crew === 'object' && !unit.crew.driver && unit.type !== 'ambulance') {
     // Tank cannot move without driver
     unit.path = [] // Clear any pending movement
     unit.moveTarget = null

--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -124,8 +124,8 @@ export class CursorManager {
       const hasSelectedHarvesters = selectedUnits.some(unit => unit.type === 'harvester')
       // Check for ambulance healing
       const hasSelectedAmbulances = selectedUnits.some(unit => unit.type === 'ambulance')
-      const hasSelectedFullyLoadedAmbulances = selectedUnits.some(unit => unit.type === 'ambulance' && unit.crew >= 4)
-      const hasSelectedNotFullyLoadedAmbulances = selectedUnits.some(unit => unit.type === 'ambulance' && unit.crew < 4)
+      const hasSelectedFullyLoadedAmbulances = selectedUnits.some(unit => unit.type === 'ambulance' && unit.medics >= 4)
+      const hasSelectedNotFullyLoadedAmbulances = selectedUnits.some(unit => unit.type === 'ambulance' && unit.medics < 4)
       // Check for recovery tank interactions
       const hasSelectedRecoveryTanks = selectedUnits.some(unit => unit.type === 'recoveryTank')
       const hasSelectedDamagedUnits = selectedUnits.some(unit => unit.health < unit.maxHealth)

--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -772,7 +772,7 @@ export class MouseHandler {
       }
 
       // Check for ambulance healing command if ambulances are selected
-      const hasSelectedAmbulances = commandableUnits.some(unit => unit.type === 'ambulance' && unit.crew > 0)
+      const hasSelectedAmbulances = commandableUnits.some(unit => unit.type === 'ambulance' && unit.medics > 0)
       
       if (hasSelectedAmbulances) {
         // Check if clicking on a friendly unit that needs healing
@@ -852,7 +852,7 @@ export class MouseHandler {
       }
 
       // Check for ambulance refilling command if ambulances are selected
-      const hasSelectedNotFullyLoadedAmbulances = commandableUnits.some(unit => unit.type === 'ambulance' && unit.crew < 4)
+      const hasSelectedNotFullyLoadedAmbulances = commandableUnits.some(unit => unit.type === 'ambulance' && unit.medics < 4)
       
       if (hasSelectedNotFullyLoadedAmbulances) {
         // Check if clicking on a player hospital
@@ -1005,7 +1005,7 @@ export class MouseHandler {
         }
         
         // Check for hospital if ambulances that need refilling are selected
-      const hasNotFullyLoadedAmbulances = commandableUnits.some(unit => unit.type === 'ambulance' && unit.crew < 4)
+      const hasNotFullyLoadedAmbulances = commandableUnits.some(unit => unit.type === 'ambulance' && unit.medics < 4)
         if (hasNotFullyLoadedAmbulances) {
           for (const building of gameState.buildings) {
             if (building.type === 'hospital' && building.owner === gameState.humanPlayer && building.health > 0 &&

--- a/src/input/unitCommands.js
+++ b/src/input/unitCommands.js
@@ -421,8 +421,8 @@ export class UnitCommandsHandler {
 
   handleAmbulanceHealCommand(selectedUnits, targetUnit, mapGrid) {
     // Filter for ambulances that can heal
-    const ambulances = selectedUnits.filter(unit => 
-      unit.type === 'ambulance' && unit.crew > 0
+    const ambulances = selectedUnits.filter(unit =>
+      unit.type === 'ambulance' && unit.medics > 0
     )
 
     if (ambulances.length === 0) {
@@ -523,8 +523,8 @@ export class UnitCommandsHandler {
 
   handleAmbulanceRefillCommand(selectedUnits, hospital, mapGrid) {
     // Filter for ambulances that need refilling
-    const ambulances = selectedUnits.filter(unit => 
-      unit.type === 'ambulance' && unit.crew < 4
+    const ambulances = selectedUnits.filter(unit =>
+      unit.type === 'ambulance' && unit.medics < 4
     )
 
     if (ambulances.length === 0) {

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -265,7 +265,7 @@ export class UnitRenderer {
     } else if (unit.type === 'ambulance') {
       // Ambulance crew loading bar
       shouldShowBar = true
-      progress = (unit.crew || 0) / (unit.maxCrew || 10)
+      progress = (unit.medics || 0) / (unit.maxMedics || 10)
       barColor = '#00FFFF' // Cyan for ambulance crew
     } else if (unit.type === 'tankerTruck') {
       shouldShowBar = true

--- a/src/units.js
+++ b/src/units.js
@@ -685,15 +685,24 @@ export function createUnit(factory, unitType, x, y) {
   }
 
   // Add unit-specific properties
-  if (actualType.startsWith('tank')) {
-    unit.crew = { driver: true, gunner: true, loader: true, commander: true };
+  const fullCrewTanks = ['tank_v1', 'tank-v2', 'tank-v3']
+  const loaderUnits = ['tankerTruck', 'ambulance', 'recoveryTank', 'harvester', 'rocketTank']
+
+  unit.crew = { driver: true, commander: true }
+
+  if (fullCrewTanks.includes(actualType)) {
+    unit.crew.gunner = true
+    unit.crew.loader = true
+  } else if (loaderUnits.includes(actualType)) {
+    unit.crew.loader = true
   }
+
   if (actualType === 'ambulance') {
-    unit.crew = unitProps.crew || 10;
-    unit.maxCrew = unitProps.maxCrew || 10;
+    unit.medics = unitProps.medics || 10
+    unit.maxMedics = unitProps.maxMedics || 10
     unit.ambulanceProps = {
       streetSpeedMultiplier: unitProps.streetSpeedMultiplier || 6.0
-    };
+    }
   }
   if (actualType === 'tankerTruck') {
     unit.maxSupplyGas = TANKER_SUPPLY_CAPACITY;


### PR DESCRIPTION
## Summary
- add medic capacity config for ambulance
- give most units only driver and commander
- add loader to select non-tank units
- stop excluding rocket tanks from AI crew logic
- refactor ambulance scripts to use `medics` count

## Testing
- `npm run lint` *(fails: trailing spaces and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_6881954c68408328883e032af6c5b50c