### PR TITLE
Allow selecting enemy buildings and add kill cheat code

### DIFF
--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -1150,26 +1150,22 @@ export class MouseHandler {
     // PRIORITY 2: Check for building selection (including vehicle factories)
     let clickedBuilding = null
     if (gameState.buildings && gameState.buildings.length > 0) {
-      const humanPlayer = gameState.humanPlayer || 'player1'
       for (const building of gameState.buildings) {
-        const isPlayerBuilding = selectionManager.isHumanPlayerBuilding(building)
-        const isEnemyYard =
-          building.type === 'constructionYard' && building.owner !== humanPlayer
-        if (isPlayerBuilding || isEnemyYard) {
-          const buildingX = building.x * TILE_SIZE
-          const buildingY = building.y * TILE_SIZE
-          const buildingWidth = building.width * TILE_SIZE
-          const buildingHeight = building.height * TILE_SIZE
+        if (!building || building.health <= 0) continue
 
-          if (
-            worldX >= buildingX &&
-            worldX < buildingX + buildingWidth &&
-            worldY >= buildingY &&
-            worldY < buildingY + buildingHeight
-          ) {
-            clickedBuilding = building
-            break
-          }
+        const buildingX = building.x * TILE_SIZE
+        const buildingY = building.y * TILE_SIZE
+        const buildingWidth = building.width * TILE_SIZE
+        const buildingHeight = building.height * TILE_SIZE
+
+        if (
+          worldX >= buildingX &&
+          worldX < buildingX + buildingWidth &&
+          worldY >= buildingY &&
+          worldY < buildingY + buildingHeight
+        ) {
+          clickedBuilding = building
+          break
         }
       }
     }


### PR DESCRIPTION
## Summary
- let the mouse handler treat any healthy building as selectable so enemy structures can be inspected
- surface the new `kill` cheat code in the cheat dialog help and wire it into the console
- implement the cheat logic to zero out health on all selected units or buildings and clear the selection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690375e8d3ac8328a825634c8c0151d9