### PR TITLE
Prevent mobile zooming on orientation changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     >
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ import { milestoneSystem } from './game/milestoneSystem.js'
 import { updateDangerZoneMaps } from './game/dangerZoneMap.js'
 import { APP_VERSION } from './version.js'
 import { initializeShadowOfWar, updateShadowOfWar } from './game/shadowOfWar.js'
+import { initializeMobileViewportLock } from './ui/mobileViewportLock.js'
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
@@ -69,6 +70,8 @@ let gameInstance = null
 let lastIsTouchState = null
 let lastMobileLayoutMode = null
 let portraitQuery = null
+
+initializeMobileViewportLock()
 
 const mobileLayoutState = {
   productionArea: null,

--- a/src/ui/mobileViewportLock.js
+++ b/src/ui/mobileViewportLock.js
@@ -1,0 +1,124 @@
+const VIEWPORT_META_SELECTOR = 'meta[name="viewport"]'
+const LOCKED_VIEWPORT_CONTENT = [
+  'width=device-width',
+  'initial-scale=1.0',
+  'minimum-scale=1.0',
+  'maximum-scale=1.0',
+  'user-scalable=no',
+  'viewport-fit=cover'
+].join(', ')
+
+let initialized = false
+let viewportMeta = null
+let pendingReset = null
+let lastTouchEnd = 0
+
+function getViewportMeta() {
+  if (viewportMeta && viewportMeta.isConnected) {
+    return viewportMeta
+  }
+
+  viewportMeta = typeof document !== 'undefined'
+    ? document.querySelector(VIEWPORT_META_SELECTOR)
+    : null
+
+  return viewportMeta
+}
+
+function applyViewportLock() {
+  const meta = getViewportMeta()
+  if (!meta) {
+    return
+  }
+
+  const currentContent = meta.getAttribute('content') || ''
+  if (currentContent === LOCKED_VIEWPORT_CONTENT) {
+    return
+  }
+
+  meta.setAttribute('content', LOCKED_VIEWPORT_CONTENT)
+}
+
+function scheduleViewportReset() {
+  if (pendingReset !== null) {
+    return
+  }
+
+  const run = () => {
+    pendingReset = null
+    applyViewportLock()
+  }
+
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    pendingReset = window.requestAnimationFrame(run)
+  } else {
+    pendingReset = setTimeout(run, 16)
+  }
+}
+
+function handleOrientationChange() {
+  scheduleViewportReset()
+  // Run a few additional resets after the orientation settles because some browsers
+  // adjust their viewport metrics asynchronously.
+  setTimeout(scheduleViewportReset, 150)
+  setTimeout(scheduleViewportReset, 350)
+}
+
+function handleTouchEnd(event) {
+  if (event.touches?.length) {
+    return
+  }
+
+  const target = event.target
+  if (target && typeof target.closest === 'function') {
+    const interactive = target.closest('input, textarea, select, [contenteditable="true"], [contenteditable=""]')
+    if (interactive) {
+      return
+    }
+  }
+
+  const now = performance.now()
+  if (now - lastTouchEnd <= 350) {
+    event.preventDefault()
+    scheduleViewportReset()
+  }
+
+  lastTouchEnd = now
+}
+
+export function initializeMobileViewportLock() {
+  if (initialized) {
+    return
+  }
+
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return
+  }
+
+  const hasNavigator = typeof navigator !== 'undefined'
+  const hasTouchSupport = ('ontouchstart' in window) || (hasNavigator && navigator.maxTouchPoints > 0)
+
+  // Only apply the lock on touch-capable devices.
+  if (!hasTouchSupport) {
+    return
+  }
+
+  initialized = true
+
+  applyViewportLock()
+
+  window.addEventListener('orientationchange', handleOrientationChange)
+
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', scheduleViewportReset)
+  } else {
+    window.addEventListener('resize', scheduleViewportReset)
+  }
+
+  document.addEventListener('gesturestart', event => {
+    event.preventDefault()
+    scheduleViewportReset()
+  }, { passive: false })
+
+  document.addEventListener('touchend', handleTouchEnd, { passive: false })
+}


### PR DESCRIPTION
## Summary
- lock the viewport scale on touch devices to prevent unintended zooming
- reset the viewport meta tag after orientation changes and double taps
- update the viewport meta declaration to disallow user scaling

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_69009bff76688328bcb78a42f76af4f5