### PR TITLE
Implement spawn cheat and docs

### DIFF
--- a/CHEAT_SYSTEM_README.md
+++ b/CHEAT_SYSTEM_README.md
@@ -40,6 +40,7 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
   - `tank_v1 9` spawns nine tanks for the player
   - `tank_v3` spawns one tank for the player
   - `tank_v2 3 red` spawns three tanks for the red party
+  - Available units: `harvester`, `tank_v1`, `tank-v2`, `tank-v3`, `rocketTank`, `recoveryTank`, `ambulance`, `tankerTruck`
 
 ### 📊 Status Command
 - **Command**: `status`

--- a/CHEAT_SYSTEM_README.md
+++ b/CHEAT_SYSTEM_README.md
@@ -34,6 +34,10 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 - **Commands**: `driver`, `commander`, `loader`, `gunner`
 - **Function**: Toggles the specified crew member for all selected units
 
+### 🚀 Spawn Units
+- **Command**: `[type] [amount] [party]`
+- **Function**: Spawns the specified unit type around the mouse cursor. `amount` and `party` are optional.
+
 ### 📊 Status Command
 - **Command**: `status`
 - **Function**: Shows current game state including:
@@ -165,8 +169,6 @@ window.cheatSystem.addMoney(10000)
 window.cheatSystem.showStatus()
 ```
 
-## Future Enhancements
-
 ## Recent Bug Fixes
 
 - **v1.1** - Fixed god mode damage prevention issue where units with armor would still take 1 damage due to `Math.max(1, ...)` calculation in bulletSystem.js. Now damage is only applied when `actualDamage > 0`.
@@ -182,8 +184,7 @@ window.cheatSystem.showStatus()
 
 ## Future Enhancements
 
-Potential future additions:
-- Unit spawning commands
+- Potential future additions:
 - Speed manipulation
 - Resource commands
 - AI behavior toggles

--- a/CHEAT_SYSTEM_README.md
+++ b/CHEAT_SYSTEM_README.md
@@ -36,7 +36,10 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 
 ### 🚀 Spawn Units
 - **Command**: `[type] [amount] [party]`
-- **Function**: Spawns the specified unit type around the mouse cursor. `amount` and `party` are optional.
+- **Function**: Spawns the specified unit type around the mouse cursor. `amount` and `party` are optional. When `party` is omitted, units belong to the player's party.
+  - `tank_v1 9` spawns nine tanks for the player
+  - `tank_v3` spawns one tank for the player
+  - `tank_v2 3 red` spawns three tanks for the red party
 
 ### 📊 Status Command
 - **Command**: `status`

--- a/src/input/cheatSystem.js
+++ b/src/input/cheatSystem.js
@@ -182,10 +182,10 @@ export class CheatSystem {
     dialog.innerHTML = `
       <h2>🎮 Cheat Console</h2>
       <div class="cheat-input-container">
-        <input 
-          type="text" 
-          class="cheat-input" 
-          id="cheat-input" 
+        <input
+          type="text"
+          class="cheat-input"
+          id="cheat-input"
           placeholder="Enter cheat code..."
           autocomplete="off"
           spellcheck="false"
@@ -290,7 +290,7 @@ export class CheatSystem {
 
   processCheatCode(code) {
     const normalizedCode = code.toLowerCase().trim()
-    
+
     try {
       // God mode commands
       if (normalizedCode === 'godmode on' || normalizedCode === 'god on' || normalizedCode === 'invincible on') {
@@ -349,10 +349,10 @@ export class CheatSystem {
           this.showError(`Unknown cheat code: "${code}"`)
         }
       }
-      } catch (error) {
-        console.error('Cheat system error:', error)
-        this.showError('Error processing cheat code')
-      }
+    } catch (error) {
+      console.error('Cheat system error:', error)
+      this.showError('Error processing cheat code')
+    }
   }
 
   parseAmount(amountStr) {
@@ -516,9 +516,9 @@ export class CheatSystem {
           health: unit.health,
           maxHealth: unit.maxHealth
         })
-        
+
         this.godModeUnits.add(unit.id)
-        
+
         // Set to maximum health and make effectively invincible
         unit.health = unit.maxHealth
         unit.isInvincible = true
@@ -553,7 +553,6 @@ export class CheatSystem {
   }
 
   addMoney(amount) {
-    const oldMoney = gameState.money
     gameState.money += amount
     gameState.totalMoneyEarned += amount
 
@@ -565,7 +564,6 @@ export class CheatSystem {
   }
 
   setMoney(amount) {
-    const oldMoney = gameState.money
     gameState.money = amount
 
     showNotification(`💰 Money set to $${amount.toLocaleString()}`, 3000)
@@ -582,7 +580,7 @@ export class CheatSystem {
     if (typeof window !== 'undefined' && window.debugGetSelectedUnits) {
       try {
         selected = window.debugGetSelectedUnits()
-      } catch (e) {
+      } catch {
         selected = []
       }
     }
@@ -674,22 +672,22 @@ export class CheatSystem {
   // Hook into unit damage to prevent damage when god mode is enabled
   preventDamage(target, damage) {
     if (!this.godModeEnabled) return damage
-    
+
     // Handle units
     if (target.owner === gameState.humanPlayer && target.id && this.godModeUnits.has(target.id)) {
       return 0 // Prevent all damage to player units
     }
-    
+
     // Handle buildings (buildings have owner but different structure)
     if (target.owner === gameState.humanPlayer && target.type && !target.id) {
       return 0 // Prevent all damage to player buildings
     }
-    
+
     // Handle factories (factories use id as human player ID)
     if (target.id === gameState.humanPlayer) {
       return 0 // Prevent all damage to player factory
     }
-    
+
     return damage // Allow normal damage
   }
 
@@ -752,7 +750,7 @@ export class CheatSystem {
       if (typeof window !== 'undefined' && window.debugGetSelectedUnits) {
         selected = window.debugGetSelectedUnits()
       }
-    } catch (e) {
+    } catch {
       selected = []
     }
 

--- a/src/input/cheatSystem.js
+++ b/src/input/cheatSystem.js
@@ -378,8 +378,18 @@ export class CheatSystem {
     if (!input) return null
     const tokens = input.trim().split(/\s+/)
     if (tokens.length === 0) return null
-    const unitType = tokens[0].toLowerCase()
-    if (!UNIT_PROPERTIES[unitType]) return null
+    const rawType = tokens[0]
+
+    // Create a case-insensitive map of allowed unit types on first use
+    if (!this.unitTypeMap) {
+      this.unitTypeMap = Object.keys(UNIT_PROPERTIES).reduce((acc, key) => {
+        acc[key.toLowerCase()] = key
+        return acc
+      }, {})
+    }
+
+    const unitType = this.unitTypeMap[rawType.toLowerCase()]
+    if (!unitType) return null
 
     let count = 1
     let owner = gameState.humanPlayer

--- a/src/input/cheatSystem.js
+++ b/src/input/cheatSystem.js
@@ -206,7 +206,7 @@ export class CheatSystem {
           <li><code>fuel [amount|percent%]</code> - Set fuel level of selected unit</li>
           <li><code>enemycontrol on</code> / <code>enemycontrol off</code> - Toggle enemy unit control</li>
           <li><code>driver</code> / <code>commander</code> / <code>loader</code> / <code>gunner</code> - Toggle crew for selected unit</li>
-          <li><code>[type] [amount] [party]</code> - Spawn units around the cursor (amount and party optional)</li>
+          <li><code>[type] [amount] [party]</code> - Spawn units around the cursor. Defaults to the player's party</li>
         </ul>
       </div>
     `

--- a/src/input/cursorManager.js
+++ b/src/input/cursorManager.js
@@ -83,6 +83,10 @@ export class CursorManager {
     const worldX = x - rect.left + gameState.scrollOffset.x
     const worldY = y - rect.top + gameState.scrollOffset.y
 
+    // Update global cursor position for other systems like cheats
+    gameState.cursorX = worldX
+    gameState.cursorY = worldY
+
     // Convert to tile coordinates
     const tileX = Math.floor(worldX / TILE_SIZE)
     const tileY = Math.floor(worldY / TILE_SIZE)


### PR DESCRIPTION
## Summary
- add ability to spawn units near the cursor via cheat command
- document new cheat command

## Testing
- `npm run lint` *(fails: no-trailing-spaces and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882d5cf99548328a09a45b3423abba1