### PR TITLE
Fix non-finite explosion radii in effects renderer

### DIFF
--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -288,11 +288,15 @@ export function cleanupDestroyedFactories(factories, mapGrid, gameState) {
       playPositionalSound('explosion', explosionX, explosionY, 0.5)
 
       // Add explosion effect at factory center
+      const maxDimension = Math.max(factory.width || 1, factory.height || 1)
+      const explosionRadius = Math.max(TILE_SIZE * 2, maxDimension * TILE_SIZE * 1.2)
+
       gameState.explosions.push({
         x: explosionX,
         y: explosionY,
         startTime: performance.now(),
         duration: 1000,
+        maxRadius: explosionRadius,
         color: '#ff4444'
       })
     }

--- a/src/rendering/effectsRenderer.js
+++ b/src/rendering/effectsRenderer.js
@@ -212,11 +212,22 @@ export class EffectsRenderer {
     if (gameState?.explosions && gameState?.explosions.length > 0) {
       const currentTime = performance.now()
       gameState.explosions.forEach(exp => {
-        const progress = (currentTime - exp.startTime) / exp.duration
-        const currentRadius = exp.maxRadius * progress
+        if (!exp) {
+          return
+        }
+
+        const safeDuration = Number.isFinite(exp.duration) && exp.duration > 0 ? exp.duration : 1
+        const rawProgress = (currentTime - exp.startTime) / safeDuration
+        const progress = Math.min(Math.max(rawProgress, 0), 1)
+        const maxRadius = Number.isFinite(exp.maxRadius) && exp.maxRadius > 0 ? exp.maxRadius : TILE_SIZE * 2
+        const currentRadius = maxRadius * progress
         const alpha = Math.max(0, 1 - progress)
         const centerX = exp.x - scrollOffset.x
         const centerY = exp.y - scrollOffset.y
+
+        if (!Number.isFinite(centerX) || !Number.isFinite(centerY) || !Number.isFinite(currentRadius) || currentRadius <= 0) {
+          return
+        }
 
         const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, currentRadius)
         gradient.addColorStop(0, `rgba(255,150,0,${alpha})`)


### PR DESCRIPTION
## Summary
- ensure factory cleanup records a max explosion radius so renderer receives finite data
- guard the effects renderer against invalid explosion duration and radius values before drawing gradients

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_690909509b448328a1821811096107ce