### PR TITLE
Add shoreline smoothing: chunk-local masks + shader blending

### DIFF
--- a/TODO/Improvements.md
+++ b/TODO/Improvements.md
@@ -780,3 +780,4 @@
 - [x] Restore mobile double-tap cancel behavior for placement/planning mode and keep two-finger pan scrolling functional after using draw-to-plan mode.
 
 - [x] ✅ Add fuzzy runtime-config search that matches variable names/IDs/current values and allows editing directly from filtered results.
+- [x] Implement shoreline smoothing in the WebGL terrain path using a shoreline-only soft alpha mask that blends procedural water with land texture samples, supports grayscale shoreline-mask debug view, and updates chunk-local shoreline masks only for affected tiles.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-starter",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-starter",
-      "version": "0.30.2",
+      "version": "0.30.3",
       "license": "MIT",
       "dependencies": {
         "@netlify/blobs": "^10.4.2",

--- a/prompt-history/2026-04-08T10-50-55Z_shoreline-smoothing-shader.md
+++ b/prompt-history/2026-04-08T10-50-55Z_shoreline-smoothing-shader.md
@@ -1,0 +1,23 @@
+# 2026-04-08T10-50-55Z UTC
+- Model: codex
+
+## Prompt
+Implement shoreline smoothing by blending land and water in the terrain shader using a soft alpha mask.
+
+Requirements:
+- Keep the terrain tile system tile-based
+- Detect shoreline tiles where land borders water
+- For shoreline areas, generate a blend mask that smoothly transitions from land to water
+- In the WebGL terrain shader, sample both the land texture and the water texture and blend them using the shoreline mask
+- Use smooth interpolation so tile intersections and jagged shoreline edges become visually softer
+- Restrict this extra blending work to shoreline tiles only
+- Preserve current terrain rendering performance as much as possible
+- Terrain changes must update the shoreline mask only in affected chunks/tiles
+- Add a debug view to render the shoreline mask in grayscale
+
+Implementation notes:
+- Prefer chunk-local precomputed mask data
+- Avoid full-map rebuilds when only a few tiles change
+- Do not use a fullscreen postprocess pass
+- Do not blur unrelated terrain
+- The result should make the coast look softer without making the whole map look muddy

--- a/specs/061-shoreline-smoothing.md
+++ b/specs/061-shoreline-smoothing.md
@@ -1,0 +1,24 @@
+# Spec 061: Shoreline Smoothing (Shoreline-Only Blend Mask)
+
+## Summary
+
+Add shoreline-only terrain blending in the WebGL path by precomputing chunk-local shoreline edge masks and using a soft alpha transition in the terrain shader to blend land and water at coastlines.
+
+## Requirements
+
+1. Keep the tile-based terrain system intact.
+2. Detect shoreline tiles where orthogonal land/water borders exist.
+3. Precompute shoreline mask data chunk-locally.
+4. In WebGL terrain shader, sample land texture data and procedural water shading and blend using shoreline mask.
+5. Use smooth interpolation (`smoothstep`) so shoreline intersections appear softer.
+6. Restrict additional blend work to shoreline tiles only.
+7. Avoid full-map recompute when a few tiles mutate; invalidate only affected chunks/tiles.
+8. Add a debug mode that renders the shoreline mask in grayscale.
+9. Do not apply fullscreen postprocessing and do not blur unrelated terrain.
+10. Preserve runtime performance characteristics as much as possible.
+
+## Notes
+
+- Shoreline chunk masks are keyed by map-renderer chunk key and rebuilt lazily on demand.
+- Tile updates invalidate shoreline chunks in a 3x3 chunk neighborhood around the changed tile to preserve correctness for adjacent coastline transitions.
+- Shader path keeps non-shoreline tiles on existing fast path and branches into blend logic only when per-instance shoreline metadata is active.

--- a/src/config.js
+++ b/src/config.js
@@ -378,7 +378,8 @@ function saveGraphicsSettingsToLocalStorage() {
       JSON.stringify({
         useProceduralWaterRendering: USE_PROCEDURAL_WATER_RENDERING,
         waterEffectTone: WATER_EFFECT_TONE,
-        waterEffectSaturation: WATER_EFFECT_SATURATION
+        waterEffectSaturation: WATER_EFFECT_SATURATION,
+        shorelineMaskDebugView: SHORELINE_MASK_DEBUG_VIEW
       })
     )
   } catch (error) {
@@ -412,6 +413,9 @@ function loadGraphicsSettingsFromLocalStorage() {
 
     WATER_EFFECT_TONE = clampNumber(parsed?.waterEffectTone, -1, 1, WATER_EFFECT_TONE)
     WATER_EFFECT_SATURATION = clampNumber(parsed?.waterEffectSaturation, 0, 2, WATER_EFFECT_SATURATION)
+    if (typeof parsed?.shorelineMaskDebugView === 'boolean') {
+      SHORELINE_MASK_DEBUG_VIEW = parsed.shorelineMaskDebugView
+    }
   } catch (error) {
     window.logger?.warn('Failed to load graphics settings from localStorage:', error)
   }
@@ -458,6 +462,15 @@ export function setWaterEffectZoom(value) {
   WATER_EFFECT_ZOOM = numericValue
   requestGraphicsSettingsRender()
   return WATER_EFFECT_ZOOM
+}
+
+export let SHORELINE_MASK_DEBUG_VIEW = false
+
+export function setShorelineMaskDebugView(value) {
+  SHORELINE_MASK_DEBUG_VIEW = Boolean(value)
+  saveGraphicsSettingsToLocalStorage()
+  requestGraphicsSettingsRender()
+  return SHORELINE_MASK_DEBUG_VIEW
 }
 
 loadGraphicsSettingsFromLocalStorage()

--- a/src/configRegistry.js
+++ b/src/configRegistry.js
@@ -107,7 +107,9 @@ import {
   WATER_EFFECT_SATURATION,
   setWaterEffectSaturation,
   WATER_EFFECT_ZOOM,
-  setWaterEffectZoom
+  setWaterEffectZoom,
+  SHORELINE_MASK_DEBUG_VIEW,
+  setShorelineMaskDebugView
   , HOWITZER_COST
   , setHowitzerCost
   , HOWITZER_SPEED
@@ -194,6 +196,15 @@ export const configRegistry = {
     min: 0.05,
     max: 2,
     step: 0.05,
+    category: 'Graphics'
+  },
+
+  shorelineMaskDebugView: {
+    name: 'Shoreline Mask Debug View',
+    description: 'Render shoreline blend mask in grayscale instead of terrain shading',
+    type: 'boolean',
+    get: () => SHORELINE_MASK_DEBUG_VIEW,
+    set: setShorelineMaskDebugView,
     category: 'Graphics'
   },
 

--- a/src/rendering/mapRenderer.js
+++ b/src/rendering/mapRenderer.js
@@ -218,6 +218,8 @@ export class MapRenderer {
     // sotMask[y][x] = { orientation: 'top-left'|'top-right'|'bottom-left'|'bottom-right', type: 'street'|'water' } or null
     this.sotMask = null
     this.sotMaskVersion = 0
+    this.shorelineChunkMaskCache = new Map()
+    this.shorelineMaskVersion = 0
   }
 
   /**
@@ -230,6 +232,8 @@ export class MapRenderer {
       this.sotMask = null
       return
     }
+    this.shorelineChunkMaskCache.clear()
+    this.shorelineMaskVersion++
 
     const mapHeight = mapGrid.length
     const mapWidth = mapGrid[0].length
@@ -373,23 +377,109 @@ export class MapRenderer {
     }
     // Also invalidate SOT mask since map dimensions may have changed
     this.sotMask = null
+    this.shorelineChunkMaskCache.clear()
   }
 
   markTileDirty(tileX, tileY) {
-    if (!this.canUseOffscreen || !this.chunkCache.size) return
     const chunkX = Math.floor(tileX / this.chunkSize)
     const chunkY = Math.floor(tileY / this.chunkSize)
-
-    for (let dy = -1; dy <= 1; dy++) {
-      for (let dx = -1; dx <= 1; dx++) {
-        const key = this.getChunkKey(chunkX + dx, chunkY + dy)
-        const chunk = this.chunkCache.get(key)
-        if (chunk) {
-          chunk.signature = null
-          chunk.lastWaterFrameIndex = null
+    if (this.canUseOffscreen && this.chunkCache.size) {
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          const key = this.getChunkKey(chunkX + dx, chunkY + dy)
+          const chunk = this.chunkCache.get(key)
+          if (chunk) {
+            chunk.signature = null
+            chunk.lastWaterFrameIndex = null
+          }
         }
       }
     }
+
+    this.invalidateShorelineChunksForTile(tileX, tileY)
+  }
+
+  invalidateShorelineChunksForTile(tileX, tileY) {
+    const chunkX = Math.floor(tileX / this.chunkSize)
+    const chunkY = Math.floor(tileY / this.chunkSize)
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        this.shorelineChunkMaskCache.delete(this.getChunkKey(chunkX + dx, chunkY + dy))
+      }
+    }
+    this.shorelineMaskVersion++
+  }
+
+  computeShorelineMaskForChunk(mapGrid, chunkX, chunkY) {
+    if (!mapGrid?.length || !mapGrid[0]?.length) return null
+    const mapHeight = mapGrid.length
+    const mapWidth = mapGrid[0].length
+    const startX = chunkX * this.chunkSize
+    const startY = chunkY * this.chunkSize
+    if (startX >= mapWidth || startY >= mapHeight || chunkX < 0 || chunkY < 0) {
+      return null
+    }
+
+    const width = Math.min(this.chunkSize, mapWidth - startX)
+    const height = Math.min(this.chunkSize, mapHeight - startY)
+    const data = new Uint8Array(width * height * 4)
+
+    for (let localY = 0; localY < height; localY++) {
+      const y = startY + localY
+      for (let localX = 0; localX < width; localX++) {
+        const x = startX + localX
+        const tile = mapGrid[y]?.[x]
+        const tileType = tile?.airstripStreet ? 'land' : tile?.type
+        const isLandLike = tileType === 'land' || tileType === 'street'
+        const isWater = tileType === 'water'
+        if (!isLandLike && !isWater) continue
+
+        const topType = (mapGrid[y - 1]?.[x]?.airstripStreet ? 'land' : mapGrid[y - 1]?.[x]?.type) ?? null
+        const rightType = (mapGrid[y]?.[x + 1]?.airstripStreet ? 'land' : mapGrid[y]?.[x + 1]?.type) ?? null
+        const bottomType = (mapGrid[y + 1]?.[x]?.airstripStreet ? 'land' : mapGrid[y + 1]?.[x]?.type) ?? null
+        const leftType = (mapGrid[y]?.[x - 1]?.airstripStreet ? 'land' : mapGrid[y]?.[x - 1]?.type) ?? null
+
+        const top = isWater ? (topType === 'land' || topType === 'street') : topType === 'water'
+        const right = isWater ? (rightType === 'land' || rightType === 'street') : rightType === 'water'
+        const bottom = isWater ? (bottomType === 'land' || bottomType === 'street') : bottomType === 'water'
+        const left = isWater ? (leftType === 'land' || leftType === 'street') : leftType === 'water'
+        if (!top && !right && !bottom && !left) continue
+
+        const index = (localY * width + localX) * 4
+        data[index] = top ? 1 : 0
+        data[index + 1] = right ? 1 : 0
+        data[index + 2] = bottom ? 1 : 0
+        data[index + 3] = left ? 1 : 0
+      }
+    }
+
+    return { startX, startY, width, height, data }
+  }
+
+  getShorelineMaskForTile(mapGrid, tileX, tileY) {
+    if (!mapGrid?.length || !mapGrid[0]?.length) return null
+    if (tileX < 0 || tileY < 0 || tileY >= mapGrid.length || tileX >= mapGrid[0].length) return null
+
+    const chunkX = Math.floor(tileX / this.chunkSize)
+    const chunkY = Math.floor(tileY / this.chunkSize)
+    const key = this.getChunkKey(chunkX, chunkY)
+    let chunkMask = this.shorelineChunkMaskCache.get(key)
+    if (!chunkMask) {
+      chunkMask = this.computeShorelineMaskForChunk(mapGrid, chunkX, chunkY)
+      if (!chunkMask) return null
+      this.shorelineChunkMaskCache.set(key, chunkMask)
+    }
+
+    const localX = tileX - chunkMask.startX
+    const localY = tileY - chunkMask.startY
+    if (localX < 0 || localY < 0 || localX >= chunkMask.width || localY >= chunkMask.height) return null
+    const index = (localY * chunkMask.width + localX) * 4
+    return [
+      chunkMask.data[index],
+      chunkMask.data[index + 1],
+      chunkMask.data[index + 2],
+      chunkMask.data[index + 3]
+    ]
   }
 
   getChunkKey(chunkX, chunkY) {

--- a/src/rendering/webglRenderer.js
+++ b/src/rendering/webglRenderer.js
@@ -2,6 +2,7 @@ import {
   TILE_COLORS,
   TILE_SIZE,
   USE_TEXTURES,
+  SHORELINE_MASK_DEBUG_VIEW,
   WATER_EFFECT_TONE,
   WATER_EFFECT_SATURATION,
   WATER_EFFECT_ZOOM
@@ -38,6 +39,10 @@ layout(location = 3) in vec4 aColor;
 layout(location = 4) in float aTextureType;
 layout(location = 5) in vec4 aWaterEdges;
 layout(location = 6) in float aClipOrientation;
+layout(location = 7) in vec4 aShorelineEdges;
+layout(location = 8) in vec2 aShorelineMeta;
+layout(location = 9) in vec4 aShorelineLandUV;
+layout(location = 10) in vec4 aShorelineLandColor;
 
 uniform vec2 uResolution;
 uniform vec2 uScroll;
@@ -51,6 +56,10 @@ out vec2 vLocalPos;
 out vec2 vWorldPos;
 out vec4 vWaterEdges;
 out float vClipOrientation;
+out vec4 vShorelineEdges;
+out vec2 vShorelineMeta;
+out vec4 vShorelineLandUV;
+out vec4 vShorelineLandColor;
 
 void main() {
   vec2 worldPos = aTranslation * uTileStep - uScroll + aPosition * uTileSize;
@@ -65,6 +74,10 @@ void main() {
   vWorldPos = worldSamplePos;
   vWaterEdges = aWaterEdges;
   vClipOrientation = aClipOrientation;
+  vShorelineEdges = aShorelineEdges;
+  vShorelineMeta = aShorelineMeta;
+  vShorelineLandUV = aShorelineLandUV;
+  vShorelineLandColor = aShorelineLandColor;
 }
 `
 
@@ -76,6 +89,7 @@ uniform float uTime;
 uniform float uWaterZoom;
 uniform float uWaterTone;
 uniform float uWaterSaturation;
+uniform float uShorelineMaskDebugView;
 
 in vec2 vUV;
 in vec4 vColor;
@@ -84,12 +98,57 @@ in vec2 vLocalPos;
 in vec2 vWorldPos;
 in vec4 vWaterEdges;
 in float vClipOrientation;
+in vec4 vShorelineEdges;
+in vec2 vShorelineMeta;
+in vec4 vShorelineLandUV;
+in vec4 vShorelineLandColor;
 
 out vec4 outColor;
 
 vec3 applySaturation(vec3 color, float saturation) {
   float luma = dot(color, vec3(0.2126, 0.7152, 0.0722));
   return mix(vec3(luma), color, max(saturation, 0.0));
+}
+
+vec3 sampleProceduralWater(vec2 worldPos, vec2 localPos, vec4 edgeMask) {
+  float t = uTime * 0.001;
+  float worldScale = 1.0 / max(uWaterZoom, 0.001);
+  vec2 flow = vec2(
+    sin(worldPos.y * (0.031 * worldScale) + t * 0.82),
+    cos(worldPos.x * (0.029 * worldScale) - t * 0.74)
+  );
+  vec2 p = worldPos * (0.052 * worldScale) + flow * 1.15;
+  float waveA = sin(p.x * 1.2 + t * 1.1);
+  float waveB = cos(p.y * 1.35 - t * 1.25);
+  float waveC = sin((p.x - p.y) * 0.92 + t * 0.63);
+  float wave = (waveA + waveB + waveC) / 3.0;
+  float shimmer = 0.5 + 0.5 * sin((p.x * 1.2 - p.y * 1.05) + t * 1.65);
+  float toneBlend = clamp((uWaterTone + 1.0) * 0.5, 0.0, 1.0);
+
+  vec3 deepColor = mix(vec3(0.04, 0.18, 0.32), vec3(0.09, 0.27, 0.30), toneBlend);
+  vec3 brightColor = mix(vec3(0.08, 0.39, 0.58), vec3(0.13, 0.52, 0.43), toneBlend);
+  float contrast = clamp(0.5 + wave * 0.45, 0.0, 1.0);
+  vec3 waterColor = mix(deepColor, brightColor, contrast);
+  waterColor += vec3(0.04, 0.08, 0.10) * shimmer * 0.42;
+  waterColor = applySaturation(waterColor, uWaterSaturation);
+
+  float edgeDistance = 1.0;
+  if (edgeMask.x > 0.5) edgeDistance = min(edgeDistance, localPos.y);
+  if (edgeMask.y > 0.5) edgeDistance = min(edgeDistance, 1.0 - localPos.x);
+  if (edgeMask.z > 0.5) edgeDistance = min(edgeDistance, 1.0 - localPos.y);
+  if (edgeMask.w > 0.5) edgeDistance = min(edgeDistance, localPos.x);
+  float shoreMask = edgeDistance < 0.09 ? 1.0 : 0.0;
+  waterColor += vec3(0.03, 0.05, 0.05) * shoreMask;
+  return waterColor;
+}
+
+float computeShorelineBlendMask(vec2 localPos, vec4 edgeMask) {
+  float edgeDistance = 1.0;
+  if (edgeMask.x > 0.5) edgeDistance = min(edgeDistance, localPos.y);
+  if (edgeMask.y > 0.5) edgeDistance = min(edgeDistance, 1.0 - localPos.x);
+  if (edgeMask.z > 0.5) edgeDistance = min(edgeDistance, 1.0 - localPos.y);
+  if (edgeMask.w > 0.5) edgeDistance = min(edgeDistance, localPos.x);
+  return 1.0 - smoothstep(0.08, 0.42, edgeDistance);
 }
 
 void main() {
@@ -110,42 +169,43 @@ void main() {
     }
   }
 
-  if (vTextureType > 1.5) {
-    float t = uTime * 0.001;
-    float worldScale = 1.0 / max(uWaterZoom, 0.001);
-    vec2 flow = vec2(
-      sin(vWorldPos.y * (0.031 * worldScale) + t * 0.82),
-      cos(vWorldPos.x * (0.029 * worldScale) - t * 0.74)
-    );
-    vec2 p = vWorldPos * (0.052 * worldScale) + flow * 1.15;
-    float waveA = sin(p.x * 1.2 + t * 1.1);
-    float waveB = cos(p.y * 1.35 - t * 1.25);
-    float waveC = sin((p.x - p.y) * 0.92 + t * 0.63);
-    float wave = (waveA + waveB + waveC) / 3.0;
-    float shimmer = 0.5 + 0.5 * sin((p.x * 1.2 - p.y * 1.05) + t * 1.65);
-    float toneBlend = clamp((uWaterTone + 1.0) * 0.5, 0.0, 1.0);
+  vec3 baseColor = vColor.rgb;
+  bool isWaterBase = vTextureType > 1.5;
 
-    vec3 deepColor = mix(vec3(0.04, 0.18, 0.32), vec3(0.09, 0.27, 0.30), toneBlend);
-    vec3 brightColor = mix(vec3(0.08, 0.39, 0.58), vec3(0.13, 0.52, 0.43), toneBlend);
-    float contrast = clamp(0.5 + wave * 0.45, 0.0, 1.0);
-    vec3 waterColor = mix(deepColor, brightColor, contrast);
-    waterColor += vec3(0.04, 0.08, 0.10) * shimmer * 0.42;
-    waterColor = applySaturation(waterColor, uWaterSaturation);
-
-    float edgeDistance = 1.0;
-    if (vWaterEdges.x > 0.5) edgeDistance = min(edgeDistance, vLocalPos.y);
-    if (vWaterEdges.y > 0.5) edgeDistance = min(edgeDistance, 1.0 - vLocalPos.x);
-    if (vWaterEdges.z > 0.5) edgeDistance = min(edgeDistance, 1.0 - vLocalPos.y);
-    if (vWaterEdges.w > 0.5) edgeDistance = min(edgeDistance, vLocalPos.x);
-
-    float shoreMask = edgeDistance < 0.09 ? 1.0 : 0.0;
-    waterColor += vec3(0.03, 0.05, 0.05) * shoreMask;
-
-    outColor = vec4(waterColor, 1.0);
+  if (isWaterBase) {
+    baseColor = sampleProceduralWater(vWorldPos, vLocalPos, vWaterEdges);
   } else if (vTextureType > 0.5) {
     outColor = texture(uAtlas, vUV);
+    baseColor = outColor.rgb;
+  }
+
+  if (vShorelineMeta.x > 0.5) {
+    float shoreMask = computeShorelineBlendMask(vLocalPos, vShorelineEdges);
+    if (uShorelineMaskDebugView > 0.5) {
+      outColor = vec4(vec3(shoreMask), 1.0);
+      return;
+    }
+
+    vec3 waterColor = sampleProceduralWater(vWorldPos, vLocalPos, vWaterEdges);
+    vec3 landColor = vShorelineLandColor.rgb;
+    if (vShorelineLandUV.z > vShorelineLandUV.x && vShorelineLandUV.w > vShorelineLandUV.y) {
+      landColor = texture(uAtlas, mix(vShorelineLandUV.xy, vShorelineLandUV.zw, vLocalPos)).rgb;
+    }
+
+    if (vShorelineMeta.y > 0.5) {
+      baseColor = mix(waterColor, landColor, shoreMask);
+    } else {
+      baseColor = mix(baseColor, waterColor, shoreMask);
+    }
+  } else if (uShorelineMaskDebugView > 0.5) {
+    outColor = vec4(0.0, 0.0, 0.0, 1.0);
+    return;
+  }
+
+  if (!isWaterBase && vTextureType <= 0.5) {
+    outColor = vec4(baseColor, vColor.a);
   } else {
-    outColor = vColor;
+    outColor = vec4(baseColor, 1.0);
   }
 }
 `
@@ -275,6 +335,10 @@ export class GameWebGLRenderer {
     this.buffers.color = gl.createBuffer()
     this.buffers.textureType = gl.createBuffer()
     this.buffers.clipOrientation = gl.createBuffer()
+    this.buffers.shorelineEdges = gl.createBuffer()
+    this.buffers.shorelineMeta = gl.createBuffer()
+    this.buffers.shorelineLandUV = gl.createBuffer()
+    this.buffers.shorelineLandColor = gl.createBuffer()
 
     gl.useProgram(this.program)
     gl.uniform1i(gl.getUniformLocation(this.program, 'uAtlas'), 0)
@@ -365,7 +429,11 @@ export class GameWebGLRenderer {
       color: this.getColor('water'),
       textureType: 2,
       waterEdges: [0, 0, 0, 0],
-      clipOrientation: getSotClipOrientation(orientation)
+      clipOrientation: getSotClipOrientation(orientation),
+      shorelineEdges: [0, 0, 0, 0],
+      shorelineMeta: [0, 0],
+      shorelineLandUV: [0, 0, 0, 0],
+      shorelineLandColor: this.getColor('land')
     }
   }
 
@@ -378,7 +446,33 @@ export class GameWebGLRenderer {
     return {
       ...instance,
       waterEdges: [0, 0, 0, 0],
-      clipOrientation: getSotClipOrientation(orientation)
+      clipOrientation: getSotClipOrientation(orientation),
+      shorelineEdges: [0, 0, 0, 0],
+      shorelineMeta: [0, 0],
+      shorelineLandUV: [0, 0, 0, 0],
+      shorelineLandColor: this.getColor('land')
+    }
+  }
+
+  getLandBlendSource(tileX, tileY, canUseTextures) {
+    const useTexture = canUseTextures && this.textureManager.tileTextureCache?.land?.length
+    if (!useTexture) {
+      return { uvRect: [0, 0, 0, 0], color: this.getColor('land') }
+    }
+    const cache = this.textureManager.tileTextureCache.land
+    const idx = this.textureManager.getTileVariation('land', tileX, tileY)
+    const info = cache[idx % cache.length]
+    if (!info) {
+      return { uvRect: [0, 0, 0, 0], color: this.getColor('land') }
+    }
+    return {
+      uvRect: [
+        info.x / this.atlasSize.width,
+        info.y / this.atlasSize.height,
+        (info.x + info.width) / this.atlasSize.width,
+        (info.y + info.height) / this.atlasSize.height
+      ],
+      color: this.getColor('land')
     }
   }
 
@@ -401,13 +495,26 @@ export class GameWebGLRenderer {
       }
     }
 
+    const shorelineInfo = (type === 'water' || type === 'land' || type === 'street')
+      ? this.getShorelineInfo(mapGrid, tileX, tileY, type, canUseTextures)
+      : {
+        shorelineEdges: [0, 0, 0, 0],
+        shorelineMeta: [0, 0],
+        shorelineLandUV: [0, 0, 0, 0],
+        shorelineLandColor: this.getColor('land')
+      }
+
     return {
       translation: [tileX, tileY],
       uvRect,
       color: this.getColor(type),
       textureType: isWaterAnimated ? 2 : useTexture ? 1 : 0,
       waterEdges: isWaterAnimated ? this.computeWaterEdges(mapGrid, tileX, tileY, sotMask) : [0, 0, 0, 0],
-      clipOrientation: SOT_CLIP_NONE
+      clipOrientation: SOT_CLIP_NONE,
+      shorelineEdges: shorelineInfo.shorelineEdges,
+      shorelineMeta: shorelineInfo.shorelineMeta,
+      shorelineLandUV: shorelineInfo.shorelineLandUV,
+      shorelineLandColor: shorelineInfo.shorelineLandColor
     }
   }
 
@@ -449,6 +556,27 @@ export class GameWebGLRenderer {
     return [top, right, bottom, left]
   }
 
+  getShorelineInfo(mapGrid, tileX, tileY, type, canUseTextures) {
+    if (!this.mapRenderer || !mapGrid?.length) {
+      return {
+        shorelineEdges: [0, 0, 0, 0],
+        shorelineMeta: [0, 0],
+        shorelineLandUV: [0, 0, 0, 0],
+        shorelineLandColor: this.getColor('land')
+      }
+    }
+    const edges = this.mapRenderer.getShorelineMaskForTile(mapGrid, tileX, tileY) || [0, 0, 0, 0]
+    const isShoreline = edges[0] || edges[1] || edges[2] || edges[3]
+    const isWaterBase = type === 'water'
+    const landBlend = this.getLandBlendSource(tileX, tileY, canUseTextures)
+    return {
+      shorelineEdges: edges,
+      shorelineMeta: [isShoreline ? 1 : 0, isWaterBase ? 1 : 0],
+      shorelineLandUV: landBlend.uvRect,
+      shorelineLandColor: landBlend.color
+    }
+  }
+
   ensureInstanceCapacity(count) {
     if (count <= this.instanceCapacity) return
     this.instanceCapacity = count
@@ -485,6 +613,10 @@ export class GameWebGLRenderer {
     const textureType = new Float32Array(instances.length)
     const waterEdges = new Float32Array(instances.length * 4)
     const clipOrientation = new Float32Array(instances.length)
+    const shorelineEdges = new Float32Array(instances.length * 4)
+    const shorelineMeta = new Float32Array(instances.length * 2)
+    const shorelineLandUV = new Float32Array(instances.length * 4)
+    const shorelineLandColor = new Float32Array(instances.length * 4)
 
     for (let i = 0; i < instances.length; i++) {
       const inst = instances[i]
@@ -504,6 +636,20 @@ export class GameWebGLRenderer {
       waterEdges[i * 4 + 2] = inst.waterEdges[2]
       waterEdges[i * 4 + 3] = inst.waterEdges[3]
       clipOrientation[i] = inst.clipOrientation
+      shorelineEdges[i * 4] = inst.shorelineEdges[0]
+      shorelineEdges[i * 4 + 1] = inst.shorelineEdges[1]
+      shorelineEdges[i * 4 + 2] = inst.shorelineEdges[2]
+      shorelineEdges[i * 4 + 3] = inst.shorelineEdges[3]
+      shorelineMeta[i * 2] = inst.shorelineMeta[0]
+      shorelineMeta[i * 2 + 1] = inst.shorelineMeta[1]
+      shorelineLandUV[i * 4] = inst.shorelineLandUV[0]
+      shorelineLandUV[i * 4 + 1] = inst.shorelineLandUV[1]
+      shorelineLandUV[i * 4 + 2] = inst.shorelineLandUV[2]
+      shorelineLandUV[i * 4 + 3] = inst.shorelineLandUV[3]
+      shorelineLandColor[i * 4] = inst.shorelineLandColor[0]
+      shorelineLandColor[i * 4 + 1] = inst.shorelineLandColor[1]
+      shorelineLandColor[i * 4 + 2] = inst.shorelineLandColor[2]
+      shorelineLandColor[i * 4 + 3] = inst.shorelineLandColor[3]
     }
 
     gl.viewport(0, 0, canvas.width, canvas.height)
@@ -520,6 +666,7 @@ export class GameWebGLRenderer {
     const waterZoomLocation = gl.getUniformLocation(this.program, 'uWaterZoom')
     const waterToneLocation = gl.getUniformLocation(this.program, 'uWaterTone')
     const waterSaturationLocation = gl.getUniformLocation(this.program, 'uWaterSaturation')
+    const shorelineMaskDebugViewLocation = gl.getUniformLocation(this.program, 'uShorelineMaskDebugView')
 
     gl.uniform2f(resolutionLocation, canvas.width, canvas.height)
     gl.uniform2f(scrollLocation, scrollX, scrollY)
@@ -529,6 +676,7 @@ export class GameWebGLRenderer {
     gl.uniform1f(waterZoomLocation, WATER_EFFECT_ZOOM)
     gl.uniform1f(waterToneLocation, WATER_EFFECT_TONE)
     gl.uniform1f(waterSaturationLocation, WATER_EFFECT_SATURATION)
+    gl.uniform1f(shorelineMaskDebugViewLocation, SHORELINE_MASK_DEBUG_VIEW ? 1 : 0)
 
     gl.activeTexture(gl.TEXTURE0)
     gl.bindTexture(gl.TEXTURE_2D, this.atlasTexture)
@@ -582,6 +730,30 @@ export class GameWebGLRenderer {
     gl.enableVertexAttribArray(6)
     gl.vertexAttribPointer(6, 1, gl.FLOAT, false, 0, 0)
     gl.vertexAttribDivisor(6, 1)
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.buffers.shorelineEdges)
+    gl.bufferData(gl.ARRAY_BUFFER, shorelineEdges, gl.DYNAMIC_DRAW)
+    gl.enableVertexAttribArray(7)
+    gl.vertexAttribPointer(7, 4, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(7, 1)
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.buffers.shorelineMeta)
+    gl.bufferData(gl.ARRAY_BUFFER, shorelineMeta, gl.DYNAMIC_DRAW)
+    gl.enableVertexAttribArray(8)
+    gl.vertexAttribPointer(8, 2, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(8, 1)
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.buffers.shorelineLandUV)
+    gl.bufferData(gl.ARRAY_BUFFER, shorelineLandUV, gl.DYNAMIC_DRAW)
+    gl.enableVertexAttribArray(9)
+    gl.vertexAttribPointer(9, 4, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(9, 1)
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.buffers.shorelineLandColor)
+    gl.bufferData(gl.ARRAY_BUFFER, shorelineLandColor, gl.DYNAMIC_DRAW)
+    gl.enableVertexAttribArray(10)
+    gl.vertexAttribPointer(10, 4, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(10, 1)
 
     gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, instances.length)
 

--- a/tests/unit/mapRendererWater.test.js
+++ b/tests/unit/mapRendererWater.test.js
@@ -66,6 +66,43 @@ describe('MapRenderer water rendering', () => {
     expect(waterSotInstances[0].translation).toEqual([1, 1])
   })
 
+  it('computes chunk-local shoreline masks and only marks coastal tiles', () => {
+    const mapRenderer = new MapRenderer(makeTextureManager())
+    const mapGrid = [
+      [{ type: 'land' }, { type: 'land' }, { type: 'land' }],
+      [{ type: 'land' }, { type: 'water' }, { type: 'water' }],
+      [{ type: 'land' }, { type: 'land' }, { type: 'water' }]
+    ]
+
+    const inland = mapRenderer.getShorelineMaskForTile(mapGrid, 0, 0)
+    const shorelineLand = mapRenderer.getShorelineMaskForTile(mapGrid, 1, 0)
+    const shorelineWater = mapRenderer.getShorelineMaskForTile(mapGrid, 1, 1)
+
+    expect(inland).toEqual([0, 0, 0, 0])
+    expect(shorelineLand).toEqual([0, 0, 1, 0])
+    expect(shorelineWater).toEqual([1, 0, 1, 1])
+  })
+
+  it('invalidates only affected shoreline chunks on tile updates', () => {
+    const mapRenderer = new MapRenderer(makeTextureManager())
+    mapRenderer.canUseOffscreen = false
+    const mapGrid = [
+      [{ type: 'land' }, { type: 'land' }, { type: 'land' }],
+      [{ type: 'land' }, { type: 'land' }, { type: 'land' }],
+      [{ type: 'land' }, { type: 'land' }, { type: 'land' }]
+    ]
+    mapRenderer.computeSOTMask(mapGrid)
+
+    mapRenderer.getShorelineMaskForTile(mapGrid, 1, 1)
+    expect(mapRenderer.shorelineChunkMaskCache.size).toBe(1)
+
+    mapGrid[1][2] = { type: 'water' }
+    mapRenderer.updateSOTMaskForTile(mapGrid, 2, 1)
+
+    expect(mapRenderer.shorelineChunkMaskCache.size).toBe(0)
+    expect(mapRenderer.getShorelineMaskForTile(mapGrid, 1, 1)).toEqual([0, 1, 0, 0])
+  })
+
   it('suppresses water SOT for a single land tile island inside water', () => {
     const mapRenderer = new MapRenderer(makeTextureManager())
     const mapGrid = [
@@ -187,6 +224,28 @@ describe('MapRenderer water rendering', () => {
     expect(inverseLandSotInstances.map(instance => instance.translation)).toEqual(
       expect.arrayContaining([[1, 1], [3, 1], [1, 3], [3, 3]])
     )
+  })
+
+  it('adds shoreline blend metadata only for coastline tiles in the WebGL batch', () => {
+    const mapRenderer = new MapRenderer(makeTextureManager())
+    const mapGrid = [
+      [{ type: 'land' }, { type: 'land' }, { type: 'land' }],
+      [{ type: 'land' }, { type: 'water' }, { type: 'water' }],
+      [{ type: 'land' }, { type: 'land' }, { type: 'water' }]
+    ]
+
+    const webglRenderer = new GameWebGLRenderer(null, makeTextureManager(), mapRenderer)
+    const instances = webglRenderer.buildTileInstances(mapGrid, 0, 0, 3, 3)
+    const shoreInstances = instances.filter(instance => instance.shorelineMeta[0] > 0.5)
+    const inlandInstance = instances.find(instance =>
+      instance.translation[0] === 0 && instance.translation[1] === 0 && instance.clipOrientation === 0
+    )
+
+    expect(shoreInstances.length).toBeGreaterThan(0)
+    expect(shoreInstances.every(instance =>
+      instance.shorelineEdges.some(edge => edge > 0)
+    )).toBe(true)
+    expect(inlandInstance.shorelineMeta[0]).toBe(0)
   })
 
   it('does not add inverse land SOT on coastline water tiles when the land mass reaches the map edge', () => {


### PR DESCRIPTION
### Motivation
- Improve visual quality of coasts by softly blending land and water at tile borders while keeping the tile-based terrain system intact.
- Restrict extra work to coastal tiles to preserve current rendering performance and avoid full-map rebuilds.
- Provide a developer-facing debug view to inspect the shoreline mask during iteration and tuning.

### Description
- MapRenderer: added `shorelineChunkMaskCache` with lazy per-chunk `computeShorelineMaskForChunk`, `getShorelineMaskForTile` lookup, and `invalidateShorelineChunksForTile` to only invalidate nearby chunks on tile updates.  Chunk masks encode orthogonal edges (top/right/bottom/left) per tile as compact bytes.
- WebGL renderer: extended vertex attributes and instance data (`aShorelineEdges`, `aShorelineMeta`, `aShorelineLandUV`, `aShorelineLandColor`) and added GPU buffers to carry shoreline metadata per tile instance so blending only runs for shoreline-tagged instances.
- Shader: added `sampleProceduralWater` and `computeShorelineBlendMask` helpers, a soft alpha blend using `smoothstep` for shoreline transitions, and logic to sample land atlas UVs and mix land/water only where per-instance shoreline metadata is active; added `uShorelineMaskDebugView` uniform to render the mask in grayscale.
- Config/Runtime: added `SHORELINE_MASK_DEBUG_VIEW` and `setShorelineMaskDebugView` plus a `shorelineMaskDebugView` entry in `configRegistry` and persistent storage so the debug view can be toggled at runtime.
- Tests & artifacts: added unit tests that verify chunk-local shoreline mask computation, incremental invalidation, and presence of shoreline metadata in WebGL instances; added spec (`specs/061-shoreline-smoothing.md`), a prompt-history entry, and updated `TODO/Improvements.md` per repo workflow.

### Testing
- Ran `npm run lint:fix:changed` to auto-fix changed-file lint issues and reformat as required, which completed successfully.
- Ran `npm run test:unit` and all unit tests passed (Test Files: 136, Tests: 3613 passed); the Shoreline-related unit tests were added and pass.

Commit message: `Implement shoreline-only terrain blend mask in WebGL`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d63190c3f88328b519e247ef74b84d)