### PR TITLE
style(multiplayer): remove owner badge borders

### DIFF
--- a/TODO/Improvements.md
+++ b/TODO/Improvements.md
@@ -1,3 +1,4 @@
+- [x] Remove borders from multiplayer sidebar colored owner badges (party bubbles) so the solid fill style matches the updated multiplayer row visuals.
 - [x] Make multiplayer owner badge width content-driven, force dark text on green/yellow badges, and add right-side spacing in party-info row alignment for consistent sidebar padding.
 - [x] Move multiplayer owner labels into the colored party badge to save row space and force dark text on yellow-like badge colors for readability contrast.
 - [x] Keep multiplayer row status text free of defeated/invite-readiness labels and use compact invite-button copy (`Invite`/`Copied!`/`Defeated`) to fit narrow sidebar controls.

--- a/prompt-history/20260416T093919Z_multiplayer-bubble-border.md
+++ b/prompt-history/20260416T093919Z_multiplayer-bubble-border.md
@@ -1,0 +1,6 @@
+UTC: 2026-04-16T09:39:19Z
+LLM: codex (GPT-5.3-Codex)
+
+Prompt:
+
+> the colored bubbles in the multiplayer section of the sidebar should have no border

--- a/specs/061-multiplayer-invite-button-status.md
+++ b/specs/061-multiplayer-invite-button-status.md
@@ -17,6 +17,7 @@ Remove redundant per-player `Invite ready` sidebar labels and communicate invite
 - Party badges with green backgrounds must also use dark text for contrast.
 - Owner badge width must be content-driven (no fixed minimum badge width), while preserving overflow safety for very long names.
 - Party info block should include right-side spacing consistent with nearby row elements.
+- Multiplayer colored owner badges (party bubbles) must render without any outline/border stroke.
 
 ## Validation
 - Unit/manual: render multiplayer sidebar with no invite token and verify invite button label is `Invite`.
@@ -28,3 +29,4 @@ Remove redundant per-player `Invite ready` sidebar labels and communicate invite
 - Unit/manual: verify green party badges render dark (black-ish) text instead of white.
 - Unit/manual: verify short owner names produce compact badges sized to text content (not wide fixed badges), and long names still truncate safely.
 - Unit/manual: verify right-side spacing between party-info block and controls matches neighboring row spacing conventions.
+- Unit/manual: verify multiplayer colored badges render as flat fills with no visible border/outline.

--- a/styles/base.css
+++ b/styles/base.css
@@ -105,7 +105,7 @@ body.is-touch {
   max-width: 120px;
   height: 20px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.4);
+  border: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
### Motivation
- Make the multiplayer sidebar owner badges render as flat color fills without an outline to match the updated compact UI and contrast requirements.

### Description
- Remove the border stroke from `.multiplayer-party-dot` by setting `border: none` in `styles/base.css` and update related tracking/spec files by adding a TODO entry, updating `specs/061-multiplayer-invite-button-status.md`, and adding a prompt-history note.

### Testing
- Ran `npm run lint:fix:changed` (no changes required) and `npm run test:unit`, and all unit tests completed successfully (`139` test files, `3629` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ae060c1483289056b320fb9b7977)