### PR TITLE
Adjust game over conditions to ignore concrete walls

### DIFF
--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -342,9 +342,18 @@ export function checkGameEndConditions(factories, gameState) {
   if (gameState.gameOver) return true
   if (!gameState.buildings) return false
 
-  // Count remaining buildings AND factories for human player
-  const humanPlayerBuildings = gameState.buildings.filter(b => b.owner === gameState.humanPlayer && b.health > 0)
-  const humanPlayerFactories = factories.filter(f => (f.id === gameState.humanPlayer || f.owner === gameState.humanPlayer) && f.health > 0)
+  const shouldCountBuilding = (building) => {
+    if (!building || building.health <= 0) return false
+    return building.type !== 'concreteWall'
+  }
+
+  // Count remaining buildings AND factories for human player (excluding concrete walls)
+  const humanPlayerBuildings = gameState.buildings.filter(
+    b => b.owner === gameState.humanPlayer && shouldCountBuilding(b)
+  )
+  const humanPlayerFactories = factories.filter(
+    f => (f.id === gameState.humanPlayer || f.owner === gameState.humanPlayer) && shouldCountBuilding(f)
+  )
   const totalHumanPlayerBuildings = humanPlayerBuildings.length + humanPlayerFactories.length
 
   // Check if human player has no buildings left
@@ -367,8 +376,12 @@ export function checkGameEndConditions(factories, gameState) {
   const defeatedAiPlayers = []
 
   for (const aiPlayerId of aiPlayerIds) {
-    const aiBuildings = gameState.buildings.filter(b => b.owner === aiPlayerId && b.health > 0)
-    const aiFactories = factories.filter(f => (f.id === aiPlayerId || f.owner === aiPlayerId) && f.health > 0)
+    const aiBuildings = gameState.buildings.filter(
+      b => b.owner === aiPlayerId && shouldCountBuilding(b)
+    )
+    const aiFactories = factories.filter(
+      f => (f.id === aiPlayerId || f.owner === aiPlayerId) && shouldCountBuilding(f)
+    )
     const totalAiBuildings = aiBuildings.length + aiFactories.length
 
     if (totalAiBuildings > 0) {


### PR DESCRIPTION
## Summary
- ensure game end checks ignore concrete wall structures when counting remaining buildings
- prevent defeat or victory from triggering until all non-wall buildings for a side are destroyed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902173644d08328857b8fd4ced9f695