### PR TITLE
Fix enemy power display

### DIFF
--- a/src/gameState.js
+++ b/src/gameState.js
@@ -34,6 +34,16 @@ export const gameState = {
   mapGrid: [], // Add mapGrid array to gameState
   occupancyMap: [], // Global occupancy map updated incrementally
   powerSupply: 0,
+  // Separate power tracking for each side
+  playerPowerSupply: 0,
+  playerTotalPowerProduction: 0,
+  playerPowerConsumption: 0,
+  enemyPowerSupply: 0,
+  enemyTotalPowerProduction: 0,
+  enemyPowerConsumption: 0,
+  // Build speed modifiers start at normal speed
+  playerBuildSpeedModifier: 1.0,
+  enemyBuildSpeedModifier: 1.0,
   buildingPlacementMode: false,
   currentBuildingType: null,
   cursorX: 0,

--- a/src/rendering/buildingRenderer.js
+++ b/src/rendering/buildingRenderer.js
@@ -830,7 +830,8 @@ export class BuildingRenderer {
       ctx.strokeStyle = '#000'
       ctx.lineWidth = 2
       const textX = screenX + width / 2
-      const textY = screenY - 12
+      // Display power below the budget text
+      const textY = screenY + 12
       ctx.strokeText(powerText, textX, textY)
       ctx.fillText(powerText, textX, textY)
       ctx.restore()


### PR DESCRIPTION
## Summary
- add power tracking fields to `gameState`
- render enemy power supply below budget in HUD

## Testing
- `npm run lint` *(fails: 3022 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882d13ced2c8328811047285619cb52