### PR TITLE
Add animated water tiles

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -57,7 +57,7 @@ export const TILE_IMAGES = {
     useGrassTileDiscovery: true
   },
   water: {
-    paths: ['images/map/water01']
+    animated: true
   },
   rock: {
     paths: ['images/map/rock_on_grass01', 'images/map/rock01', 'images/map/rock02', 'images/map/rock03', 'images/map/rock04', 'images/map/rock05']

--- a/src/rendering/mapRenderer.js
+++ b/src/rendering/mapRenderer.js
@@ -17,6 +17,14 @@ export class MapRenderer {
       const screenX = Math.floor(x * TILE_SIZE - scrollOffset.x)
       const screenY = Math.floor(y * TILE_SIZE - scrollOffset.y)
 
+      if (type === 'water' && this.textureManager.waterFrames.length) {
+        const frame = this.textureManager.getCurrentWaterFrame()
+        if (frame) {
+          ctx.drawImage(frame, screenX, screenY, TILE_SIZE + 1, TILE_SIZE + 1)
+          return
+        }
+      }
+
       if (useTexture && this.textureManager.tileTextureCache[type]) {
         const idx = this.textureManager.getTileVariation(type, x, y)
         if (idx >= 0 && idx < this.textureManager.tileTextureCache[type].length) {
@@ -200,7 +208,15 @@ export class MapRenderer {
     ctx.closePath()
     ctx.clip()
 
-    if (useTexture) {
+    if (type === 'water' && this.textureManager.waterFrames.length) {
+      const frame = this.textureManager.getCurrentWaterFrame()
+      if (frame) {
+        ctx.drawImage(frame, screenX, screenY, size, size)
+      } else {
+        ctx.fillStyle = TILE_COLORS[type]
+        ctx.fill()
+      }
+    } else if (useTexture) {
       const idx = this.textureManager.getTileVariation(type, tileX, tileY)
       if (idx >= 0 && idx < this.textureManager.tileTextureCache[type].length) {
         const info = this.textureManager.tileTextureCache[type][idx]


### PR DESCRIPTION
## Summary
- add water animation using `water_spritesheet.png`
- update map renderer to draw animated water frames
- remove old static water image path

## Testing
- `npm run lint` *(fails: 3030 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68825b258f4c83288837ac16c8da1141