### PR TITLE
Enforce stationary state for refuel/repair/crew transfer

### DIFF
--- a/src/game/ambulanceSystem.js
+++ b/src/game/ambulanceSystem.js
@@ -43,6 +43,13 @@ export const updateAmbulanceLogic = logPerformance(function(units, gameState, de
         return
       }
 
+      // Target must be stationary to receive healing
+      if (target.movement && target.movement.isMoving) {
+        ambulance.healingTarget = null
+        ambulance.healingTimer = 0
+        return
+      }
+
       const missingCrew = Object.entries(target.crew).filter(([_, alive]) => !alive)
       if (missingCrew.length === 0) {
         // Target is fully healed
@@ -98,6 +105,10 @@ export function canAmbulanceHealUnit(ambulance, targetUnit) {
     return false
   }
 
+  if (targetUnit.movement && targetUnit.movement.isMoving) {
+    return false
+  }
+
   // Check if target has missing crew members
   const missingCrew = Object.entries(targetUnit.crew).filter(([_, alive]) => !alive)
   if (missingCrew.length === 0) {
@@ -117,6 +128,10 @@ export function assignAmbulanceToHealUnit(ambulance, targetUnit) {
     return false
   }
   if (!canAmbulanceHealUnit(ambulance, targetUnit)) {
+    return false
+  }
+
+  if (targetUnit.movement && targetUnit.movement.isMoving) {
     return false
   }
 

--- a/src/game/gasStationLogic.js
+++ b/src/game/gasStationLogic.js
@@ -21,7 +21,9 @@ export const updateGasStationLogic = logPerformance(function(units, buildings, g
         unit.tileY >= areaStartY &&
         unit.tileY <= areaEndY
 
-      if (inArea) {
+      const stationary = !(unit.movement && unit.movement.isMoving)
+
+      if (inArea && stationary) {
         let refilling = false
 
         if (unit.gas < unit.maxGas) {

--- a/src/game/hospitalLogic.js
+++ b/src/game/hospitalLogic.js
@@ -10,7 +10,9 @@ export const updateHospitalLogic = logPerformance(function(units, buildings, gam
       if(!unit.crew) return
       // Skip ambulances for AI players as they don't use the crew system
       if((unit.owner !== gameState.humanPlayer) && (unit.type === 'ambulance')) return
-      if(unit.tileY===healRow && unit.tileX>=hospital.x && unit.tileX<hospital.x+hospital.width){
+      const inArea = unit.tileY===healRow && unit.tileX>=hospital.x && unit.tileX<hospital.x+hospital.width
+      const stationary = !(unit.movement && unit.movement.isMoving)
+      if(inArea && stationary){
         unit.healTimer = (unit.healTimer||0)+delta
         const missing = Object.entries(unit.crew).filter(([_,alive])=>!alive)
         while(missing.length>0 && unit.healTimer>=10000){
@@ -22,6 +24,8 @@ export const updateHospitalLogic = logPerformance(function(units, buildings, gam
             gameState.money-=100
           }
         }
+      } else {
+        unit.healTimer = 0
       }
     })
   })

--- a/src/game/recoveryTankSystem.js
+++ b/src/game/recoveryTankSystem.js
@@ -36,10 +36,12 @@ export const updateRecoveryTankLogic = logPerformance(function(units, gameState,
     // Auto-repair logic - find nearby damaged units
     if (!tank.repairTarget) {
       const target = units.find(u =>
-        u.owner === tank.owner && u !== tank &&
+        u.owner === tank.owner &&
+        u !== tank &&
         u.health < u.maxHealth &&
         Math.abs(u.tileX - tank.tileX) <= 1 &&
-        Math.abs(u.tileY - tank.tileY) <= 1
+        Math.abs(u.tileY - tank.tileY) <= 1 &&
+        !(u.movement && u.movement.isMoving)
       )
       if (target) {
         tank.repairTarget = target
@@ -64,7 +66,10 @@ export const updateRecoveryTankLogic = logPerformance(function(units, gameState,
       const target = tank.repairTarget
       
       // Check if target is still valid
-      if (target.health <= 0 || Math.abs(target.tileX - tank.tileX) > 1 || Math.abs(target.tileY - tank.tileY) > 1) {
+      if (target.health <= 0 ||
+          Math.abs(target.tileX - tank.tileX) > 1 ||
+          Math.abs(target.tileY - tank.tileY) > 1 ||
+          (target.movement && target.movement.isMoving)) {
         // console.log(`Recovery tank repair cancelled: target invalid`)
         tank.repairTarget = null
         tank.repairData = null

--- a/src/game/tankerTruckLogic.js
+++ b/src/game/tankerTruckLogic.js
@@ -58,7 +58,7 @@ export const updateTankerTruckLogic = logPerformance(function(units, gameState, 
       } else {
         // Check if we're close enough to start refueling
         const distance = Math.abs(emergencyUnit.tileX - tanker.tileX) + Math.abs(emergencyUnit.tileY - tanker.tileY)
-        if (distance <= 1) {
+        if (distance <= 1 && !(emergencyUnit.movement && emergencyUnit.movement.isMoving)) {
           // Start emergency refueling
           tanker.refuelTarget = emergencyUnit
           tanker.refuelTimer = 0
@@ -79,7 +79,8 @@ export const updateTankerTruckLogic = logPerformance(function(units, gameState, 
         u.gas < (u.maxGas * 0.95) && // Only refuel if unit has less than 95% gas
         u.health > 0 && // Ensure target is alive
         Math.abs(u.tileX - tanker.tileX) <= 1 &&
-        Math.abs(u.tileY - tanker.tileY) <= 1
+        Math.abs(u.tileY - tanker.tileY) <= 1 &&
+        !(u.movement && u.movement.isMoving)
       )
       if (target && (tanker.supplyGas > 0 || tanker.supplyGas === undefined)) {
         // Initialize supply gas if not set
@@ -121,7 +122,11 @@ export const updateTankerTruckLogic = logPerformance(function(units, gameState, 
         tanker.lastRefuelDebug = performance.now()
       }
       
-      if (!target || target.health <= 0 || Math.abs(target.tileX - tanker.tileX) > 1 || Math.abs(target.tileY - tanker.tileY) > 1) {
+      if (!target ||
+          target.health <= 0 ||
+          Math.abs(target.tileX - tanker.tileX) > 1 ||
+          Math.abs(target.tileY - tanker.tileY) > 1 ||
+          (target.movement && target.movement.isMoving)) {
         const distance = target ? Math.abs(target.tileX - tanker.tileX) + Math.abs(target.tileY - tanker.tileY) : 'N/A'
         console.log(`Tanker ${tanker.id} lost refuel target - target exists: ${!!target}, distance: ${distance}`)
         

--- a/src/game/workshopLogic.js
+++ b/src/game/workshopLogic.js
@@ -98,7 +98,11 @@ export const updateWorkshopLogic = logPerformance(function updateWorkshopLogic(u
       const dist = Math.hypot(unit.x - slot.x * TILE_SIZE, unit.y - slot.y * TILE_SIZE)
       
       // Check if unit has been moved away from workshop (new path or move target)
-      if (unit.repairingAtWorkshop && (unit.path.length > 0 || (unit.moveTarget && (unit.moveTarget.x !== slot.x || unit.moveTarget.y !== slot.y)))) {
+      if (unit.repairingAtWorkshop && (
+          unit.path.length > 0 ||
+          (unit.moveTarget && (unit.moveTarget.x !== slot.x || unit.moveTarget.y !== slot.y)) ||
+          (unit.movement && unit.movement.isMoving)
+        )) {
         // Unit is being moved away, clean up repair state and workshop assignment
         unit.repairingAtWorkshop = false
         unit.returningToWorkshop = false
@@ -111,7 +115,7 @@ export const updateWorkshopLogic = logPerformance(function updateWorkshopLogic(u
         return
       }
       if (!unit.repairingAtWorkshop) {
-        if (dist < TILE_SIZE / 3) {
+        if (dist < TILE_SIZE / 3 && !(unit.movement && unit.movement.isMoving)) {
           unit.repairingAtWorkshop = true
           unit.path = []
           unit.moveTarget = null


### PR DESCRIPTION
## Summary
- block gas station refueling unless the unit is stationary
- require refuel targets of tanker trucks to be stationary
- cancel recovery tank repair if target is moving
- only repair at workshop when unit is not moving
- only heal in hospitals when units are not moving
- only heal with ambulance if target is stationary

## Testing
- `npm run lint` *(fails: trailing spaces and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_688395c6c89483288b27a279d481d7d1