### PR TITLE
Ensure initial build clicks always stack up

### DIFF
--- a/src/ui/productionController.js
+++ b/src/ui/productionController.js
@@ -654,7 +654,13 @@ export class ProductionController {
 
         const buildingType = button.getAttribute('data-building-type')
         const currentTime = performance.now()
-        const isUpperHalf = this.isUpperHalfClick(event, button)
+        const hasExistingStack = this.getBuildingProductionCount(button) > 0 ||
+          button.classList.contains('ready-for-placement')
+        let isUpperHalf = this.isUpperHalfClick(event, button)
+
+        if (!hasExistingStack) {
+          isUpperHalf = true
+        }
 
         this.showStackDirectionIndicator(button, isUpperHalf ? 'increase' : 'decrease')
 


### PR DESCRIPTION
## Summary
- treat the first click on a build button as a stack-up action even if the lower half is clicked
- allow stack-down interpretation only when the button already has queued or ready items

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe85f78c608328ac63822e308fdac4