### PR TITLE
Reorder building menu and hide locked building buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,9 +177,9 @@
               </button>
             </div>
                 <div id="buildingsTabContent" class="tab-content active">
-              <button class="production-button" data-building-type="constructionYard">
-                <img draggable="true" src="images/sidebar/construction_yard.png" onerror="this.style.display='none'">
-                <span class="building-name">Construction Yard</span>
+              <button class="production-button" data-building-type="powerPlant">
+                <img draggable="true" src="images/sidebar/power_plant.webp" onerror="this.style.display='none'">
+                <span class="building-name">Power Plant</span>
                 <span class="building-cost"></span>
                 <span class="building-power"></span>
                 <div class="production-progress"></div>
@@ -195,27 +195,9 @@
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
               </button>
-              <button class="production-button" data-building-type="powerPlant">
-                <img draggable="true" src="images/sidebar/power_plant.webp" onerror="this.style.display='none'">
-                <span class="building-name">Power Plant</span>
-                <span class="building-cost"></span>
-                <span class="building-power"></span>
-                <div class="production-progress"></div>
-                <div class="batch-counter" style="display:none">0</div>
-                <div class="new-label" style="display:none">NEW</div>
-              </button>
               <button class="production-button" data-building-type="vehicleFactory">
                 <img draggable="true" src="images/sidebar/vehicle_factory.webp" onerror="this.style.display='none'">
                 <span class="building-name">Vehicle Factory</span>
-                <span class="building-cost"></span>
-                <span class="building-power"></span>
-                <div class="production-progress"></div>
-                <div class="batch-counter" style="display:none">0</div>
-                <div class="new-label" style="display:none">NEW</div>
-              </button>
-              <button class="production-button" data-building-type="vehicleWorkshop">
-                <img draggable="true" src="images/sidebar/vehicle_workshop.webp" onerror="this.style.display='none'">
-                <span class="building-name">Vehicle Workshop</span>
                 <span class="building-cost"></span>
                 <span class="building-power"></span>
                 <div class="production-progress"></div>
@@ -231,18 +213,27 @@
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
               </button>
-              <button class="production-button" data-building-type="hospital">
-                <img draggable="true" src="images/sidebar/hospital.webp" onerror="this.style.display='none'">
-                <span class="building-name">Hospital</span>
+              <button class="production-button" data-building-type="gasStation">
+                <img draggable="true" src="images/sidebar/gas_station.webp" onerror="this.style.display='none'">
+                <span class="building-name">Gas Station</span>
                 <span class="building-cost"></span>
                 <span class="building-power"></span>
                 <div class="production-progress"></div>
                 <div class="batch-counter" style="display:none">0</div>
                 <div class="new-label" style="display:none">NEW</div>
               </button>
-              <button class="production-button" data-building-type="gasStation">
-                <img draggable="true" src="images/sidebar/gas_station.webp" onerror="this.style.display='none'">
-                <span class="building-name">Gas Station</span>
+              <button class="production-button" data-building-type="vehicleWorkshop">
+                <img draggable="true" src="images/sidebar/vehicle_workshop.webp" onerror="this.style.display='none'">
+                <span class="building-name">Vehicle Workshop</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
+                <div class="production-progress"></div>
+                <div class="batch-counter" style="display:none">0</div>
+                <div class="new-label" style="display:none">NEW</div>
+              </button>
+              <button class="production-button" data-building-type="hospital">
+                <img draggable="true" src="images/sidebar/hospital.webp" onerror="this.style.display='none'">
+                <span class="building-name">Hospital</span>
                 <span class="building-cost"></span>
                 <span class="building-power"></span>
                 <div class="production-progress"></div>
@@ -306,6 +297,15 @@
               <button class="production-button" data-building-type="concreteWall">
                 <img draggable="true" src="images/sidebar/concrete_wall.webp" onerror="this.style.display='none'">
                 <span class="building-name">Concrete Wall</span>
+                <span class="building-cost"></span>
+                <span class="building-power"></span>
+                <div class="production-progress"></div>
+                <div class="batch-counter" style="display:none">0</div>
+                <div class="new-label" style="display:none">NEW</div>
+              </button>
+              <button class="production-button" data-building-type="constructionYard">
+                <img draggable="true" src="images/sidebar/construction_yard.png" onerror="this.style.display='none'">
+                <span class="building-name">Construction Yard</span>
                 <span class="building-cost"></span>
                 <span class="building-power"></span>
                 <div class="production-progress"></div>

--- a/src/ui/productionController.js
+++ b/src/ui/productionController.js
@@ -111,6 +111,7 @@ export class ProductionController {
     const hasPowerPlant = playerBuildings.some(b => b.type === 'powerPlant')
     const hasRefinery = playerBuildings.some(b => b.type === 'oreRefinery')
     const hasVehicleFactory = playerBuildings.some(b => b.type === 'vehicleFactory')
+    const hasVehicleWorkshop = playerBuildings.some(b => b.type === 'vehicleWorkshop')
 
     const buildingButtons = document.querySelectorAll('.production-button[data-building-type]')
 
@@ -118,6 +119,15 @@ export class ProductionController {
       const type = button.getAttribute('data-building-type')
       let disable = false
       const req = []
+      const shouldForceVisible =
+        button.classList.contains('ready-for-placement') ||
+        this.getBuildingProductionCount(button) > 0
+
+      if (!gameState.availableBuildingTypes.has(type)) {
+        button.classList.add('disabled')
+        button.style.display = 'none'
+        return
+      }
 
       const isPowerPlant = type === 'powerPlant'
       const isOreRefinery = type === 'oreRefinery'
@@ -126,12 +136,12 @@ export class ProductionController {
 
       if (!hasConstructionYard && !isConstructionYardButton) {
         disable = true
-        req.push('Construction Yard')
+        if (!req.includes('Construction Yard')) req.push('Construction Yard')
       }
 
       if (buildingData[type]?.requiresRadar && !hasRadar) {
         disable = true
-        req.push('Radar Station')
+        if (!req.includes('Radar Station')) req.push('Radar Station')
       }
 
       if (!hasPowerPlant && !isPowerPlant && !isConstructionYardButton) {
@@ -149,14 +159,26 @@ export class ProductionController {
         if (!req.includes('Vehicle Factory')) req.push('Vehicle Factory')
       }
 
+      if (isConstructionYardButton && !hasVehicleWorkshop) {
+        disable = true
+        if (!req.includes('Vehicle Workshop')) req.push('Vehicle Workshop')
+      }
+
       // Vehicle Factory now only requires Power Plant (removed refinery requirement)
 
       if (disable) {
         button.classList.add('disabled')
-        button.title = 'Requires ' + req.join(' & ')
+        const requirementText = req.length ? 'Requires ' + req.join(' & ') : ''
+        button.title = requirementText
+        if (!shouldForceVisible) {
+          button.style.display = 'none'
+        } else {
+          button.style.display = ''
+        }
       } else {
         button.classList.remove('disabled')
         button.title = ''
+        button.style.display = ''
       }
     })
   }


### PR DESCRIPTION
## Summary
- reorder the building production menu so power infrastructure leads and the construction yard sits at the end
- hide building buttons while their prerequisites are unmet and require a vehicle workshop before the construction yard becomes available

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ff6fce06d48328b2df1caf34b8b8c2