### PR TITLE
Add Apache rotor loop sound effect

### DIFF
--- a/src/sound.js
+++ b/src/sound.js
@@ -101,6 +101,9 @@ const soundFiles = {
   // Looping tank drive sound
   tankDriveLoop: ['tankDrive4sLoop.mp3'],
 
+  // Apache helicopter flight loop
+  apache_fly: ['apache_fly.mp3'],
+
   // Game event aliases (previously in soundMapping)
   movement: ['tankEngineStart01.mp3', 'confirmed.mp3', 'onMyWay.mp3'], // alias for tankMove
   shoot: ['tankShot01.mp3', 'tankShot02.mp3', 'tankShot03.mp3'], // alias for tankShot


### PR DESCRIPTION
## Summary
- add the `apache_fly` audio asset to the sound library for helicopter flight
- start and manage a looping positional rotor sound whenever Apache units are airborne

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69091328509c8328ad2809eb115d022c