### PR TITLE
Prevent issuing commands during mobile two-finger panning

### DIFF
--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -15,6 +15,7 @@ import {
   getPlayableViewportHeight,
   getPlayableViewportWidth
 } from '../utils/layoutMetrics.js'
+import { suspendRemoteControlAutoFocus } from '../game/remoteControl.js'
 
 export class MouseHandler {
   constructor() {
@@ -1454,6 +1455,7 @@ export class MouseHandler {
         pointerIds,
         lastCenter: center
       }
+      suspendRemoteControlAutoFocus()
       pointerIds.forEach(id => {
         const state = activePointers.get(id)
         if (state) {


### PR DESCRIPTION
## Summary
- cancel selection state and mark touch pointers when a two-finger pan begins
- block synthetic tap commands after panning so scrolling does not order units to move or attack

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_6903a80bc9e88328aff3c39eff1c061a