### PR TITLE
Prevent Apache landing on occupied tiles and refine combat behaviour

### DIFF
--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -326,6 +326,14 @@ export class UnitRenderer {
       shouldShowBar = true
       progress = (unit.medics || 0) / (unit.maxMedics || 10)
       barColor = '#00FFFF' // Cyan for ambulance crew
+    } else if (unit.type === 'apache') {
+      const maxAmmo = typeof unit.maxRocketAmmo === 'number' ? unit.maxRocketAmmo : null
+      if (unit.selected && maxAmmo && maxAmmo > 0) {
+        shouldShowBar = true
+        const ammoRatio = Math.max(0, Math.min(1, (unit.rocketAmmo || 0) / maxAmmo))
+        progress = ammoRatio
+        barColor = unit.apacheAmmoEmpty ? '#FF6B6B' : '#FFA500'
+      }
     } else if (unit.type === 'tankerTruck') {
       shouldShowBar = true
       progress = (unit.supplyGas || 0) / (unit.maxSupplyGas || TANKER_SUPPLY_CAPACITY)


### PR DESCRIPTION
## Summary
- block Apache landing attempts when the current tile is already occupied and hold a safe hover height instead
- keep Apaches in place when already in attack range, strafe aside only when directly above the target, and rotate them toward their target while firing
- show Apache rocket ammunition in the selection overlay instead of an empty bar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908baded564832893f8e030dedb3384