### PR TITLE
Add HP cheat command

### DIFF
--- a/CHEAT_SYSTEM_README.md
+++ b/CHEAT_SYSTEM_README.md
@@ -19,8 +19,8 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
   - `money 50000` - Sets money to $50,000
 
 ### ❤️ HP Command
-- **Command**: `hp [amount]`
-- **Function**: Sets the health of all currently selected units
+- **Command**: `hp [amount]` or `hp [amount]%`
+- **Function**: Sets the health of all currently selected units. Append `%` to use a percentage of each unit's max HP
 
 ### 🎮 Enemy Control
 - **Command**: `enemycontrol on` / `enemycontrol off`
@@ -55,8 +55,8 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 > give 25000
 💰 Added $25,000 (Total: $35,000)
 
-> hp 100
-❤ Set HP to 100 for 1 unit(s)
+> hp 75%
+❤ Set HP to 75% for 1 unit(s)
 
 > status
 💰 Money: $35,000

--- a/CHEAT_SYSTEM_README.md
+++ b/CHEAT_SYSTEM_README.md
@@ -18,6 +18,10 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
   - `give 10000` - Adds $10,000
   - `money 50000` - Sets money to $50,000
 
+### ❤️ HP Command
+- **Command**: `hp [amount]`
+- **Function**: Sets the health of all currently selected units
+
 ### 🎮 Enemy Control
 - **Command**: `enemycontrol on` / `enemycontrol off`
 - **Function**: Allows selecting and issuing commands to enemy units
@@ -50,6 +54,9 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 
 > give 25000
 💰 Added $25,000 (Total: $35,000)
+
+> hp 100
+❤ Set HP to 100 for 1 unit(s)
 
 > status
 💰 Money: $35,000

--- a/src/input/cheatSystem.js
+++ b/src/input/cheatSystem.js
@@ -193,7 +193,7 @@ export class CheatSystem {
           <li><code>godmode on</code> / <code>godmode off</code> - Toggle invincibility for all units</li>
           <li><code>give [amount]</code> - Add money (e.g., <code>give 10000</code>)</li>
           <li><code>money [amount]</code> - Set money to specific amount</li>
-          <li><code>hp [amount]</code> - Set HP of selected unit(s)</li>
+          <li><code>hp [amount]</code> or <code>hp [amount]%</code> - Set HP of selected unit(s)</li>
           <li><code>status</code> - Show current cheat status</li>
           <li><code>enemycontrol on</code> / <code>enemycontrol off</code> - Toggle enemy unit control</li>
         </ul>
@@ -303,11 +303,17 @@ export class CheatSystem {
           this.showError('Invalid amount. Use: money [number]')
         }
       } else if (normalizedCode.startsWith('hp ')) {
-        const amount = this.parseAmount(normalizedCode.substring(3))
+        let raw = normalizedCode.substring(3).trim()
+        let isPercent = false
+        if (raw.endsWith('%')) {
+          isPercent = true
+          raw = raw.slice(0, -1)
+        }
+        const amount = this.parseAmount(raw)
         if (amount !== null) {
-          this.setSelectedUnitsHP(amount)
+          this.setSelectedUnitsHP(amount, isPercent)
         } else {
-          this.showError('Invalid amount. Use: hp [number]')
+          this.showError('Invalid amount. Use: hp [number] or hp [number]%')
         }
       }
       // Enemy control command
@@ -447,7 +453,7 @@ export class CheatSystem {
     this.selectedUnits = selectedUnits
   }
 
-  setSelectedUnitsHP(amount) {
+  setSelectedUnitsHP(amount, isPercent = false) {
     if (!this.selectedUnits || this.selectedUnits.length === 0) {
       this.showError('No unit selected')
       return
@@ -456,14 +462,19 @@ export class CheatSystem {
     let appliedCount = 0
     this.selectedUnits.forEach(unit => {
       if (!unit || unit.maxHealth === undefined) return
-      const clamped = Math.min(Math.max(amount, 0), unit.maxHealth)
+      let newHp = amount
+      if (isPercent) {
+        newHp = Math.round(unit.maxHealth * (amount / 100))
+      }
+      const clamped = Math.min(Math.max(newHp, 0), unit.maxHealth)
       unit.health = clamped
       updateUnitSpeedModifier(unit)
       appliedCount++
     })
 
     if (appliedCount > 0) {
-      showNotification(`❤ Set HP to ${amount} for ${appliedCount} unit(s)`, 3000)
+      const label = isPercent ? `${amount}%` : `${amount}`
+      showNotification(`❤ Set HP to ${label} for ${appliedCount} unit(s)`, 3000)
     }
   }
 

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -35,6 +35,7 @@ export class KeyboardHandler {
   setupKeyboardEvents(units, selectedUnits, mapGrid, factories) {
     // Store references for use in other methods
     this.selectedUnits = selectedUnits
+    this.cheatSystem.setSelectedUnitsRef(selectedUnits)
     this.units = units
     this.mapGrid = mapGrid
     this.factories = factories


### PR DESCRIPTION
## Summary
- support `hp <amount>` cheat code for setting selected unit HP
- wire up cheat system to selected units
- document HP command in cheat console help and readme

## Testing
- `npm run lint` *(fails: 3031 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688257c1f0288328ad3893332db9e9b6