### PR TITLE
Add party targeting support to give cheat command

### DIFF
--- a/CHEAT_SYSTEM_README.md
+++ b/CHEAT_SYSTEM_README.md
@@ -12,10 +12,11 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 - **Integration**: Hooks into all damage systems (bullets, explosions, Tesla coils)
 
 ### 💰 Money Commands
-- **Give Money**: `give [amount]` - Adds money to current total
+- **Give Money**: `give [amount]` or `give [party] [amount]` - Adds money to the specified party (defaults to the player)
 - **Set Money**: `money [amount]` - Sets money to specific amount
 - **Examples**:
-  - `give 10000` - Adds $10,000
+  - `give 10000` - Adds $10,000 to the player
+  - `give red 5000` - Adds $5,000 to the red party (Player 2)
   - `money 50000` - Sets money to $50,000
 
 ### ❤️ HP Command
@@ -74,6 +75,9 @@ A comprehensive cheat system has been implemented for the RTS game that allows f
 
 > give 25000
 💰 Added $25,000 (Total: $35,000)
+
+> give red 5000
+💰 Added $5,000 to Red (Player 2) (Total: $17,000)
 
 > hp 75%
 ❤ Set HP to 75% for 1 unit(s)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-starter",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-starter",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "sharp": "^0.34.3"
       },


### PR DESCRIPTION
## Summary
- allow the `give` cheat code to optionally target a specific party and surface party-aware notifications
- document the new syntax in the cheat dialog and cheat system readme
- align the package lock version metadata with package.json

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c53baba8832899cac7ebb339a04f