### PR TITLE
Align building shadow of war discovery radii

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -121,6 +121,16 @@ export const TANK_FIRE_RANGE = 9
 // Maximum Manhattan distance for new buildings to stay connected
 export const BUILDING_PROXIMITY_RANGE = 2
 
+// Shadow of War configuration
+export const SHADOW_OF_WAR_CONFIG = {
+  tilePadding: 0.5,
+  rocketRangeMultiplier: 1.5,
+  defaultNonCombatRange: 2,
+  harvesterRange: 5,
+  initialBaseDiscoveryRadius: 10,
+  baseVisibilityBorder: 4
+}
+
 // Tank constants
 export const DEFAULT_ROTATION_SPEED = 0.05 // Radians per frame
 export const FAST_ROTATION_SPEED = 0.1 // Radians per frame


### PR DESCRIPTION
## Summary
- centralize Shadow of War tuning values in `config.js`, including the harvester discovery radius
- update the fog of war logic to reuse passive building radii for circular visibility and discovery updates
- extend the harvester vision range to five tiles through the new configuration

## Testing
- npm run lint *(fails: existing lint issues throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e7c29ae1948328877fbd16c0e39580