### PR TITLE
Add mobile stack drag for unit production

### DIFF
--- a/style.css
+++ b/style.css
@@ -321,6 +321,45 @@ body.is-touch {
   text-overflow: ellipsis;
 }
 
+.production-button .stack-direction-indicator {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 6;
+  transition: opacity 80ms ease-out;
+}
+
+.production-button .stack-direction-indicator.align-top {
+  top: 0;
+  bottom: 50%;
+}
+
+.production-button .stack-direction-indicator.align-bottom {
+  top: 50%;
+  bottom: 0;
+}
+
+.production-button .stack-direction-indicator.visible {
+  opacity: 1;
+}
+
+.production-button .stack-direction-indicator .arrow-shape {
+  width: 42px;
+  height: 42px;
+  background-color: rgba(255, 255, 255, 0.3);
+  clip-path: polygon(50% 0%, 100% 40%, 72% 40%, 72% 100%, 28% 100%, 28% 40%, 0% 40%);
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.45));
+}
+
+.production-button .stack-direction-indicator.align-bottom .arrow-shape {
+  transform: rotate(180deg);
+}
+
 .production-button:hover {
   background-color: #444;
 }


### PR DESCRIPTION
## Summary
- add touch-specific drag gestures on production buttons to grow or shrink unit stacks
- introduce helpers to query and adjust unit queues safely during mobile interactions
- ensure traditional drag-to-canvas behaviour only runs when not in stack adjustment mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa8a6f37ac8328b36a73f4c8f32e4e