### PR TITLE
Implement tanker truck and gas station explosions

### DIFF
--- a/src/game/buildingSystem.js
+++ b/src/game/buildingSystem.js
@@ -3,6 +3,7 @@ import { TILE_SIZE, TANK_TURRET_ROT, BUILDING_SELL_DURATION } from '../config.js
 import { playSound, playPositionalSound } from '../sound.js'
 import { selectedUnits } from '../inputHandler.js'
 import { triggerExplosion } from '../logic.js'
+import { triggerDistortionEffect } from '../ui/distortionEffect.js'
 import { updatePowerSupply, clearBuildingFromMapGrid } from '../buildings.js'
 import { checkGameEndConditions } from './gameStateManager.js'
 import { updateUnitSpeedModifier } from '../utils.js'
@@ -93,8 +94,25 @@ export const updateBuildings = logPerformance(function updateBuildings(gameState
         // Play explosion sound with reduced volume (0.5)
         playPositionalSound('explosion', buildingCenterX, buildingCenterY, 0.5)
 
-        // Add explosion effect
-        triggerExplosion(buildingCenterX, buildingCenterY, 40, units, factories, null, now)
+        if (building.type === 'gasStation') {
+          const radius = TILE_SIZE * 5
+          triggerExplosion(
+            buildingCenterX,
+            buildingCenterY,
+            95 * 5,
+            units,
+            factories,
+            null,
+            now,
+            undefined,
+            radius,
+            true
+          )
+          triggerDistortionEffect(buildingCenterX, buildingCenterY, radius, gameState)
+        } else {
+          // Add standard explosion effect
+          triggerExplosion(buildingCenterX, buildingCenterY, 40, units, factories, null, now)
+        }
 
         // Check for game end conditions after a building is destroyed
         checkGameEndConditions(factories, gameState)

--- a/src/logic.js
+++ b/src/logic.js
@@ -14,7 +14,18 @@ export let explosions = [] // Global explosion effects for rocket impacts
 // --- Helper Functions ---
 
 // Trigger explosion effect and apply area damage
-export function triggerExplosion(x, y, baseDamage, units, factories, shooter, now, _mapGrid, radius = TILE_SIZE * 2) {
+export function triggerExplosion(
+  x,
+  y,
+  baseDamage,
+  units,
+  factories,
+  shooter,
+  now,
+  _mapGrid,
+  radius = TILE_SIZE * 2,
+  constantDamage = false
+) {
   const explosionRadius = radius
 
   // Add explosion visual effect
@@ -36,16 +47,21 @@ export function triggerExplosion(x, y, baseDamage, units, factories, shooter, no
     // Skip the shooter if this was their own bullet
     if (distance < explosionRadius) {
       if (shooter && unit.id === shooter.id) return
-      const falloff = 1 - (distance / explosionRadius)
-      let damage = Math.round(baseDamage * falloff * 0.5) // Half damage with falloff
+      let damage
+      if (constantDamage) {
+        damage = baseDamage
+      } else {
+        const falloff = 1 - distance / explosionRadius
+        damage = Math.round(baseDamage * falloff * 0.5) // Half damage with falloff
+      }
       
-      // Apply hit zone damage multiplier for tanks (simulate explosion hitting from all directions)
-      // For explosions, we'll create a mock bullet object at explosion center for calculation
-      if (shooter) {
+      if (!constantDamage && shooter) {
+        // Apply hit zone damage multiplier for tanks (simulate explosion hitting from all directions)
+        // For explosions, we'll create a mock bullet object at explosion center for calculation
         const mockBullet = { x: x, y: y, shooter: shooter }
         const hitZoneResult = calculateHitZoneDamageMultiplier(mockBullet, unit)
         damage = Math.round(damage * hitZoneResult.multiplier)
-        
+
         // Play critical damage sound only when player's units are hit from behind (with cooldown)
         if (
           hitZoneResult.isRearHit &&
@@ -97,8 +113,13 @@ export function triggerExplosion(x, y, baseDamage, units, factories, shooter, no
     const distance = Math.hypot(dx, dy)
 
     if (distance < explosionRadius) {
-      const falloff = 1 - (distance / explosionRadius)
-      let damage = Math.round(baseDamage * falloff * 0.3) // 30% damage with falloff
+      let damage
+      if (constantDamage) {
+        damage = baseDamage
+      } else {
+        const falloff = 1 - distance / explosionRadius
+        damage = Math.round(baseDamage * falloff * 0.3) // 30% damage with falloff
+      }
       
       // Check for god mode protection for player factories
       if (window.cheatSystem && factory.id === gameState.humanPlayer) {
@@ -136,8 +157,13 @@ export function triggerExplosion(x, y, baseDamage, units, factories, shooter, no
       const distance = Math.hypot(dx, dy)
 
       if (distance < explosionRadius) {
-        const falloff = 1 - (distance / explosionRadius)
-        let damage = Math.round(baseDamage * falloff * 0.3) // 30% damage with falloff
+        let damage
+        if (constantDamage) {
+          damage = baseDamage
+        } else {
+          const falloff = 1 - distance / explosionRadius
+          damage = Math.round(baseDamage * falloff * 0.3) // 30% damage with falloff
+        }
         
         // Check for god mode protection for player buildings
         if (window.cheatSystem && building.owner === gameState.humanPlayer) {

--- a/src/rendering/effectsRenderer.js
+++ b/src/rendering/effectsRenderer.js
@@ -150,10 +150,22 @@ export class EffectsRenderer {
         const progress = (currentTime - exp.startTime) / exp.duration
         const currentRadius = exp.maxRadius * progress
         const alpha = Math.max(0, 1 - progress)
+        const centerX = exp.x - scrollOffset.x
+        const centerY = exp.y - scrollOffset.y
+
+        const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, currentRadius)
+        gradient.addColorStop(0, `rgba(255,150,0,${alpha})`)
+        gradient.addColorStop(0.4, `rgba(255,90,0,${alpha * 0.8})`)
+        gradient.addColorStop(1, 'rgba(255,50,0,0)')
+        ctx.fillStyle = gradient
+        ctx.beginPath()
+        ctx.arc(centerX, centerY, currentRadius, 0, 2 * Math.PI)
+        ctx.fill()
+
         ctx.strokeStyle = `rgba(255,165,0,${alpha})`
         ctx.lineWidth = 2
         ctx.beginPath()
-        ctx.arc(exp.x - scrollOffset.x, exp.y - scrollOffset.y, currentRadius, 0, 2 * Math.PI)
+        ctx.arc(centerX, centerY, currentRadius, 0, 2 * Math.PI)
         ctx.stroke()
       })
     }

--- a/src/ui/distortionEffect.js
+++ b/src/ui/distortionEffect.js
@@ -1,0 +1,39 @@
+export function triggerDistortionEffect(x, y, radius, gameState) {
+  if (!radius || radius <= 0) return
+  // Add styles once
+  if (!document.getElementById('distortion-effect-styles')) {
+    const style = document.createElement('style')
+    style.id = 'distortion-effect-styles'
+    style.textContent = `
+      .distortion-effect {
+        position: absolute;
+        pointer-events: none;
+        border-radius: 50%;
+        mix-blend-mode: screen;
+        background: radial-gradient(circle, rgba(255,255,255,0.4) 0%, rgba(255,255,255,0) 60%);
+        animation: distortion-scale 0.5s ease-out forwards;
+        filter: blur(0px);
+      }
+      @keyframes distortion-scale {
+        from { transform: scale(0.3); opacity: 0.7; }
+        to { transform: scale(1.8); opacity: 0; filter: blur(8px); }
+      }
+    `
+    document.head.appendChild(style)
+  }
+  const canvas = document.getElementById('gameCanvas')
+  if (!canvas) return
+  const rect = canvas.getBoundingClientRect()
+  const screenX = x - gameState.scrollOffset.x + rect.left
+  const screenY = y - gameState.scrollOffset.y + rect.top
+  const effect = document.createElement('div')
+  effect.className = 'distortion-effect'
+  effect.style.left = `${screenX - radius}px`
+  effect.style.top = `${screenY - radius}px`
+  effect.style.width = `${radius * 2}px`
+  effect.style.height = `${radius * 2}px`
+  effect.style.zIndex = '999'
+  document.body.appendChild(effect)
+  effect.addEventListener('animationend', () => effect.remove())
+}
+


### PR DESCRIPTION
## Summary
- add constant-damage option to `triggerExplosion`
- make tanker truck explosions apply to units and buildings
- trigger massive blast for gas station destruction
- draw fiery explosion gradient

## Testing
- `npm run lint` *(fails: 3001 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688668ab9bf4832882040c64186414be