### PR TITLE
Disable shadow of war by default and persist setting

### DIFF
--- a/src/gameState.js
+++ b/src/gameState.js
@@ -113,8 +113,8 @@ export const gameState = {
   // Radar station status - initialize to false (no radar at game start)
   radarActive: false,
 
-  // Shadow of war visibility state
-  shadowOfWarEnabled: true,
+  // Shadow of war visibility state (disabled by default for new games)
+  shadowOfWarEnabled: false,
   visibilityMap: [],
 
   // Grid visibility toggle - initialize to false (grid hidden by default)

--- a/src/main.js
+++ b/src/main.js
@@ -955,6 +955,8 @@ function loadPersistedSettings() {
     const storedShadowSetting = localStorage.getItem(SHADOW_OF_WAR_STORAGE_KEY)
     if (storedShadowSetting !== null) {
       gameState.shadowOfWarEnabled = storedShadowSetting === 'true'
+    } else {
+      gameState.shadowOfWarEnabled = false
     }
   } catch (e) {
     console.warn('Failed to load shadow of war setting from localStorage:', e)


### PR DESCRIPTION
## Summary
- default new games to start with shadow of war disabled in game state
- keep loading the user's stored shadow of war preference from localStorage with a disabled fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907c112f3408328897888736ffb567d