### PR TITLE
Ensure rendering resumes when unpausing

### DIFF
--- a/src/game/gameLoop.js
+++ b/src/game/gameLoop.js
@@ -91,6 +91,16 @@ export class GameLoop {
     this.scheduleNextFrame()
   }
 
+  resumeFromPause() {
+    if (!this.running) {
+      return
+    }
+
+    this.forceRender = true
+    this.lastFrameTime = null
+    this.scheduleNextFrame()
+  }
+
   scheduleNextFrame() {
     if (!this.running || this.animationId) {
       return

--- a/src/saveGame.js
+++ b/src/saveGame.js
@@ -678,6 +678,10 @@ export function loadGame(key) {
     gameState.gamePaused = false
     gameState.gameStarted = true
 
+    if (gameInstance && gameInstance.gameLoop && typeof gameInstance.gameLoop.resumeFromPause === 'function') {
+      gameInstance.gameLoop.resumeFromPause()
+    }
+
     // Update pause button to show pause icon since game is now running
     const pauseBtn = document.getElementById('pauseBtn')
     if (pauseBtn) {

--- a/src/ui/eventHandlers.js
+++ b/src/ui/eventHandlers.js
@@ -58,6 +58,10 @@ export class EventHandlers {
       // If the game was just unpaused, resume any pending productions
       if (!gameState.gamePaused) {
         productionQueue.resumeProductionAfterUnpause()
+
+        if (this.gameInstance && this.gameInstance.gameLoop && typeof this.gameInstance.gameLoop.resumeFromPause === 'function') {
+          this.gameInstance.gameLoop.resumeFromPause()
+        }
       }
     })
 


### PR DESCRIPTION
## Summary
- add a GameLoop.resumeFromPause helper that restarts scheduled frames
- invoke the new helper when unpausing via the pause button or after loading a save

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904c18874448328beb78de3c66b2eb7