### PR TITLE
Fix self occupancy blocking

### DIFF
--- a/src/game/remoteControl.js
+++ b/src/game/remoteControl.js
@@ -95,10 +95,13 @@ export function updateRemoteControlledUnits(units, bullets, mapGrid, occupancyMa
       const checkY = unit.y + TILE_SIZE / 2 + fy * checkDistance * directionSign
       const nextTileX = Math.floor(checkX / TILE_SIZE)
       const nextTileY = Math.floor(checkY / TILE_SIZE)
+      const currentTileX = Math.floor((unit.x + TILE_SIZE / 2) / TILE_SIZE)
+      const currentTileY = Math.floor((unit.y + TILE_SIZE / 2) / TILE_SIZE)
       const occupied =
         occupancyMap &&
         occupancyMap[nextTileY] &&
-        occupancyMap[nextTileY][nextTileX]
+        occupancyMap[nextTileY][nextTileX] &&
+        !(nextTileX === currentTileX && nextTileY === currentTileY)
 
       if (!occupied) {
         unit.movement.targetVelocity.x = fx * effectiveMaxSpeed * directionSign

--- a/src/units.js
+++ b/src/units.js
@@ -256,7 +256,10 @@ export const findPath = logPerformance(function findPath(start, end, mapGrid, oc
   const destType = destTile.type
   const destHasBuilding = destTile.building
   const destSeedCrystal = destTile.seedCrystal
-  const destOccupied = occupancyMap && occupancyMap[adjustedEnd.y][adjustedEnd.x]
+  const destOccupied =
+    occupancyMap &&
+    !(adjustedEnd.x === start.x && adjustedEnd.y === start.y) &&
+    occupancyMap[adjustedEnd.y][adjustedEnd.x]
   if (
     destType === 'water' ||
     destType === 'rock' ||
@@ -340,8 +343,14 @@ export const findPath = logPerformance(function findPath(start, end, mapGrid, oc
     for (const neighbor of neighbors) {
       const neighborKey = `${neighbor.x},${neighbor.y}`
       if (closedSet.has(neighborKey)) continue
-      // Skip if occupancyMap is provided and the tile is occupied.
-      if (occupancyMap && occupancyMap[neighbor.y][neighbor.x]) continue
+      // Skip if occupancyMap is provided and the tile is occupied,
+      // except when the tile is the starting tile for this path.
+      if (
+        occupancyMap &&
+        !(neighbor.x === start.x && neighbor.y === start.y) &&
+        occupancyMap[neighbor.y][neighbor.x]
+      )
+        continue
 
       const baseCost = Math.hypot(neighbor.x - currentNode.x, neighbor.y - currentNode.y)
       const tileType = mapGrid[neighbor.y][neighbor.x].type


### PR DESCRIPTION
## Summary
- allow pathfinder to treat the unit's own tile as free
- ignore self tile when checking occupancy for remote control

## Testing
- `npm run lint` *(fails: 3034 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688229ed05948328ab71fd48efb39faa