### PR TITLE
Make lower sidebar scrollable

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,8 @@
           <span class="button-icon music-icon">♪</span>
         </button>
       </div>
+
+      <div id="sidebarScroll">
       
       <div id="production">
         <div id="productionContainer">
@@ -340,9 +342,10 @@
             <span id="volumeValue" class="volume-value">50%</span>
           </label>
         </div>
+        </div>
       </div>
-    </div>
-    <canvas id="gameCanvas"></canvas>
+      </div>
+      <canvas id="gameCanvas"></canvas>
     
     <!-- FPS Display Overlay -->
     <div id="fpsDisplay" class="fps-overlay">

--- a/style.css
+++ b/style.css
@@ -30,13 +30,18 @@ html, body {
   color: #fff;
   padding: 10px;
   box-sizing: border-box;
-  overflow-y: scroll;
-  overflow-x: hidden; /* Ensure no horizontal scrollbar */
+  overflow: hidden;
   font-family: sans-serif;
   display: flex;
   flex-direction: column;
   scrollbar-width: none; /* Hide scrollbar for Firefox */
   -ms-overflow-style: none; /* Hide scrollbar for IE and Edge */
+}
+
+#sidebarScroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .sidebar-input {
@@ -53,6 +58,10 @@ html, body {
 
 /* Hide scrollbar for Chrome, Safari and Opera */
 #sidebar::-webkit-scrollbar {
+  display: none;
+}
+
+#sidebarScroll::-webkit-scrollbar {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- wrap sidebar content after the action buttons in a new `sidebarScroll` container
- make the top of the sidebar static and apply scrolling to the new container

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882625cea888328ab0a1826ff082f37