### PR TITLE
Reduce ambulance acceleration rate

### DIFF
--- a/src/game/unifiedMovement.js
+++ b/src/game/unifiedMovement.js
@@ -318,9 +318,9 @@ export function updateUnitPosition(unit, mapGrid, occupancyMap, now, units = [],
   if (shouldDecelerate || !movement.isMoving) {
     accelRate = MOVEMENT_CONFIG.DECELERATION
   } else if (canAccelerate && movement.isMoving) {
-    // Special case for ambulances - they accelerate half as fast
+    // Special case for ambulances - they accelerate at a quarter speed
     if (unit.type === 'ambulance') {
-      accelRate = MOVEMENT_CONFIG.ACCELERATION * 0.5
+      accelRate = MOVEMENT_CONFIG.ACCELERATION * 0.25
     } else {
       accelRate = MOVEMENT_CONFIG.ACCELERATION
     }


### PR DESCRIPTION
## Summary
- reduce the ambulance acceleration multiplier so it accelerates at 25% of the standard rate
- clarify the accompanying comment about the reduced acceleration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69026dab87648328bff6bf67a331fc69