### PR TITLE
Fix occupancy map reset when loading saves

### DIFF
--- a/src/saveGame.js
+++ b/src/saveGame.js
@@ -585,6 +585,17 @@ export function loadGame(key) {
       })
     }
 
+    // Clear stale building references before re-placing buildings from the save
+    for (let y = 0; y < mapGrid.length; y++) {
+      if (!mapGrid[y]) continue
+      for (let x = 0; x < mapGrid[y].length; x++) {
+        const tile = mapGrid[y][x]
+        if (tile && tile.building) {
+          delete tile.building
+        }
+      }
+    }
+
     // Re-place all buildings on the map to set building properties correctly
     gameState.buildings.forEach(building => {
       for (let y = building.y; y < building.y + building.height; y++) {


### PR DESCRIPTION
## Summary
- clear stale building references from the map grid before re-placing loaded buildings
- ensure the rebuilt occupancy map reflects only the structures present in the loaded save

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f7ea39a9988328807fc5d557024aee