### PR TITLE
Fix cheat dialog overflow on small screens

### DIFF
--- a/src/input/cheatSystem.js
+++ b/src/input/cheatSystem.js
@@ -51,9 +51,12 @@ export class CheatSystem {
           border: 2px solid #3498db;
           border-radius: 8px;
           padding: 20px;
-          min-width: 400px;
+          width: min(90vw, 500px);
+          max-height: 90vh;
+          overflow-y: auto;
           box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
           font-family: 'Arial', sans-serif;
+          box-sizing: border-box;
         }
 
         .cheat-dialog h2 {


### PR DESCRIPTION
## Summary
- ensure the cheat dialog fits within the viewport on small screens by constraining width and height
- enable internal scrolling so long cheat help content remains accessible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69027ab19c6c8328a8a031ddcd3267a6