### PR TITLE
Rename game branding to CodeAndConquer

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -1,4 +1,4 @@
-# Gemini RTS Game - Documentation
+# CodeAndConquer - Documentation
 
 ## Enemy Unit Retaliation System
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gemini RTS Game
+# CodeAndConquer
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/theSystem85/gemini-rts-game)
 
@@ -20,7 +20,7 @@ Develop a fully functional, minimal viable product (MVP) of a real-time strategy
 
 ## 1. Intro
 
-**1.1** Gemini RTS Game – a test project to build a complex RTS game from scratch using a 1M token context window.
+**1.1** CodeAndConquer – a test project to build a complex RTS game from scratch using a 1M token context window.
 
 ## 2. General Setup
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <title>Gemini RTS Game</title>
+    <title>CodeAndConquer</title>
     <meta name="description" content="A 2D tile-based Real-Time Strategy game built with vanilla JavaScript">
     
     <!-- Favicons -->

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Gemini RTS Game",
-  "short_name": "RTS Game",
+  "name": "CodeAndConquer",
+  "short_name": "CodeAndConquer",
   "description": "A 2D tile-based Real-Time Strategy game built with vanilla JavaScript",
   "icons": [
     {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'gemini-rts-cache-v1'
+const CACHE_NAME = 'codeandconquer-cache-v1'
 const PRECACHE_URLS = [
   '/',
   '/index.html',

--- a/src/main.js
+++ b/src/main.js
@@ -54,7 +54,7 @@ if ('serviceWorker' in navigator) {
     if (typeof caches !== 'undefined' && caches?.keys) {
       caches.keys().then(cacheNames => {
         cacheNames
-          .filter(name => name.startsWith('gemini-rts-cache-'))
+          .filter(name => name.startsWith('codeandconquer-cache-'))
           .forEach(name => {
             caches.delete(name).catch(err => {
               console.warn('Failed to delete service worker cache', name, err)

--- a/statistics.md
+++ b/statistics.md
@@ -2,7 +2,7 @@
 
 **Generated on:** June 25, 2025  
 **Analysis Date:** 2025-06-25  
-**Project:** Gemini RTS Game Clone
+**Project:** CodeAndConquer Clone
 
 ## File Size Analysis
 


### PR DESCRIPTION
## Summary
- rename documentation, metadata, and UI title to CodeAndConquer
- update PWA manifest and service worker cache naming to the new branding
- align service worker cleanup logic with the CodeAndConquer cache prefix

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902366b1d1c8328a96dcf882e290ad5