### PR TITLE
Enforce loader requirement for support units

### DIFF
--- a/src/game/ambulanceSystem.js
+++ b/src/game/ambulanceSystem.js
@@ -8,6 +8,12 @@ export const updateAmbulanceLogic = logPerformance(function(units, gameState, de
   if (ambulances.length === 0) return
 
   ambulances.forEach(ambulance => {
+    // Ambulances require a loader to tend to wounded units
+    if (ambulance.crew && typeof ambulance.crew === 'object' && !ambulance.crew.loader) {
+      ambulance.healingTarget = null
+      ambulance.healingTimer = 0
+      return
+    }
     // Handle ambulance healing target
     if (ambulance.healingTarget) {
       const target = ambulance.healingTarget
@@ -84,6 +90,9 @@ export const updateAmbulanceLogic = logPerformance(function(units, gameState, de
 })
 
 export function canAmbulanceHealUnit(ambulance, targetUnit) {
+  if (ambulance.crew && typeof ambulance.crew === 'object' && !ambulance.crew.loader) {
+    return false
+  }
   // Check if target has crew system
   if (!targetUnit.crew || typeof targetUnit.crew !== 'object') {
     return false
@@ -104,6 +113,9 @@ export function canAmbulanceHealUnit(ambulance, targetUnit) {
 }
 
 export function assignAmbulanceToHealUnit(ambulance, targetUnit) {
+  if (ambulance.crew && typeof ambulance.crew === 'object' && !ambulance.crew.loader) {
+    return false
+  }
   if (!canAmbulanceHealUnit(ambulance, targetUnit)) {
     return false
   }

--- a/src/game/recoveryTankSystem.js
+++ b/src/game/recoveryTankSystem.js
@@ -25,6 +25,14 @@ export const updateRecoveryTankLogic = logPerformance(function(units, gameState,
       tank.speed = unitProps
     }
 
+    const hasLoader = !(tank.crew && typeof tank.crew === 'object' && !tank.crew.loader)
+    if (!hasLoader) {
+      tank.repairTarget = null
+      tank.repairData = null
+      tank.repairStarted = false
+      return
+    }
+
     // Auto-repair logic - find nearby damaged units
     if (!tank.repairTarget) {
       const target = units.find(u =>

--- a/src/game/tankerTruckLogic.js
+++ b/src/game/tankerTruckLogic.js
@@ -10,6 +10,13 @@ export const updateTankerTruckLogic = logPerformance(function(units, gameState, 
   handleEmergencyFuelRequests(tankers, units, gameState)
 
   tankers.forEach(tanker => {
+    // Tankers need a loader to operate the refueling equipment
+    if (tanker.crew && typeof tanker.crew === 'object' && !tanker.crew.loader) {
+      tanker.refuelTarget = null
+      tanker.emergencyTarget = null
+      tanker.refuelTimer = 0
+      return
+    }
     // Ensure tanker has proper gas properties initialized
     if (tanker.supplyGas === undefined || tanker.maxSupplyGas === undefined) {
       tanker.maxSupplyGas = TANKER_SUPPLY_CAPACITY

--- a/src/input/unitCommands.js
+++ b/src/input/unitCommands.js
@@ -422,7 +422,8 @@ export class UnitCommandsHandler {
   handleAmbulanceHealCommand(selectedUnits, targetUnit, mapGrid) {
     // Filter for ambulances that can heal
     const ambulances = selectedUnits.filter(unit =>
-      unit.type === 'ambulance' && unit.medics > 0
+      unit.type === 'ambulance' && unit.medics > 0 &&
+      (!unit.crew || unit.crew.loader)
     )
 
     if (ambulances.length === 0) {
@@ -490,7 +491,9 @@ export class UnitCommandsHandler {
   }
 
   handleTankerRefuelCommand(selectedUnits, targetUnit, mapGrid) {
-    const tankers = selectedUnits.filter(u => u.type === 'tankerTruck')
+    const tankers = selectedUnits.filter(u =>
+      u.type === 'tankerTruck' && (!u.crew || u.crew.loader)
+    )
     if (tankers.length === 0) return
     if (typeof targetUnit.maxGas !== 'number' || targetUnit.gas >= targetUnit.maxGas) {
       showNotification('Target unit does not need fuel!', 2000)
@@ -637,7 +640,9 @@ export class UnitCommandsHandler {
   }
 
   handleRecoveryTankRepairCommand(selectedUnits, targetUnit, mapGrid) {
-    const recoveryTanks = selectedUnits.filter(unit => unit.type === 'recoveryTank')
+    const recoveryTanks = selectedUnits.filter(unit =>
+      unit.type === 'recoveryTank' && (!unit.crew || unit.crew.loader)
+    )
     if (recoveryTanks.length === 0) {
       return
     }


### PR DESCRIPTION
## Summary
- prevent tanker trucks from refuelling without a loader
- stop recovery tanks repairing if their loader is gone
- block ambulances with no loader from healing
- ignore units missing a loader when issuing heal, refuel or repair commands

## Testing
- `npm run lint` *(fails: 3021 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882cfed04c8832893aa4a82d62455f0