### PR TITLE
Pause/resume audio with game pause

### DIFF
--- a/src/game/gameLoop.js
+++ b/src/game/gameLoop.js
@@ -9,6 +9,7 @@ import { updateEnergyBar } from '../ui/energyBar.js'
 import { milestoneSystem } from './milestoneSystem.js'
 import { FPSDisplay } from '../ui/fpsDisplay.js'
 import { logPerformance } from '../performanceUtils.js'
+import { pauseAllSounds, resumeAllSounds } from '../sound.js'
 
 export class GameLoop {
   constructor(canvasManager, productionController, mapGrid, factories, units, bullets, productionQueue, moneyEl, gameTimeEl) {
@@ -37,6 +38,9 @@ export class GameLoop {
 
     // Set the production controller reference in milestone system
     milestoneSystem.setProductionController(productionController)
+
+    // Track pause state to manage audio playback
+    this.wasPaused = gameState.gamePaused
   }
 
   setAssetsLoaded(loaded) {
@@ -69,6 +73,16 @@ export class GameLoop {
 
     // Always update FPS tracking
     this.fpsDisplay.updateFPS(now)
+
+    // Pause or resume sounds when game pause state changes
+    if (gameState.gamePaused !== this.wasPaused) {
+      this.wasPaused = gameState.gamePaused
+      if (gameState.gamePaused) {
+        pauseAllSounds()
+      } else {
+        resumeAllSounds()
+      }
+    }
 
     if (!gameState.gameStarted || gameState.gamePaused) {
       // When paused, still render FPS overlay but skip game updates

--- a/src/sound.js
+++ b/src/sound.js
@@ -651,4 +651,7 @@ export function clearSoundCache() {
   console.log('Sound cache cleared, background music reset')
 }
 
-export { audioContext, pauseAllSounds, resumeAllSounds }
+// Export the audio context for other modules that need direct access
+// Pause/resume helpers are already exported above with their function
+// declarations, so exporting them again would cause a duplicate export error.
+export { audioContext }

--- a/src/sound.js
+++ b/src/sound.js
@@ -545,6 +545,39 @@ export async function toggleBackgroundMusic() {
   }
 }
 
+// --- Game Pause/Resume Helpers ---
+// Pause all currently playing audio including background music and looped sounds
+export function pauseAllSounds() {
+  if (bgMusicAudio && !bgMusicAudio.paused) {
+    try {
+      bgMusicAudio.pause()
+    } catch (e) {
+      console.warn('Error pausing background music:', e)
+    }
+  }
+
+  if (audioContext && audioContext.state === 'running') {
+    audioContext.suspend().catch(e => {
+      console.warn('Failed to suspend audio context:', e)
+    })
+  }
+}
+
+// Resume playback after game unpause
+export function resumeAllSounds() {
+  if (bgMusicAudio && bgMusicAudio.paused) {
+    bgMusicAudio.play().catch(e => {
+      console.warn('Error resuming background music:', e)
+    })
+  }
+
+  if (audioContext && audioContext.state === 'suspended') {
+    audioContext.resume().catch(e => {
+      console.warn('Failed to resume audio context:', e)
+    })
+  }
+}
+
 // --- Master Volume Control Functions ---
 export function setMasterVolume(volume) {
   masterVolume = Math.max(0, Math.min(1, volume)) // Clamp between 0 and 1
@@ -618,4 +651,4 @@ export function clearSoundCache() {
   console.log('Sound cache cleared, background music reset')
 }
 
-export { audioContext }
+export { audioContext, pauseAllSounds, resumeAllSounds }


### PR DESCRIPTION
## Summary
- add helpers to pause and resume all sounds in `sound.js`
- pause or resume audio whenever the game pause state changes

## Testing
- `npm run lint` *(fails: Trailing spaces, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6885f76ba33883288433063879bd97de