### PR TITLE
Fix tanker truck spawn location

### DIFF
--- a/src/ai/enemyAIPlayer.js
+++ b/src/ai/enemyAIPlayer.js
@@ -506,7 +506,15 @@ const updateAIPlayer = logPerformance(function updateAIPlayer(aiPlayerId, units,
         let spawnFactory = aiFactory // Default to main construction yard
 
         // Harvesters and other vehicle units should spawn from vehicle factories
-        if (unitType === 'harvester' || unitType === 'tank_v1' || unitType === 'tank-v2' || unitType === 'tank-v3' || unitType === 'rocketTank' || unitType === 'ambulance') {
+        if (
+          unitType === 'harvester' ||
+          unitType === 'tank_v1' ||
+          unitType === 'tank-v2' ||
+          unitType === 'tank-v3' ||
+          unitType === 'rocketTank' ||
+          unitType === 'ambulance' ||
+          unitType === 'tankerTruck'
+        ) {
           const aiVehicleFactories = gameState.buildings.filter(
             b => b.type === 'vehicleFactory' && b.owner === aiPlayerId
           )


### PR DESCRIPTION
## Summary
- ensure AI spawns tanker trucks from vehicle factories

## Testing
- `npm run lint` *(fails: thousands of eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68836be3c64c8328bb6deb3aa709d616