### PR TITLE
Improve smoke particle performance and pooling

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -461,6 +461,11 @@ export let TURRET_RECOIL_DISTANCE = 6 // pixels for building turrets
 export let SMOKE_PARTICLE_LIFETIME = 4500 // milliseconds (increased for longer-lasting building smoke)
 export let SMOKE_EMIT_INTERVAL = 120 // milliseconds between puffs (slightly less frequent)
 export let SMOKE_PARTICLE_SIZE = 8 // radius of smoke particles (reduced from 12)
+export let MAX_SMOKE_PARTICLES = 600 // Upper limit to keep smoke rendering performant
+
+export function setMaxSmokeParticles(value) {
+  MAX_SMOKE_PARTICLES = value
+}
 
 // Duration of the building sell animation (in milliseconds)
 export let BUILDING_SELL_DURATION = 3000

--- a/src/gameState.js
+++ b/src/gameState.js
@@ -33,6 +33,7 @@ export const gameState = {
   lastOreUpdate: performance.now(),
   explosions: [],  // Initialized empty explosions array for visual effects.
   smokeParticles: [], // Smoke particles emitted by damaged units
+  smokeParticlePool: [], // Reusable pool to avoid allocations during heavy smoke
   unitWrecks: [], // Destroyed unit remnants that can be recovered or recycled
   selectedWreckId: null, // Currently selected wreck (for UI feedback)
   speedMultiplier: 1.0,  // Set to 1.0 as requested

--- a/src/saveGame.js
+++ b/src/saveGame.js
@@ -5,6 +5,7 @@ import { units } from './main.js'
 import { mapGrid } from './main.js'
 import { cleanupOreFromBuildings } from './gameSetup.js'
 import { TILE_SIZE, TANKER_SUPPLY_CAPACITY } from './config.js'
+import { enforceSmokeParticleCapacity } from './utils/smokeUtils.js'
 import { createUnit } from './units.js'
 import { buildingData } from './buildings.js'
 import { showNotification } from './ui/notifications.js'
@@ -360,6 +361,10 @@ export function loadGame(key) {
         typeof p.duration === 'number'
       )
     }
+
+    // Smoke particle pools are transient and should always be reset on load/save
+    gameState.smokeParticlePool = []
+    enforceSmokeParticleCapacity(gameState)
 
     // Restore AI player budgets
     if (loaded.aiFactoryBudgets) {

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -1,7 +1,8 @@
 // Main Game Update Module - Coordinates all game systems
 import {
   TILE_SIZE,
-  SMOKE_EMIT_INTERVAL
+  SMOKE_EMIT_INTERVAL,
+  BUILDING_SMOKE_EMIT_INTERVAL
 } from './config.js'
 
 import { emitSmokeParticles } from './utils/smokeUtils.js'
@@ -163,16 +164,15 @@ export const updateGame = logPerformance(function updateGame(delta, mapGrid, fac
             const tracker = building.smokeEmissionTrackers[spotIndex]
             const timeSinceLastEmission = now - tracker.lastEmissionTime
 
-            // Emit every 200ms for steady, overlapping smoke streams
-            if (timeSinceLastEmission > 200) {
+            if (timeSinceLastEmission > BUILDING_SMOKE_EMIT_INTERVAL) {
               const scaledX = smokeSpot.x * scaleX
               const scaledY = smokeSpot.y * scaleY
               // Use precise coordinates without additional offset now that scaling is accurate
               const smokeX = building.x * TILE_SIZE + scaledX
               const smokeY = building.y * TILE_SIZE + scaledY
 
-              // Emit 3 particles for denser, overlapping effect
-              emitSmokeParticles(gameState, smokeX, smokeY, now, 3)
+              // Emit a limited number of particles per puff to avoid runaway counts
+              emitSmokeParticles(gameState, smokeX, smokeY, now, 2)
 
               tracker.lastEmissionTime = now
               tracker.emissionStage = (tracker.emissionStage + 1) % 4 // Cycle through stages

--- a/src/utils/smokeUtils.js
+++ b/src/utils/smokeUtils.js
@@ -1,6 +1,53 @@
 // smokeUtils.js
 // Utility functions for creating smoke particle effects used by units and buildings
-import { SMOKE_PARTICLE_LIFETIME, SMOKE_PARTICLE_SIZE } from '../config.js'
+import {
+  MAX_SMOKE_PARTICLES,
+  SMOKE_PARTICLE_LIFETIME,
+  SMOKE_PARTICLE_SIZE
+} from '../config.js'
+
+const spread = 4
+
+function ensureSmokeCollections(gameState) {
+  if (!Array.isArray(gameState.smokeParticles)) {
+    gameState.smokeParticles = []
+  }
+  if (!Array.isArray(gameState.smokeParticlePool)) {
+    gameState.smokeParticlePool = []
+  }
+}
+
+function recycleParticleInstance(gameState, particle) {
+  if (!particle) {
+    return
+  }
+
+  // Reset mutable fields to reduce stale data when reusing the particle
+  particle.originalSize = undefined
+  particle.alpha = 0
+  particle.size = 0
+
+  gameState.smokeParticlePool.push(particle)
+}
+
+export function removeSmokeParticle(gameState, index) {
+  ensureSmokeCollections(gameState)
+
+  if (index < 0 || index >= gameState.smokeParticles.length) {
+    return
+  }
+
+  const [particle] = gameState.smokeParticles.splice(index, 1)
+  recycleParticleInstance(gameState, particle)
+}
+
+export function enforceSmokeParticleCapacity(gameState) {
+  ensureSmokeCollections(gameState)
+
+  while (gameState.smokeParticles.length > MAX_SMOKE_PARTICLES) {
+    removeSmokeParticle(gameState, 0)
+  }
+}
 
 /**
  * Emit a number of smoke particles at the specified world coordinates.
@@ -13,17 +60,33 @@ import { SMOKE_PARTICLE_LIFETIME, SMOKE_PARTICLE_SIZE } from '../config.js'
  * @param {number} [count=1] - Number of particles to emit
  */
 export function emitSmokeParticles(gameState, x, y, now, count = 1) {
-  const spread = 4
+  ensureSmokeCollections(gameState)
+
+  if (!Number.isFinite(count) || count <= 0) {
+    return
+  }
+
+  // Make sure we never exceed the configured cap by recycling the oldest particles
   for (let i = 0; i < count; i++) {
-    gameState.smokeParticles.push({
-      x: x + (Math.random() - 0.5) * spread,
-      y: y + (Math.random() - 0.5) * spread,
-      vx: (Math.random() - 0.5) * 0.2,
-      vy: -0.6 + Math.random() * -0.2, // Increased upward velocity for higher flight
-      size: SMOKE_PARTICLE_SIZE + Math.random() * 2,
-      startTime: now,
-      duration: SMOKE_PARTICLE_LIFETIME + Math.random() * 500, // Increased random duration variation
-      alpha: 0.7 + Math.random() * 0.2
-    })
+    if (gameState.smokeParticles.length >= MAX_SMOKE_PARTICLES) {
+      removeSmokeParticle(gameState, 0)
+    }
+
+    if (gameState.smokeParticles.length >= MAX_SMOKE_PARTICLES) {
+      break
+    }
+
+    const particle = gameState.smokeParticlePool.pop() || {}
+
+    particle.x = x + (Math.random() - 0.5) * spread
+    particle.y = y + (Math.random() - 0.5) * spread
+    particle.vx = (Math.random() - 0.5) * 0.2
+    particle.vy = -0.6 + Math.random() * -0.2 // Increased upward velocity for higher flight
+    particle.size = SMOKE_PARTICLE_SIZE + Math.random() * 2
+    particle.startTime = now
+    particle.duration = SMOKE_PARTICLE_LIFETIME + Math.random() * 500 // Increased random duration variation
+    particle.alpha = 0.7 + Math.random() * 0.2
+
+    gameState.smokeParticles.push(particle)
   }
 }


### PR DESCRIPTION
## Summary
- add pooling and capacity enforcement for smoke particles to prevent runaway allocations
- throttle building smoke emission and rely on configuration-driven timing for steady output
- reset transient smoke pools on save/load to avoid leaking particles between sessions

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fe8685276c83289cd4665699031735