### PR TITLE
Enable utility queue chaining for support units

### DIFF
--- a/src/units.js
+++ b/src/units.js
@@ -698,6 +698,9 @@ export function createUnit(factory, unitType, x, y, options = {}) {
     buildDuration: determineBuildDuration(actualType, options.buildDuration || null)
   }
 
+  const utilityUnitTypes = ['ambulance', 'tankerTruck', 'recoveryTank']
+  unit.isUtilityUnit = utilityUnitTypes.includes(actualType)
+
   // Gas system
   const gasProps = UNIT_GAS_PROPERTIES[actualType]
   if (gasProps) {


### PR DESCRIPTION
## Summary
- flag ambulances, tanker trucks, and recovery tanks with an `isUtilityUnit` marker
- allow holding Alt/Option to append ambulance, tanker, and recovery tank targets (including wrecks) to their utility queues
- render chained utility targets with the existing waypoint visuals for clearer queue feedback

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fe3913335c8328a1288d78fece7114