### PR TITLE
Improve workshop restoration behavior

### DIFF
--- a/src/game/recoveryTankSystem.js
+++ b/src/game/recoveryTankSystem.js
@@ -10,7 +10,7 @@ import {
   releaseWreckAssignment
 } from './unitWreckManager.js'
 
-const TOW_DISTANCE_THRESHOLD = TILE_SIZE * 0.9 // Increased by 50% from 0.6
+const TOW_DISTANCE_THRESHOLD = TILE_SIZE * 1.8 // Doubled hook-up range for easier towing
 
 function distanceBetweenPoints(ax, ay, bx, by) {
   return Math.hypot(ax - bx, ay - by)

--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -9,6 +9,7 @@ import { findWreckAtTile } from '../game/unitWreckManager.js'
 import { markWaypointsAdded } from '../game/waypointSounds.js'
 import { initiateRetreat } from '../behaviours/retreat.js'
 import { AttackGroupHandler } from './attackGroupHandler.js'
+import { isWithinBaseRange } from '../utils/baseUtils.js'
 
 export class MouseHandler {
   constructor() {
@@ -551,6 +552,15 @@ export class MouseHandler {
         showNotification('Cannot set rally point on occupied tile', 1500)
         cursorManager.updateCustomCursor(e, gameState.mapGrid || [], factories, selectedUnits, units)
         return
+      }
+
+      if (selectedBuilding.type === 'vehicleWorkshop') {
+        const owner = selectedBuilding.owner || gameState.humanPlayer
+        if (!isWithinBaseRange(rallyTileX, rallyTileY, owner)) {
+          showNotification('Workshop rally point must stay near your base', 2000)
+          cursorManager.updateCustomCursor(e, gameState.mapGrid || [], factories, selectedUnits, units)
+          return
+        }
       }
 
       selectedBuilding.rallyPoint = {

--- a/src/utils/baseUtils.js
+++ b/src/utils/baseUtils.js
@@ -1,0 +1,73 @@
+import { MAX_BUILDING_GAP_TILES } from '../config.js'
+import { gameState } from '../gameState.js'
+
+function normalizeStructures(structures) {
+  return structures.filter(Boolean).map(structure => ({
+    x: structure.x || 0,
+    y: structure.y || 0,
+    width: structure.width || 1,
+    height: structure.height || 1
+  }))
+}
+
+export function getBaseStructures(owner, {
+  buildings = gameState.buildings,
+  factories = gameState.factories
+} = {}) {
+  const baseStructures = []
+
+  if (Array.isArray(factories)) {
+    factories.forEach(factory => {
+      const factoryOwner = factory?.owner ?? factory?.id
+      if (factoryOwner !== owner) return
+      baseStructures.push({
+        x: factory.x || 0,
+        y: factory.y || 0,
+        width: factory.width || 1,
+        height: factory.height || 1
+      })
+    })
+  }
+
+  if (Array.isArray(buildings)) {
+    buildings.forEach(building => {
+      if (!building || building.owner !== owner) return
+      if (building.type !== 'constructionYard' && building.type !== 'commandCenter') return
+      baseStructures.push({
+        x: building.x || 0,
+        y: building.y || 0,
+        width: building.width || 1,
+        height: building.height || 1
+      })
+    })
+  }
+
+  return normalizeStructures(baseStructures)
+}
+
+export function isWithinBaseRange(tileX, tileY, owner, {
+  buildings = gameState.buildings,
+  factories = gameState.factories,
+  maxDistance = MAX_BUILDING_GAP_TILES
+} = {}) {
+  const structures = getBaseStructures(owner, { buildings, factories })
+  if (structures.length === 0) {
+    return true
+  }
+
+  return structures.some(structure => {
+    const width = structure.width || 1
+    const height = structure.height || 1
+
+    for (let y = structure.y; y < structure.y + height; y++) {
+      for (let x = structure.x; x < structure.x + width; x++) {
+        const distance = Math.max(Math.abs(tileX - x), Math.abs(tileY - y))
+        if (distance <= maxDistance) {
+          return true
+        }
+      }
+    }
+
+    return false
+  })
+}


### PR DESCRIPTION
## Summary
- double the recovery tank hook-up range for easier towing
- spawn restored workshop units below the workshop, without crew or fuel, and route them to validated rally points
- restrict workshop rally points to base range and allow restoration move overrides so empty units can reach the rally point

## Testing
- ❌ `npm run lint` *(fails due to numerous pre-existing lint warnings about unused variables and globals)*

------
https://chatgpt.com/codex/tasks/task_e_68f9eeae2e3083289a77e08f9eecbefa