### PR TITLE
Fix howitzer map sprite orientation

### DIFF
--- a/src/rendering/howitzerImageRenderer.js
+++ b/src/rendering/howitzerImageRenderer.js
@@ -44,8 +44,8 @@ export function renderHowitzerWithImage(ctx, unit, centerX, centerY) {
   ctx.save()
   ctx.translate(centerX, centerY)
 
-  // Image faces downward by default. Rotate so direction=0 points right.
-  const rotation = unit.direction - Math.PI / 2
+  // Image faces upward by default. Rotate so direction=0 points right.
+  const rotation = unit.direction + Math.PI / 2
   ctx.rotate(rotation)
 
   const scale = TILE_SIZE / Math.max(howitzerImg.width, howitzerImg.height)


### PR DESCRIPTION
## Summary
- rotate the howitzer map sprite so the rendered unit faces the correct direction

## Testing
- `npm run lint` *(fails: pre-existing lint violations in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_690518747b10832896077377b4dcf733