### PR TITLE
fix(multiplayer): move invite-ready state to invite buttons

### DIFF
--- a/TODO/Improvements.md
+++ b/TODO/Improvements.md
@@ -1,3 +1,4 @@
+- [x] Remove per-party "Invite ready" sidebar status labels and reflect invite lifecycle state directly on each Invite button (Generating…/Copied!/Invite Ready) to avoid duplicate multiplayer UI signals.
 - [x] Add explicit hidden `form-name` inputs to the Netlify contact forms so deploy-preview submissions reliably include the form identifier and custom success-page redirects do not fall through to a 404.
 - [x] Ensure the German `Impressum` links to `/kontakt` and the English `Imprint` links to `/contact` even when the shared config stores only one base contact-form route.
 - [x] Remove the "Back to game" header link from all legal/contact pages so opening legal routes in a new tab no longer shows a misleading in-tab return action.

--- a/TODO/Improvements.md
+++ b/TODO/Improvements.md
@@ -1,3 +1,4 @@
+- [x] Make multiplayer owner badge width content-driven, force dark text on green/yellow badges, and add right-side spacing in party-info row alignment for consistent sidebar padding.
 - [x] Move multiplayer owner labels into the colored party badge to save row space and force dark text on yellow-like badge colors for readability contrast.
 - [x] Keep multiplayer row status text free of defeated/invite-readiness labels and use compact invite-button copy (`Invite`/`Copied!`/`Defeated`) to fit narrow sidebar controls.
 - [x] Disable invite actions for defeated parties and show `Defeated` on their invite buttons so hosts cannot generate/copy invites for eliminated players.

--- a/TODO/Improvements.md
+++ b/TODO/Improvements.md
@@ -1,3 +1,4 @@
+- [x] Disable invite actions for defeated parties and show `Defeated` on their invite buttons so hosts cannot generate/copy invites for eliminated players.
 - [x] Remove per-party "Invite ready" sidebar status labels and reflect invite lifecycle state directly on each Invite button (Generating…/Copied!/Invite Ready) to avoid duplicate multiplayer UI signals.
 - [x] Add explicit hidden `form-name` inputs to the Netlify contact forms so deploy-preview submissions reliably include the form identifier and custom success-page redirects do not fall through to a 404.
 - [x] Ensure the German `Impressum` links to `/kontakt` and the English `Imprint` links to `/contact` even when the shared config stores only one base contact-form route.

--- a/TODO/Improvements.md
+++ b/TODO/Improvements.md
@@ -1,3 +1,4 @@
+- [x] Move multiplayer owner labels into the colored party badge to save row space and force dark text on yellow-like badge colors for readability contrast.
 - [x] Keep multiplayer row status text free of defeated/invite-readiness labels and use compact invite-button copy (`Invite`/`Copied!`/`Defeated`) to fit narrow sidebar controls.
 - [x] Disable invite actions for defeated parties and show `Defeated` on their invite buttons so hosts cannot generate/copy invites for eliminated players.
 - [x] Remove per-party "Invite ready" sidebar status labels and reflect invite lifecycle state directly on each Invite button (Generating…/Copied!/Invite Ready) to avoid duplicate multiplayer UI signals.

--- a/TODO/Improvements.md
+++ b/TODO/Improvements.md
@@ -1,3 +1,4 @@
+- [x] Keep multiplayer row status text free of defeated/invite-readiness labels and use compact invite-button copy (`Invite`/`Copied!`/`Defeated`) to fit narrow sidebar controls.
 - [x] Disable invite actions for defeated parties and show `Defeated` on their invite buttons so hosts cannot generate/copy invites for eliminated players.
 - [x] Remove per-party "Invite ready" sidebar status labels and reflect invite lifecycle state directly on each Invite button (Generating…/Copied!/Invite Ready) to avoid duplicate multiplayer UI signals.
 - [x] Add explicit hidden `form-name` inputs to the Netlify contact forms so deploy-preview submissions reliably include the form identifier and custom success-page redirects do not fall through to a 404.

--- a/prompt-history/2026-04-14T11-45-54Z_remove-invite-ready-label.md
+++ b/prompt-history/2026-04-14T11-45-54Z_remove-invite-ready-label.md
@@ -1,0 +1,6 @@
+# Prompt History
+- UTC: 2026-04-14T11:45:54Z
+- Model: codex
+
+## User Prompt
+remove the "invite ready" label form each player of the multiplayer section because the state of the invite is already indicated at the invite button (if not ensure it is shown at the button instead)

--- a/prompt-history/2026-04-14T12-34-45Z_defeated-invite-disabled.md
+++ b/prompt-history/2026-04-14T12-34-45Z_defeated-invite-disabled.md
@@ -1,0 +1,6 @@
+# Prompt History
+- UTC: 2026-04-14T12:34:45Z
+- Model: codex
+
+## User Prompt
+ensure that when some player is defeated that the invite button shows the defeated label and the button is disabled

--- a/prompt-history/2026-04-14T12-57-51Z_compact-invite-defeated-label.md
+++ b/prompt-history/2026-04-14T12-57-51Z_compact-invite-defeated-label.md
@@ -1,0 +1,6 @@
+# Prompt History
+- UTC: 2026-04-14T12:57:51Z
+- Model: codex
+
+## User Prompt
+I still see the defeated label that has to be removed (it should only be visible on the invite button itself! Also ensure the label on the invite button is only "invite" and not "invite ready" (keep it short, there is little space in the UI).

--- a/prompt-history/2026-04-14T13-11-11Z_owner-label-in-badge.md
+++ b/prompt-history/2026-04-14T13-11-11Z_owner-label-in-badge.md
@@ -1,0 +1,6 @@
+# Prompt History
+- UTC: 2026-04-14T13:11:11Z
+- Model: codex
+
+## User Prompt
+put the label for the player's name into the colored bubble to the left of it to safe extra space. Ensure on the yellow background (if party color is yellow to use black color instead of white to keep contrast high).

--- a/prompt-history/2026-04-14T14-17-32Z_badge-width-contrast-padding.md
+++ b/prompt-history/2026-04-14T14-17-32Z_badge-width-contrast-padding.md
@@ -1,0 +1,6 @@
+# Prompt History
+- UTC: 2026-04-14T14:17:32Z
+- Model: codex
+
+## User Prompt
+ensure the label in the dot is as wide as the content. also ensure that the text color in the green bubble is black. Also add a padding to the right to be consistent to the other elements in the same row.

--- a/specs/061-multiplayer-invite-button-status.md
+++ b/specs/061-multiplayer-invite-button-status.md
@@ -10,9 +10,11 @@ Remove redundant per-player `Invite ready` sidebar labels and communicate invite
   - `Generating…` while invite creation is in progress.
   - `Copied!` immediately after invite generation and clipboard copy attempt.
   - `Invite Ready` once an invite token exists and transient copied state resets.
+- Defeated parties must show `Defeated` on their invite button, and that invite button must be disabled.
 - Existing non-invite status text behavior (for example `Defeated`, `Reconnecting`, `Invite failed`, `Available`) must remain unchanged.
 
 ## Validation
 - Unit/manual: render multiplayer sidebar with no invite token and verify invite button label is `Invite`.
 - Unit/manual: trigger invite generation and verify button label progression to `Generating…` then `Copied!` then `Invite Ready`.
+- Unit/manual: mark a party as defeated and verify that party invite button label is `Defeated` and button is disabled.
 - Unit/manual: verify party status text no longer displays `Invite ready` and still shows `Defeated`/`Reconnecting`/`Invite failed` as applicable.

--- a/specs/061-multiplayer-invite-button-status.md
+++ b/specs/061-multiplayer-invite-button-status.md
@@ -14,6 +14,9 @@ Remove redundant per-player `Invite ready` sidebar labels and communicate invite
 - Existing non-invite status text behavior (for example `Reconnecting`, `Invite failed`, `Available`) must remain unchanged.
 - Multiplayer party owner labels must be rendered inside the colored badge (left-side bubble) instead of as separate text to save horizontal space.
 - Party badges with yellow-like backgrounds must use dark text for contrast.
+- Party badges with green backgrounds must also use dark text for contrast.
+- Owner badge width must be content-driven (no fixed minimum badge width), while preserving overflow safety for very long names.
+- Party info block should include right-side spacing consistent with nearby row elements.
 
 ## Validation
 - Unit/manual: render multiplayer sidebar with no invite token and verify invite button label is `Invite`.
@@ -22,3 +25,6 @@ Remove redundant per-player `Invite ready` sidebar labels and communicate invite
 - Unit/manual: verify party status text no longer displays `Invite ready` or `Defeated` and still shows `Reconnecting`/`Invite failed` as applicable.
 - Unit/manual: verify each row shows owner text inside the colored party badge and no separate owner text label beside the badge.
 - Unit/manual: verify yellow party badges render dark (black-ish) text instead of white.
+- Unit/manual: verify green party badges render dark (black-ish) text instead of white.
+- Unit/manual: verify short owner names produce compact badges sized to text content (not wide fixed badges), and long names still truncate safely.
+- Unit/manual: verify right-side spacing between party-info block and controls matches neighboring row spacing conventions.

--- a/specs/061-multiplayer-invite-button-status.md
+++ b/specs/061-multiplayer-invite-button-status.md
@@ -9,12 +9,12 @@ Remove redundant per-player `Invite ready` sidebar labels and communicate invite
   - `Invite` when no invite token exists.
   - `Generating…` while invite creation is in progress.
   - `Copied!` immediately after invite generation and clipboard copy attempt.
-  - `Invite Ready` once an invite token exists and transient copied state resets.
+- Party rows must not render defeated status text labels; defeated state is represented on the invite button itself for invite-capable rows.
 - Defeated parties must show `Defeated` on their invite button, and that invite button must be disabled.
-- Existing non-invite status text behavior (for example `Defeated`, `Reconnecting`, `Invite failed`, `Available`) must remain unchanged.
+- Existing non-invite status text behavior (for example `Reconnecting`, `Invite failed`, `Available`) must remain unchanged.
 
 ## Validation
 - Unit/manual: render multiplayer sidebar with no invite token and verify invite button label is `Invite`.
-- Unit/manual: trigger invite generation and verify button label progression to `Generating…` then `Copied!` then `Invite Ready`.
+- Unit/manual: trigger invite generation and verify button label progression to `Generating…` then `Copied!` then `Invite`.
 - Unit/manual: mark a party as defeated and verify that party invite button label is `Defeated` and button is disabled.
-- Unit/manual: verify party status text no longer displays `Invite ready` and still shows `Defeated`/`Reconnecting`/`Invite failed` as applicable.
+- Unit/manual: verify party status text no longer displays `Invite ready` or `Defeated` and still shows `Reconnecting`/`Invite failed` as applicable.

--- a/specs/061-multiplayer-invite-button-status.md
+++ b/specs/061-multiplayer-invite-button-status.md
@@ -1,0 +1,18 @@
+# 061 - Multiplayer invite status on button
+
+## Summary
+Remove redundant per-player `Invite ready` sidebar labels and communicate invite lifecycle state directly on each party invite button.
+
+## Requirements
+- Multiplayer party status text must no longer show `Invite ready`, `Generating invite...`, or `Copied!`.
+- Invite status feedback must be shown on the invite button text itself:
+  - `Invite` when no invite token exists.
+  - `Generating…` while invite creation is in progress.
+  - `Copied!` immediately after invite generation and clipboard copy attempt.
+  - `Invite Ready` once an invite token exists and transient copied state resets.
+- Existing non-invite status text behavior (for example `Defeated`, `Reconnecting`, `Invite failed`, `Available`) must remain unchanged.
+
+## Validation
+- Unit/manual: render multiplayer sidebar with no invite token and verify invite button label is `Invite`.
+- Unit/manual: trigger invite generation and verify button label progression to `Generating…` then `Copied!` then `Invite Ready`.
+- Unit/manual: verify party status text no longer displays `Invite ready` and still shows `Defeated`/`Reconnecting`/`Invite failed` as applicable.

--- a/specs/061-multiplayer-invite-button-status.md
+++ b/specs/061-multiplayer-invite-button-status.md
@@ -12,9 +12,13 @@ Remove redundant per-player `Invite ready` sidebar labels and communicate invite
 - Party rows must not render defeated status text labels; defeated state is represented on the invite button itself for invite-capable rows.
 - Defeated parties must show `Defeated` on their invite button, and that invite button must be disabled.
 - Existing non-invite status text behavior (for example `Reconnecting`, `Invite failed`, `Available`) must remain unchanged.
+- Multiplayer party owner labels must be rendered inside the colored badge (left-side bubble) instead of as separate text to save horizontal space.
+- Party badges with yellow-like backgrounds must use dark text for contrast.
 
 ## Validation
 - Unit/manual: render multiplayer sidebar with no invite token and verify invite button label is `Invite`.
 - Unit/manual: trigger invite generation and verify button label progression to `Generating…` then `Copied!` then `Invite`.
 - Unit/manual: mark a party as defeated and verify that party invite button label is `Defeated` and button is disabled.
 - Unit/manual: verify party status text no longer displays `Invite ready` or `Defeated` and still shows `Reconnecting`/`Invite failed` as applicable.
+- Unit/manual: verify each row shows owner text inside the colored party badge and no separate owner text label beside the badge.
+- Unit/manual: verify yellow party badges render dark (black-ish) text instead of white.

--- a/src/ui/sidebarMultiplayer.js
+++ b/src/ui/sidebarMultiplayer.js
@@ -638,8 +638,8 @@ function createPartyRow(partyState) {
       const inviteButton = document.createElement('button')
       inviteButton.type = 'button'
       inviteButton.className = 'multiplayer-invite-button'
-      inviteButton.textContent = 'Invite'
       inviteButton.dataset.testid = `multiplayer-invite-${partyState.partyId}`
+      updateInviteButtonText(inviteButton, partyState)
       inviteButton.addEventListener('click', () => handleInviteClick(partyState, inviteButton, status))
 
       controls.appendChild(inviteButton)
@@ -748,16 +748,9 @@ function formatStatusText(statusKey, partyState) {
   }
 
   switch (statusKey) {
-    case 'generating':
-      return 'Generating invite...'
-    case 'copied':
-      return 'Copied!'
     case 'error':
       return 'Invite failed'
     default: {
-      if (partyState.inviteToken) {
-        return 'Invite ready'
-      }
       return partyState.aiActive ? '' : 'Available'
     }
   }
@@ -770,6 +763,19 @@ function updateStatusText(element, partyState) {
   element.textContent = formatStatusText(currentStatus, partyState)
   element.classList.toggle('defeated', isDefeated)
   element.dataset.status = currentStatus
+}
+
+function formatInviteButtonText(statusKey, partyState) {
+  if (statusKey === 'generating') return 'Generating…'
+  if (statusKey === 'copied') return 'Copied!'
+  if (partyState.inviteToken) return 'Invite Ready'
+  return 'Invite'
+}
+
+function updateInviteButtonText(button, partyState) {
+  if (!button) return
+  const currentStatus = getHostInviteStatus(partyState.partyId)
+  button.textContent = formatInviteButtonText(currentStatus, partyState)
 }
 
 async function handleInviteClick(partyState, button, status) {
@@ -799,6 +805,7 @@ async function handleInviteClick(partyState, button, status) {
     button.title = url
     setHostInviteStatus(partyState.partyId, 'copied')
     updateStatusText(status, partyState)
+    updateInviteButtonText(button, partyState)
     // Show QR code modal after generating invite
     showQRCodeModal(partyState, url)
   } catch (error) {
@@ -812,6 +819,7 @@ async function handleInviteClick(partyState, button, status) {
     setTimeout(() => {
       setHostInviteStatus(partyState.partyId, 'idle')
       updateStatusText(status, partyState)
+      updateInviteButtonText(button, partyState)
       status.classList.remove('success')
     }, 2500)
   }

--- a/src/ui/sidebarMultiplayer.js
+++ b/src/ui/sidebarMultiplayer.js
@@ -639,7 +639,7 @@ function createPartyRow(partyState) {
       inviteButton.type = 'button'
       inviteButton.className = 'multiplayer-invite-button'
       inviteButton.dataset.testid = `multiplayer-invite-${partyState.partyId}`
-      updateInviteButtonText(inviteButton, partyState)
+      updateInviteButtonState(inviteButton, partyState)
       inviteButton.addEventListener('click', () => handleInviteClick(partyState, inviteButton, status))
 
       controls.appendChild(inviteButton)
@@ -766,16 +766,22 @@ function updateStatusText(element, partyState) {
 }
 
 function formatInviteButtonText(statusKey, partyState) {
+  const isDefeated = (gameState.defeatedPlayers instanceof Set && gameState.defeatedPlayers.has(partyState.partyId))
+    || (Array.isArray(gameState.defeatedPlayers) && gameState.defeatedPlayers.includes(partyState.partyId))
+  if (isDefeated) return 'Defeated'
   if (statusKey === 'generating') return 'Generating…'
   if (statusKey === 'copied') return 'Copied!'
   if (partyState.inviteToken) return 'Invite Ready'
   return 'Invite'
 }
 
-function updateInviteButtonText(button, partyState) {
+function updateInviteButtonState(button, partyState) {
   if (!button) return
   const currentStatus = getHostInviteStatus(partyState.partyId)
   button.textContent = formatInviteButtonText(currentStatus, partyState)
+  const isDefeated = (gameState.defeatedPlayers instanceof Set && gameState.defeatedPlayers.has(partyState.partyId))
+    || (Array.isArray(gameState.defeatedPlayers) && gameState.defeatedPlayers.includes(partyState.partyId))
+  button.disabled = isDefeated || currentStatus === 'generating'
 }
 
 async function handleInviteClick(partyState, button, status) {
@@ -789,7 +795,6 @@ async function handleInviteClick(partyState, button, status) {
     return
   }
 
-  const originalText = button.textContent
   button.disabled = true
   button.textContent = 'Generating…'
   status.classList.remove('success')
@@ -805,7 +810,7 @@ async function handleInviteClick(partyState, button, status) {
     button.title = url
     setHostInviteStatus(partyState.partyId, 'copied')
     updateStatusText(status, partyState)
-    updateInviteButtonText(button, partyState)
+    updateInviteButtonState(button, partyState)
     // Show QR code modal after generating invite
     showQRCodeModal(partyState, url)
   } catch (error) {
@@ -814,12 +819,11 @@ async function handleInviteClick(partyState, button, status) {
     updateStatusText(status, partyState)
     showHostNotification(`Invite creation failed: ${error?.message || 'unknown error'}`)
   } finally {
-    button.disabled = false
-    button.textContent = originalText
+    updateInviteButtonState(button, partyState)
     setTimeout(() => {
       setHostInviteStatus(partyState.partyId, 'idle')
       updateStatusText(status, partyState)
-      updateInviteButtonText(button, partyState)
+      updateInviteButtonState(button, partyState)
       status.classList.remove('success')
     }, 2500)
   }

--- a/src/ui/sidebarMultiplayer.js
+++ b/src/ui/sidebarMultiplayer.js
@@ -587,14 +587,11 @@ function createPartyRow(partyState) {
   const dot = document.createElement('span')
   dot.className = 'multiplayer-party-dot'
   dot.style.backgroundColor = partyState.color || '#999'
+  dot.style.color = getPartyBadgeTextColor(partyState.color)
+  dot.textContent = partyState.owner
   dot.title = getPartyDisplayName(partyState.partyId, partyState.color)
+  dot.dataset.testid = `multiplayer-party-label-${partyState.partyId}`
   info.appendChild(dot)
-
-  const label = document.createElement('span')
-  label.className = 'multiplayer-party-label'
-  label.textContent = partyState.owner
-  label.dataset.testid = `multiplayer-party-label-${partyState.partyId}`
-  info.appendChild(label)
 
   const controls = document.createElement('div')
   controls.className = 'multiplayer-party-controls'
@@ -648,6 +645,48 @@ function createPartyRow(partyState) {
 
   row.append(info, controls)
   return row
+}
+
+function parseRgbChannels(color) {
+  if (typeof color !== 'string') return null
+  const value = color.trim().toLowerCase()
+  const shortHex = /^#([0-9a-f]{3})$/i.exec(value)
+  if (shortHex) {
+    const [, hex] = shortHex
+    return {
+      r: parseInt(hex[0] + hex[0], 16),
+      g: parseInt(hex[1] + hex[1], 16),
+      b: parseInt(hex[2] + hex[2], 16)
+    }
+  }
+
+  const fullHex = /^#([0-9a-f]{6})$/i.exec(value)
+  if (fullHex) {
+    const [, hex] = fullHex
+    return {
+      r: parseInt(hex.slice(0, 2), 16),
+      g: parseInt(hex.slice(2, 4), 16),
+      b: parseInt(hex.slice(4, 6), 16)
+    }
+  }
+
+  const rgb = /^rgb\(\s*(\d{1,3})\s*[,\s]\s*(\d{1,3})\s*[,\s]\s*(\d{1,3})\s*\)$/i.exec(value)
+  if (!rgb) return null
+  return {
+    r: Math.min(255, Number.parseInt(rgb[1], 10)),
+    g: Math.min(255, Number.parseInt(rgb[2], 10)),
+    b: Math.min(255, Number.parseInt(rgb[3], 10))
+  }
+}
+
+function getPartyBadgeTextColor(color) {
+  if (typeof color === 'string' && color.trim().toLowerCase().includes('yellow')) {
+    return '#111'
+  }
+  const channels = parseRgbChannels(color)
+  if (!channels) return '#fff'
+  const brightness = (channels.r * 299 + channels.g * 587 + channels.b * 114) / 1000
+  return brightness >= 160 ? '#111' : '#fff'
 }
 
 

--- a/src/ui/sidebarMultiplayer.js
+++ b/src/ui/sidebarMultiplayer.js
@@ -737,7 +737,7 @@ function formatStatusText(statusKey, partyState) {
   const isDefeated = (gameState.defeatedPlayers instanceof Set && gameState.defeatedPlayers.has(partyState.partyId))
     || (Array.isArray(gameState.defeatedPlayers) && gameState.defeatedPlayers.includes(partyState.partyId))
   if (isDefeated) {
-    return 'Defeated'
+    return ''
   }
 
   if (partyState.unresponsiveSince) {
@@ -771,7 +771,6 @@ function formatInviteButtonText(statusKey, partyState) {
   if (isDefeated) return 'Defeated'
   if (statusKey === 'generating') return 'Generating…'
   if (statusKey === 'copied') return 'Copied!'
-  if (partyState.inviteToken) return 'Invite Ready'
   return 'Invite'
 }
 

--- a/src/ui/sidebarMultiplayer.js
+++ b/src/ui/sidebarMultiplayer.js
@@ -683,6 +683,13 @@ function getPartyBadgeTextColor(color) {
   if (typeof color === 'string' && color.trim().toLowerCase().includes('yellow')) {
     return '#111'
   }
+  const normalizedColor = typeof color === 'string' ? color.trim().toLowerCase() : ''
+  if (normalizedColor.includes('green')) {
+    return '#111'
+  }
+  if (normalizedColor === '#00ff00' || normalizedColor === '#0f0' || normalizedColor === 'rgb(0,255,0)') {
+    return '#111'
+  }
   const channels = parseRgbChannels(color)
   if (!channels) return '#fff'
   const brightness = (channels.r * 299 + channels.g * 587 + channels.b * 114) / 1000

--- a/styles/base.css
+++ b/styles/base.css
@@ -97,11 +97,12 @@ body.is-touch {
   align-items: center;
   gap: 6px;
   min-width: 0;
+  padding-right: 6px;
 }
 
 .multiplayer-party-dot {
-  min-width: 54px;
-  max-width: 92px;
+  width: fit-content;
+  max-width: 120px;
   height: 20px;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.4);

--- a/styles/base.css
+++ b/styles/base.css
@@ -100,17 +100,22 @@ body.is-touch {
 }
 
 .multiplayer-party-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+  min-width: 54px;
+  max-width: 92px;
+  height: 20px;
+  border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.4);
   display: inline-flex;
-}
-
-.multiplayer-party-label {
-  color: #ddd;
-  font-size: 13px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  font-size: 11px;
+  font-weight: 700;
   letter-spacing: 0.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
 }
 
 .multiplayer-party-controls {


### PR DESCRIPTION
### Motivation
- Remove redundant per-party invite lifecycle text in the multiplayer sidebar because the invite lifecycle is already communicated by the invite button, avoiding duplicate/conflicting UI signals.

### Description
- Stop showing invite lifecycle strings (`Invite ready`, `Generating invite...`, `Copied!`) in the status label by removing those branches from `formatStatusText` and leaving non-invite statuses unchanged (e.g., `Defeated`, `Reconnecting`, `Invite failed`, `Available`).
- Add `formatInviteButtonText` and `updateInviteButtonText` and set the invite button text in `createPartyRow` to reflect invite lifecycle (`Invite`, `Generating…`, `Copied!`, `Invite Ready`).
- Update `handleInviteClick` to update the invite button text after generation/copy and when transient status resets.
- Add project tracking artifacts: TODO entry `TODO/Improvements.md`, new spec `specs/061-multiplayer-invite-button-status.md`, and a prompt-history entry `prompt-history/2026-04-14T11-45-54Z_remove-invite-ready-label.md`.

### Testing
- Ran `npm run lint:fix:changed` and it completed successfully.
- Ran `npm run test:unit` and the full Vitest suite passed: 136 test files and 3614 tests passed (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de28ba73648328895b61bf6241aa1b)