### PR TITLE
Add fuel cheat code

### DIFF
--- a/CHEAT_SYSTEM_README.md
+++ b/CHEAT_SYSTEM_README.md
@@ -23,8 +23,8 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 - **Function**: Sets the health of all currently selected units. Append `%` to use a percentage of each unit's max HP
 
 ### ⛽ Fuel Command
-- **Command**: `fuel [amount]`
-- **Function**: Sets the fuel level of the currently selected unit. The value is clamped between `0` and the unit's maximum tank capacity.
+- **Command**: `fuel [amount|percent%]`
+- **Function**: Sets the fuel level of the currently selected unit. Use a plain number for an absolute value or append `%` to set a percentage of the unit's maximum fuel. The applied value is clamped between `0` and the unit's capacity.
 
 ### 🎮 Enemy Control
 - **Command**: `enemycontrol on` / `enemycontrol off`
@@ -68,6 +68,9 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 
 > fuel 100
 ⛽ Fuel set to 100 for 1 unit
+
+> fuel 50%
+⛽ Fuel set to 50% for 1 unit
 
 > status
 💰 Money: $35,000


### PR DESCRIPTION
## Summary
- support `fuel [amount]` cheat code via the cheat dialog
- update cheat code help text and documentation

## Testing
- `npm run lint` *(fails: Trailing spaces not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6882575160b8832883e79f0111d0f447