### PR TITLE
Expand workshop rally point base range

### DIFF
--- a/src/utils/baseUtils.js
+++ b/src/utils/baseUtils.js
@@ -32,7 +32,7 @@ export function getBaseStructures(owner, {
   if (Array.isArray(buildings)) {
     buildings.forEach(building => {
       if (!building || building.owner !== owner) return
-      if (building.type !== 'constructionYard' && building.type !== 'commandCenter') return
+
       baseStructures.push({
         x: building.x || 0,
         y: building.y || 0,


### PR DESCRIPTION
## Summary
- allow workshop rally point validation to consider all player-owned structures
- ensure rally points can be set anywhere within the base's full building range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffcf7e9788832884965a93f74342b5