### PR TITLE
Add crew toggle cheat codes

### DIFF
--- a/CHEAT_SYSTEM_README.md
+++ b/CHEAT_SYSTEM_README.md
@@ -22,6 +22,10 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 - **Command**: `enemycontrol on` / `enemycontrol off`
 - **Function**: Allows selecting and issuing commands to enemy units
 
+### 👥 Crew Toggle Commands
+- **Commands**: `driver`, `commander`, `loader`, `gunner`
+- **Function**: Toggles the specified crew member for all selected units
+
 ### 📊 Status Command
 - **Command**: `status`
 - **Function**: Shows current game state including:

--- a/src/input/cheatSystem.js
+++ b/src/input/cheatSystem.js
@@ -193,6 +193,7 @@ export class CheatSystem {
           <li><code>money [amount]</code> - Set money to specific amount</li>
           <li><code>status</code> - Show current cheat status</li>
           <li><code>enemycontrol on</code> / <code>enemycontrol off</code> - Toggle enemy unit control</li>
+          <li><code>driver</code> / <code>commander</code> / <code>loader</code> / <code>gunner</code> - Toggle crew for selected unit</li>
         </ul>
       </div>
     `
@@ -305,6 +306,10 @@ export class CheatSystem {
         this.enableEnemyControl()
       } else if (normalizedCode === 'enemycontrol off') {
         this.disableEnemyControl()
+      }
+      // Crew toggle commands
+      else if (['driver', 'commander', 'loader', 'gunner'].includes(normalizedCode)) {
+        this.toggleCrewMember(normalizedCode)
       }
       // Status command
       else if (normalizedCode === 'status') {
@@ -511,5 +516,34 @@ export class CheatSystem {
       }
       unit.isInvincible = true
     }
+  }
+
+  toggleCrewMember(role) {
+    let selected = []
+    try {
+      if (typeof window !== 'undefined' && window.debugGetSelectedUnits) {
+        selected = window.debugGetSelectedUnits()
+      }
+    } catch (e) {
+      selected = []
+    }
+
+    if (!selected || selected.length === 0) {
+      this.showError('No unit selected')
+      return
+    }
+
+    selected.forEach(unit => {
+      if (unit.crew && typeof unit.crew === 'object' && role in unit.crew) {
+        unit.crew[role] = !unit.crew[role]
+
+        if (!unit.crew[role] && unit.owner === gameState.humanPlayer) {
+          playSound('our' + role.charAt(0).toUpperCase() + role.slice(1) + 'IsOut')
+        }
+
+        const state = unit.crew[role] ? 'restored' : 'removed'
+        showNotification(`${role} ${state}`, 2000)
+      }
+    })
   }
 }


### PR DESCRIPTION
## Summary
- allow toggling individual crew members using new cheat codes
- document the crew toggle commands in the cheat system readme

## Testing
- `npm run lint` *(fails: 3032 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688256f0a10883289cb7ae3bfd91d541