### PR TITLE
fix(layout): keep desktop sidebar behavior on tablet landscape touch

### DIFF
--- a/TODO/Features.md
+++ b/TODO/Features.md
@@ -1,3 +1,4 @@
+- [x] Tablet landscape sidebar parity (2026-04-14): touch landscape viewports with tablet-sized short edge now keep desktop sidebar behavior instead of forcing mobile-landscape UI.
 - [x] Debug reroute diagnostics enrichment (2026-03-28): command history now records reroute entries with move target + path signature to expose same-target path churn reasons beyond generic "move" events.
 - [x] Debug command overlay compact minimized mode (2026-03-28): when minimized, only a floating "Maximize logs" button remains visible at bottom-right above condensed sidebar space.
 - [x] Debug command overlay minimize/maximize control (2026-03-28): `?debug` command panel now has a header toggle button to collapse/expand while keeping selection-aware visibility behavior.

--- a/prompt-history/20260414T175524Z_tablet-landscape-sidebar.md
+++ b/prompt-history/20260414T175524Z_tablet-landscape-sidebar.md
@@ -1,0 +1,4 @@
+# 20260414T175524Z
+
+- Model: codex
+- Prompt: Ensure that on tablet landscape the sidebar behaves like on desktop

--- a/specs/057-tablet-landscape-desktop-sidebar.md
+++ b/specs/057-tablet-landscape-desktop-sidebar.md
@@ -1,0 +1,10 @@
+# 057 - Tablet landscape desktop sidebar behavior
+
+## Summary
+On touch tablets in landscape orientation, the sidebar should behave like desktop mode instead of mobile-landscape mode.
+
+## Requirements
+1. Keep mobile portrait behavior unchanged on touch portrait devices.
+2. Keep mobile landscape behavior unchanged for phone-scale landscape screens.
+3. For touch landscape screens where the viewport short edge is at least 600 CSS pixels, do not apply `mobile-landscape` or `mobile-portrait` body classes.
+4. Ensure sidebar/layout updates still flow through `applyMobileSidebarLayout` with `null` mode for tablet landscape so desktop layout logic remains active.

--- a/src/ui/deviceLifecycle.js
+++ b/src/ui/deviceLifecycle.js
@@ -9,6 +9,7 @@ let standaloneQuery = null
 let getGameInstance = () => null
 let requestRenderAfterResize = () => {}
 let listenersInitialized = false
+const TABLET_LANDSCAPE_MIN_SHORT_EDGE = 600
 
 export function initDeviceLifecycle({ getGameInstanceAccessor, requestRender }) {
   getGameInstance = typeof getGameInstanceAccessor === 'function' ? getGameInstanceAccessor : () => null
@@ -128,7 +129,13 @@ export function updateMobileLayoutClasses() {
 
   const isTouch = document.body.classList.contains('is-touch') || !!lastIsTouchState
   const isPortrait = portraitQuery ? portraitQuery.matches : window.matchMedia('(orientation: portrait)').matches
-  const mobileMode = isTouch ? (isPortrait ? 'portrait' : 'landscape') : null
+  const viewportWidth = Number.isFinite(window.visualViewport?.width) ? window.visualViewport.width : window.innerWidth
+  const viewportHeight = Number.isFinite(window.visualViewport?.height) ? window.visualViewport.height : window.innerHeight
+  const shortEdge = Math.min(viewportWidth || 0, viewportHeight || 0)
+  const isTabletLandscape = isTouch && !isPortrait && shortEdge >= TABLET_LANDSCAPE_MIN_SHORT_EDGE
+  const mobileMode = isTouch
+    ? (isPortrait ? 'portrait' : (isTabletLandscape ? null : 'landscape'))
+    : null
 
   if (document.body.classList.contains('mobile-sidebar-right')) {
     document.body.classList.remove('mobile-sidebar-right')

--- a/tests/unit/deviceLifecycle.test.js
+++ b/tests/unit/deviceLifecycle.test.js
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { applyMobileSidebarLayoutMock } = vi.hoisted(() => ({
+  applyMobileSidebarLayoutMock: vi.fn()
+}))
+
+vi.mock('../../src/ui/mobileLayout.js', () => ({
+  applyMobileSidebarLayout: applyMobileSidebarLayoutMock
+}))
+
+import { updateMobileLayoutClasses } from '../../src/ui/deviceLifecycle.js'
+
+describe('deviceLifecycle mobile layout detection', () => {
+  let isTouch = true
+  let isPortrait = false
+
+  beforeEach(() => {
+    isTouch = true
+    isPortrait = false
+
+    document.body.className = ''
+    document.body.style.cssText = ''
+    document.body.classList.add('is-touch')
+
+    applyMobileSidebarLayoutMock.mockClear()
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 844
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 390
+    })
+
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      writable: true,
+      value: null
+    })
+
+    window.matchMedia = vi.fn().mockImplementation((query) => {
+      const matches = query.includes('(pointer: coarse)')
+        ? isTouch
+        : query.includes('(orientation: portrait)')
+          ? isPortrait
+          : false
+      return {
+        matches,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn()
+      }
+    })
+  })
+
+  it('keeps phone landscape touch devices in mobile landscape mode', () => {
+    isPortrait = false
+    updateMobileLayoutClasses()
+
+    expect(document.body.classList.contains('mobile-landscape')).toBe(true)
+    expect(document.body.classList.contains('mobile-portrait')).toBe(false)
+    expect(applyMobileSidebarLayoutMock).toHaveBeenCalledWith('landscape')
+  })
+
+  it('switches touch tablets in landscape to desktop sidebar behavior', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 768
+    })
+
+    updateMobileLayoutClasses()
+
+    expect(document.body.classList.contains('mobile-landscape')).toBe(false)
+    expect(document.body.classList.contains('mobile-portrait')).toBe(false)
+    expect(applyMobileSidebarLayoutMock).toHaveBeenCalledWith(null)
+  })
+
+  it('still applies mobile portrait mode on touch portrait devices', () => {
+    isPortrait = true
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 768
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 1024
+    })
+
+    updateMobileLayoutClasses()
+
+    expect(document.body.classList.contains('mobile-portrait')).toBe(true)
+    expect(document.body.classList.contains('mobile-landscape')).toBe(false)
+    expect(applyMobileSidebarLayoutMock).toHaveBeenCalledWith('portrait')
+  })
+})


### PR DESCRIPTION
### Motivation
- Touch devices in landscape on tablet-sized viewports were being forced into the mobile sidebar layout, leaving the desktop sidebar unavailable on tablets.
- The intent is to treat tablet-scale landscape (safe/touch devices with a larger short edge) as desktop so the sidebar behaves like on desktop instead of mobile-landscape.

### Description
- Updated mobile layout detection in `src/ui/deviceLifecycle.js` to compute the viewport short edge (using `visualViewport` when available) and treat touch landscape with a short edge >= 600px as tablet-landscape (desktop mode) by returning `mobileMode = null` instead of `'landscape'`.
- Introduced `TABLET_LANDSCAPE_MIN_SHORT_EDGE = 600` and `isTabletLandscape` branch so phone-scale landscape and portrait touch behavior remain unchanged.
- Added unit tests `tests/unit/deviceLifecycle.test.js` that cover phone landscape, tablet landscape, and portrait layout selection and mock `applyMobileSidebarLayout` correctly with `vi.hoisted`.
- Added a focused spec `specs/057-tablet-landscape-desktop-sidebar.md`, updated `TODO/Features.md`, and recorded the prompt in `prompt-history/20260414T175524Z_tablet-landscape-sidebar.md`.

### Testing
- Ran `npm run test:unit`, and the full unit suite completed successfully (`138` test files, `3622` tests passed).
- Ran `npm run lint:fix:changed` and it completed successfully to satisfy linting workflow requirements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7f4000cc83288f1fb3a695a3efd0)