### PR TITLE
Implement camera follow toggle

### DIFF
--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -343,3 +343,33 @@ export function handleRightClickDeselect(gameState, units) {
     gameState.rightClick = false // reset flag after processing
   }
 }
+
+/**
+ * Keeps the camera centered on a followed unit if set.
+ * Automatically clears follow mode when the unit is deselected or destroyed.
+ * @param {Object} gameState - Game state object
+ * @param {Array} units - Array of unit objects
+ * @param {Array} mapGrid - 2D array representing the map
+ */
+export function updateCameraFollow(gameState, units, mapGrid) {
+  if (!gameState.cameraFollowUnitId) return
+
+  const followUnit = units.find(u => u.id === gameState.cameraFollowUnitId)
+  if (!followUnit || !followUnit.selected) {
+    gameState.cameraFollowUnitId = null
+    return
+  }
+
+  const gameCanvas = document.getElementById('gameCanvas')
+  if (!gameCanvas) return
+  const pixelRatio = window.devicePixelRatio || 1
+  const logicalWidth = gameCanvas.width / pixelRatio
+  const logicalHeight = gameCanvas.height / pixelRatio
+
+  const maxScrollX = mapGrid[0].length * TILE_SIZE - logicalWidth
+  const maxScrollY = mapGrid.length * TILE_SIZE - logicalHeight
+
+  gameState.scrollOffset.x = Math.max(0, Math.min(followUnit.x - logicalWidth / 2, maxScrollX))
+  gameState.scrollOffset.y = Math.max(0, Math.min(followUnit.y - logicalHeight / 2, maxScrollY))
+  gameState.dragVelocity = { x: 0, y: 0 }
+}

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -19,6 +19,8 @@ export const gameState = {
   totalMoneyEarned: 0,
   scrollOffset: { x: 0, y: 0 },
   dragVelocity: { x: 0, y: 0 },
+  // ID of the unit the camera should follow when auto-focus is enabled
+  cameraFollowUnitId: null,
   isRightDragging: false,
   lastDragPos: { x: 0, y: 0 },
   enemyLastProductionTime: performance.now(),

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -121,7 +121,11 @@ export class KeyboardHandler {
       // E key to focus on selected unit(s)
       else if (e.key.toLowerCase() === 'e') {
         e.preventDefault()
-        this.handleSelectedUnitFocus(selectedUnits, mapGrid)
+        if (e.shiftKey || gameState.shiftKeyDown) {
+          this.toggleAutoFocus(selectedUnits, mapGrid)
+        } else {
+          this.handleSelectedUnitFocus(selectedUnits, mapGrid)
+        }
       }
       // Control group assignment (ctrl+number)
       else if (e.ctrlKey && e.key >= '1' && e.key <= '9') {
@@ -614,6 +618,24 @@ export class KeyboardHandler {
     gameState.dragVelocity = { x: 0, y: 0 }
 
     playSound('confirmed')
+  }
+
+  toggleAutoFocus(selectedUnits, mapGrid) {
+    if (
+      gameState.cameraFollowUnitId &&
+      selectedUnits.length === 1 &&
+      selectedUnits[0].id === gameState.cameraFollowUnitId
+    ) {
+      gameState.cameraFollowUnitId = null
+      return
+    }
+
+    if (selectedUnits.length === 1) {
+      gameState.cameraFollowUnitId = selectedUnits[0].id
+      this.handleSelectedUnitFocus(selectedUnits, mapGrid)
+    } else {
+      gameState.cameraFollowUnitId = null
+    }
   }
 
   handleControlGroupAssignment(groupNum, selectedUnits) {

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -31,6 +31,7 @@ import { cleanupSoundCooldowns } from './game/soundCooldownManager.js'
 import { processCommandQueues } from './game/commandQueue.js'
 import { 
   updateMapScrolling,
+  updateCameraFollow,
   updateOreSpread,
   updateExplosions,
   updateSmokeParticles,
@@ -67,6 +68,8 @@ export const updateGame = logPerformance(function updateGame(delta, mapGrid, fac
 
     // Map scrolling with inertia
     updateMapScrolling(gameState, mapGrid)
+    // Keep camera focused on followed unit when enabled
+    updateCameraFollow(gameState, units, mapGrid)
 
     // Process queued unit commands before running unit systems
     const unitCommands = getUnitCommandsHandler()


### PR DESCRIPTION
## Summary
- add `cameraFollowUnitId` field to `gameState`
- keep the camera locked to a unit with `updateCameraFollow`
- invoke auto follow from `updateGame`
- toggle follow with Shift+E in `KeyboardHandler`

## Testing
- `npm run lint` *(fails: 3034 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68822e0b59e883288d8c1f86b998e26a