### PR TITLE
Enable arrow key map scrolling

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -89,6 +89,8 @@ export const GRASS_DECORATIVE_RATIO = 33  // 1 in x tiles will be decorative
 export const GRASS_IMPASSABLE_RATIO = 50  // 1 in x tiles will be impassable
 
 export const INERTIA_DECAY = 0.983  // Increased from 0.95 to make inertia 3x longer
+// Scroll speed when using arrow keys (pixels per frame)
+export const KEYBOARD_SCROLL_SPEED = 8
 
 // Increase tank range by 50% (for example, from 6 to 9 tiles)
 export const TANK_FIRE_RANGE = 9

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -1,5 +1,5 @@
 // Game State Management Module - Handles win/loss conditions, cleanup, and map scrolling
-import { INERTIA_DECAY, TILE_SIZE, ORE_SPREAD_INTERVAL, ORE_SPREAD_PROBABILITY, ORE_SPREAD_ENABLED } from '../config.js'
+import { INERTIA_DECAY, TILE_SIZE, KEYBOARD_SCROLL_SPEED, ORE_SPREAD_INTERVAL, ORE_SPREAD_PROBABILITY, ORE_SPREAD_ENABLED } from '../config.js'
 import { resolveUnitCollisions, removeUnitOccupancy } from '../units.js'
 import { explosions } from '../logic.js'
 import { playSound, playPositionalSound, audioContext } from '../sound.js'
@@ -15,10 +15,25 @@ export function updateMapScrolling(gameState, mapGrid) {
   if (!gameState.isRightDragging) {
     const maxScrollX = mapGrid[0].length * TILE_SIZE - (window.innerWidth - 250)
     const maxScrollY = mapGrid.length * TILE_SIZE - window.innerHeight
+    // Update velocity based on arrow key input
+    if (gameState.keyScroll.left) {
+      gameState.dragVelocity.x = KEYBOARD_SCROLL_SPEED
+    } else if (gameState.keyScroll.right) {
+      gameState.dragVelocity.x = -KEYBOARD_SCROLL_SPEED
+    } else {
+      gameState.dragVelocity.x *= INERTIA_DECAY
+    }
+
+    if (gameState.keyScroll.up) {
+      gameState.dragVelocity.y = KEYBOARD_SCROLL_SPEED
+    } else if (gameState.keyScroll.down) {
+      gameState.dragVelocity.y = -KEYBOARD_SCROLL_SPEED
+    } else {
+      gameState.dragVelocity.y *= INERTIA_DECAY
+    }
+
     gameState.scrollOffset.x = Math.max(0, Math.min(gameState.scrollOffset.x - gameState.dragVelocity.x, maxScrollX))
     gameState.scrollOffset.y = Math.max(0, Math.min(gameState.scrollOffset.y - gameState.dragVelocity.y, maxScrollY))
-    gameState.dragVelocity.x *= INERTIA_DECAY
-    gameState.dragVelocity.y *= INERTIA_DECAY
   }
 }
 

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -19,6 +19,8 @@ export const gameState = {
   totalMoneyEarned: 0,
   scrollOffset: { x: 0, y: 0 },
   dragVelocity: { x: 0, y: 0 },
+  // Arrow key scrolling state
+  keyScroll: { up: false, down: false, left: false, right: false },
   // ID of the unit the camera should follow when auto-focus is enabled
   cameraFollowUnitId: null,
   isRightDragging: false,

--- a/src/input/keyboardHandler.js
+++ b/src/input/keyboardHandler.js
@@ -182,44 +182,60 @@ export class KeyboardHandler {
         e.preventDefault()
         this.handlePerformanceToggle()
       }
-      // Arrow keys and Space for remote control feature
+      // Arrow keys and Space for remote control or map scrolling
       else if (e.code === 'ArrowUp' || e.key === 'ArrowUp' || e.key === 'Up' || e.keyCode === 38) {
         e.preventDefault()
-        if (!gameState.remoteControl.forward) {
-          console.log('Remote control: up key down')
+        if (this.selectedUnits && this.selectedUnits.length > 0) {
+          if (!gameState.remoteControl.forward) {
+            console.log('Remote control: up key down')
+          }
+          gameState.remoteControl.forward = true
+        } else {
+          gameState.keyScroll.up = true
         }
-        gameState.remoteControl.forward = true
       } else if (e.code === 'ArrowDown' || e.key === 'ArrowDown' || e.key === 'Down' || e.keyCode === 40) {
         e.preventDefault()
-        if (!gameState.remoteControl.backward) {
-          console.log('Remote control: down key down')
+        if (this.selectedUnits && this.selectedUnits.length > 0) {
+          if (!gameState.remoteControl.backward) {
+            console.log('Remote control: down key down')
+          }
+          gameState.remoteControl.backward = true
+        } else {
+          gameState.keyScroll.down = true
         }
-        gameState.remoteControl.backward = true
       } else if (e.code === 'ArrowLeft' || e.key === 'ArrowLeft' || e.key === 'Left' || e.keyCode === 37) {
         e.preventDefault()
-        if (gameState.shiftKeyDown) {
-          if (!gameState.remoteControl.turretLeft) {
-            console.log('Remote control: turret left key down')
+        if (this.selectedUnits && this.selectedUnits.length > 0) {
+          if (gameState.shiftKeyDown) {
+            if (!gameState.remoteControl.turretLeft) {
+              console.log('Remote control: turret left key down')
+            }
+            gameState.remoteControl.turretLeft = true
+          } else {
+            if (!gameState.remoteControl.turnLeft) {
+              console.log('Remote control: left key down')
+            }
+            gameState.remoteControl.turnLeft = true
           }
-          gameState.remoteControl.turretLeft = true
         } else {
-          if (!gameState.remoteControl.turnLeft) {
-            console.log('Remote control: left key down')
-          }
-          gameState.remoteControl.turnLeft = true
+          gameState.keyScroll.left = true
         }
       } else if (e.code === 'ArrowRight' || e.key === 'ArrowRight' || e.key === 'Right' || e.keyCode === 39) {
         e.preventDefault()
-        if (gameState.shiftKeyDown) {
-          if (!gameState.remoteControl.turretRight) {
-            console.log('Remote control: turret right key down')
+        if (this.selectedUnits && this.selectedUnits.length > 0) {
+          if (gameState.shiftKeyDown) {
+            if (!gameState.remoteControl.turretRight) {
+              console.log('Remote control: turret right key down')
+            }
+            gameState.remoteControl.turretRight = true
+          } else {
+            if (!gameState.remoteControl.turnRight) {
+              console.log('Remote control: right key down')
+            }
+            gameState.remoteControl.turnRight = true
           }
-          gameState.remoteControl.turretRight = true
         } else {
-          if (!gameState.remoteControl.turnRight) {
-            console.log('Remote control: right key down')
-          }
-          gameState.remoteControl.turnRight = true
+          gameState.keyScroll.right = true
         }
       } else if (e.code === 'Space' || e.key === ' ' || e.keyCode === 32) {
         e.preventDefault()
@@ -244,27 +260,43 @@ export class KeyboardHandler {
         handleAltKeyRelease() // Check if waypoints were added and play sound
       }
       if (e.code === 'ArrowUp' || e.key === 'ArrowUp' || e.key === 'Up' || e.keyCode === 38) {
-        if (gameState.remoteControl.forward) {
-          console.log('Remote control: up key up')
+        if (this.selectedUnits && this.selectedUnits.length > 0) {
+          if (gameState.remoteControl.forward) {
+            console.log('Remote control: up key up')
+          }
+          gameState.remoteControl.forward = false
+        } else {
+          gameState.keyScroll.up = false
         }
-        gameState.remoteControl.forward = false
       } else if (e.code === 'ArrowDown' || e.key === 'ArrowDown' || e.key === 'Down' || e.keyCode === 40) {
-        if (gameState.remoteControl.backward) {
-          console.log('Remote control: down key up')
+        if (this.selectedUnits && this.selectedUnits.length > 0) {
+          if (gameState.remoteControl.backward) {
+            console.log('Remote control: down key up')
+          }
+          gameState.remoteControl.backward = false
+        } else {
+          gameState.keyScroll.down = false
         }
-        gameState.remoteControl.backward = false
       } else if (e.code === 'ArrowLeft' || e.key === 'ArrowLeft' || e.key === 'Left' || e.keyCode === 37) {
-        if (gameState.remoteControl.turnLeft || gameState.remoteControl.turretLeft) {
-          console.log('Remote control: left key up')
+        if (this.selectedUnits && this.selectedUnits.length > 0) {
+          if (gameState.remoteControl.turnLeft || gameState.remoteControl.turretLeft) {
+            console.log('Remote control: left key up')
+          }
+          gameState.remoteControl.turnLeft = false
+          gameState.remoteControl.turretLeft = false
+        } else {
+          gameState.keyScroll.left = false
         }
-        gameState.remoteControl.turnLeft = false
-        gameState.remoteControl.turretLeft = false
       } else if (e.code === 'ArrowRight' || e.key === 'ArrowRight' || e.key === 'Right' || e.keyCode === 39) {
-        if (gameState.remoteControl.turnRight || gameState.remoteControl.turretRight) {
-          console.log('Remote control: right key up')
+        if (this.selectedUnits && this.selectedUnits.length > 0) {
+          if (gameState.remoteControl.turnRight || gameState.remoteControl.turretRight) {
+            console.log('Remote control: right key up')
+          }
+          gameState.remoteControl.turnRight = false
+          gameState.remoteControl.turretRight = false
+        } else {
+          gameState.keyScroll.right = false
         }
-        gameState.remoteControl.turnRight = false
-        gameState.remoteControl.turretRight = false
       } else if (e.code === 'Space' || e.key === ' ' || e.keyCode === 32) {
         if (gameState.remoteControl.fire) {
           console.log('Remote control: space released')


### PR DESCRIPTION
## Summary
- add KEYBOARD_SCROLL_SPEED constant
- keep arrow key scrolling flags in `gameState`
- update keyboard handler to toggle scrolling when no units are selected
- update map scrolling logic to apply arrow key input

## Testing
- `npm run lint` *(fails: many lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68864a548eb08328baac229291c6c354