### PR TITLE
Remove rocket turret ready indicator

### DIFF
--- a/src/rendering/buildingRenderer.js
+++ b/src/rendering/buildingRenderer.js
@@ -406,13 +406,6 @@ export class BuildingRenderer {
           ctx.restore()
         }
         
-        // For rocket turret, only draw the ready indicator in bottom left corner
-        if (!building.lastShotTime || performance.now() - building.lastShotTime >= building.fireCooldown) {
-          ctx.fillStyle = '#0F0'
-          ctx.beginPath()
-          ctx.arc(screenX + 10, screenY + height - 10, 5, 0, Math.PI * 2)
-          ctx.fill()
-        }
       }
 
       // Draw range indicator if selected (for non-tesla coil and non-artillery buildings)


### PR DESCRIPTION
## Summary
- remove the green dot showing rocket turret readiness

## Testing
- `npm run lint` *(fails: Trailing spaces not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68865d5959988328a050f670edfefb3b