### PR TITLE
Add E key focus functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Develop a fully functional, minimal viable product (MVP) of a real-time strategy
 - **6.3.5** The selection (bounding box drag) does not trigger movement commands by itself.
 - **6.3.6** Mouse cursor changes indicate valid move or attack targets.
 - **6.3.7** Hold the **Ctrl** key while a combat unit is selected to enable self‑attack. The cursor changes immediately, and clicking will target your own units or buildings.
+- **6.3.8** Press **E key** to center the view on the currently selected unit(s).
 
 ### 6.4 Start/Pause and Restart Controls
 

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -118,6 +118,11 @@ export class KeyboardHandler {
         e.preventDefault()
         this.handleFactoryFocus(mapGrid)
       }
+      // E key to focus on selected unit(s)
+      else if (e.key.toLowerCase() === 'e') {
+        e.preventDefault()
+        this.handleSelectedUnitFocus(selectedUnits, mapGrid)
+      }
       // Control group assignment (ctrl+number)
       else if (e.ctrlKey && e.key >= '1' && e.key <= '9') {
         e.preventDefault()
@@ -570,6 +575,42 @@ export class KeyboardHandler {
         mapGrid.length * TILE_SIZE - gameCanvas.height))
       playSound('unitSelection')
     }
+  }
+
+  handleSelectedUnitFocus(selectedUnits, mapGrid) {
+    if (!selectedUnits || selectedUnits.length === 0) return
+
+    const gameCanvas = document.getElementById('gameCanvas')
+
+    // Get device pixel ratio to account for Retina displays
+    const pixelRatio = window.devicePixelRatio || 1
+
+    // Calculate logical canvas dimensions
+    const logicalCanvasWidth = gameCanvas.width / pixelRatio
+    const logicalCanvasHeight = gameCanvas.height / pixelRatio
+
+    let focusX, focusY
+
+    if (selectedUnits.length === 1) {
+      focusX = selectedUnits[0].x
+      focusY = selectedUnits[0].y
+    } else {
+      // Average position of all selected units
+      focusX = selectedUnits.reduce((sum, u) => sum + u.x, 0) / selectedUnits.length
+      focusY = selectedUnits.reduce((sum, u) => sum + u.y, 0) / selectedUnits.length
+    }
+
+    gameState.scrollOffset.x = Math.max(0, Math.min(
+      focusX - logicalCanvasWidth / 2,
+      mapGrid[0].length * TILE_SIZE - logicalCanvasWidth
+    ))
+
+    gameState.scrollOffset.y = Math.max(0, Math.min(
+      focusY - logicalCanvasHeight / 2,
+      mapGrid.length * TILE_SIZE - logicalCanvasHeight
+    ))
+
+    playSound('confirmed')
   }
 
   handleControlGroupAssignment(groupNum, selectedUnits) {


### PR DESCRIPTION
## Summary
- allow centering on currently selected units with **E** key
- document the new E key shortcut in the README

## Testing
- `npm run lint` *(fails: 3034 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68821ee0bc908328b52d45c181344318