### PR TITLE
Prevent artillery explosions from damaging airborne helicopters

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -51,6 +51,13 @@ export function triggerExplosion(
     // Skip the shooter if this was their own bullet
     if (distance < explosionRadius) {
       if (shooter && unit.id === shooter.id) return
+
+      const isAirUnit = unit.isAirUnit || unit.type === 'apache'
+      const airborneStates = ['takeoff', 'airborne', 'landing']
+      const isAirborne = isAirUnit && airborneStates.includes(unit.flightState)
+      if (isAirborne) {
+        return
+      }
       let damage
       if (constantDamage) {
         damage = baseDamage


### PR DESCRIPTION
## Summary
- skip applying explosion damage to airborne helicopters when resolving ground-based blasts

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123839d56c8328913f063005614188)