### PR TITLE
Reduce artillery projectile speed

### DIFF
--- a/src/buildings.js
+++ b/src/buildings.js
@@ -207,7 +207,7 @@ export const buildingData = {
     damage: 100, // 500% of a tank's base damage
     armor: 2,
     projectileType: 'artillery',
-    projectileSpeed: 3
+    projectileSpeed: 0.75
   },
   concreteWall: {
     width: 1,


### PR DESCRIPTION
## Summary
- reduce the artillery turret projectile speed to one quarter of its previous value for slower shells

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffa26587c883288e5803d2c16d4a6f