### PR TITLE
Adjust mobile landscape map drag speed

### DIFF
--- a/src/input/mouseHandler.js
+++ b/src/input/mouseHandler.js
@@ -492,8 +492,9 @@ export class MouseHandler {
     const logicalWidth = getPlayableViewportWidth(gameCanvas)
     const logicalHeight = getPlayableViewportHeight(gameCanvas)
 
-    // Multiply by 2 to make scrolling 2x faster
-    const scrollSpeed = 2
+    // Multiply by 2 on desktop, but ease the speed slightly on mobile landscape layouts
+    const isMobileLandscape = document.body?.classList?.contains('mobile-landscape')
+    const scrollSpeed = isMobileLandscape ? 1.4 : 2
     gameState.scrollOffset.x = Math.max(
       0,
       Math.min(gameState.scrollOffset.x - (dx * scrollSpeed), mapGrid[0].length * TILE_SIZE - logicalWidth)


### PR DESCRIPTION
## Summary
- reduce drag scroll multiplier when the mobile landscape layout is active to smooth map panning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907c7b2e5a08328b23c781e538865a2