### PR TITLE
Prevent remote control of unmanned or out-of-fuel vehicles

### DIFF
--- a/src/game/remoteControl.js
+++ b/src/game/remoteControl.js
@@ -74,6 +74,18 @@ export function updateRemoteControlledUnits(units, bullets, mapGrid, occupancyMa
       return
     }
 
+    // Remote control requires an active commander
+    if (unit.crew && typeof unit.crew === 'object' && !unit.crew.commander) {
+      unit.remoteControlActive = false
+      return
+    }
+
+    // Units without fuel cannot be remote controlled
+    if (unit.gas !== undefined && unit.gas <= 0) {
+      unit.remoteControlActive = false
+      return
+    }
+
     // Cancel pathing when using remote control
     if (rc.forward || rc.backward || rc.turnLeft || rc.turnRight) {
       unit.path = []


### PR DESCRIPTION
## Summary
- block remote control commands for vehicles that have lost their commander
- prevent remotely driving vehicles that are out of fuel while keeping their state consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff4f41677483288115f5e64039caab