### PR TITLE
Add runtime-configurable howitzer building damage multiplier

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -791,6 +791,12 @@ export function setHowitzerVisionRange(value) {
   HOWITZER_VISION_RANGE = value
 }
 
+export let HOWITZER_BUILDING_DAMAGE_MULTIPLIER = 2
+
+export function setHowitzerBuildingDamageMultiplier(value) {
+  HOWITZER_BUILDING_DAMAGE_MULTIPLIER = value
+}
+
 // Tank V3 burst fire configuration
 export let TANK_V3_BURST = {
   COUNT: 2,     // Number of bullets per burst

--- a/src/configRegistry.js
+++ b/src/configRegistry.js
@@ -98,6 +98,8 @@ import {
   , setHowitzerProjectileSpeed
   , HOWITZER_VISION_RANGE
   , setHowitzerVisionRange
+  , HOWITZER_BUILDING_DAMAGE_MULTIPLIER
+  , setHowitzerBuildingDamageMultiplier
 } from './config.js'
 
 /**
@@ -307,6 +309,18 @@ export const configRegistry = {
     min: 1,
     max: 35,
     step: 1,
+    category: 'Howitzer'
+  },
+
+  howitzerBuildingDamageMultiplier: {
+    name: 'Howitzer Building Damage Multiplier',
+    description: 'Multiplier applied to howitzer explosion damage against buildings',
+    type: 'number',
+    get: () => HOWITZER_BUILDING_DAMAGE_MULTIPLIER,
+    set: setHowitzerBuildingDamageMultiplier,
+    min: 0,
+    max: 10,
+    step: 0.1,
     category: 'Howitzer'
   },
 

--- a/src/logic.js
+++ b/src/logic.js
@@ -1,6 +1,7 @@
 // logic.js
 import {
-  TILE_SIZE
+  TILE_SIZE,
+  HOWITZER_BUILDING_DAMAGE_MULTIPLIER
 } from './config.js'
 import { gameState } from './gameState.js'
 import { playSound, playPositionalSound } from './sound.js'
@@ -201,6 +202,10 @@ export function triggerExplosion(
         } else {
           const falloff = 1 - distance / explosionRadius
           damage = Math.round(baseDamage * falloff * 0.3) // 30% damage with falloff
+        }
+
+        if (shooter && shooter.type === 'howitzer') {
+          damage = Math.round(damage * HOWITZER_BUILDING_DAMAGE_MULTIPLIER)
         }
 
         // Check for god mode protection for player buildings


### PR DESCRIPTION
## Summary
- add a configurable building damage multiplier for howitzer explosions
- expose the multiplier in the runtime configuration editor alongside other howitzer settings
- apply the multiplier when buildings are damaged by howitzer shells

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_69037e3224248328b5735445504d7db1