### PR TITLE
Add gas tank to recovery tank

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -347,6 +347,7 @@ export const UNIT_GAS_PROPERTIES = {
   'tank-v2': { tankSize: 1900, consumption: 450 },
   'tank-v3': { tankSize: 1900, consumption: 450 },
   rocketTank: { tankSize: 1900, consumption: 450 },
+  recoveryTank: { tankSize: 1900, consumption: 450 },
   harvester: { tankSize: 2650, consumption: 30, harvestConsumption: 100 },
   ambulance: { tankSize: 75, consumption: 25 },
   tankerTruck: { tankSize: 700, consumption: 150 }

--- a/src/config.js
+++ b/src/config.js
@@ -347,6 +347,7 @@ export const UNIT_GAS_PROPERTIES = {
   'tank-v2': { tankSize: 1900, consumption: 450 },
   'tank-v3': { tankSize: 1900, consumption: 450 },
   rocketTank: { tankSize: 1900, consumption: 450 },
+  // Recovery tanks consume the same fuel as standard tanks
   recoveryTank: { tankSize: 1900, consumption: 450 },
   harvester: { tankSize: 2650, consumption: 30, harvestConsumption: 100 },
   ambulance: { tankSize: 75, consumption: 25 },


### PR DESCRIPTION
## Summary
- add recovery tank to `UNIT_GAS_PROPERTIES` so it has a gas tank and consumption

## Testing
- `npm run lint` *(fails: 3031 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68825907a8c483289b10047e348910b5