### PR TITLE
fix(combat): delay unit destruction explosion by 2s

### DIFF
--- a/TODO/Bugs.md
+++ b/TODO/Bugs.md
@@ -386,3 +386,4 @@
 - [x] Follow-up: convert remaining gameplay-critical wall-clock timers from the game-speed fix (Tesla Coil sequencing and AI/LLM building sell timers) to the simulation clock so they obey sidebar speed changes too.
 - [ ] Stabilize unit test mocks after runtime API changes (config exports, harvester runtime state exports, deterministic RNG export, enemy utility exports) so unit suites run without import-time failures.
 - [ ] Align unit tests with simulation-time behavior (mine deploy timestamps, AI decision timing, projectile timing/speed assertions) while keeping behavior-focused assertions meaningful.
+- [x] Unit destruction freeze/explosion sync (2026-04-16): units now stay frozen in-place for 2000ms after HP reaches 0 before running destruction cleanup, so wreck spawn and explosion SFX/VFX are delayed in sync with bullet impact animations.

--- a/prompt-history/20260416T101742Z_unit-destruction-delay.md
+++ b/prompt-history/20260416T101742Z_unit-destruction-delay.md
@@ -1,0 +1,5 @@
+UTC Timestamp: 2026-04-16T10:17:49Z
+LLM: codex (GPT-5.3-Codex)
+
+Prompt:
+when a unit gets destroyed (hp <= 0) ensure it freezes for 2s (to wait until the bullet impact animation is done) before it explodes and leaves the wreck left. Also ensure to sync the explosion audio with that new delay.

--- a/specs/061-bullet-impact-explosion-vfx.md
+++ b/specs/061-bullet-impact-explosion-vfx.md
@@ -28,3 +28,9 @@ Bullet impact explosions should look more realistic and visually rich, but rende
 7. Hot-path rendering must stay performant for large concurrent counts (no per-frame metadata parsing, no per-frame image creation).
 8. Sprite-sheet source cropping must remain correct across retina/non-retina displays by using texture dimension-aware source tile calculation, not assumptions tied to canvas DPR.
 9. Black background pixels in additive sprite sheets must be treated as transparent in final output (no visible black boxes during explosion playback).
+
+## Follow-up (2026-04-16): Unit Death Hold Before Explosion
+1. When a unit reaches `health <= 0`, it remains frozen in-place for 2000ms of simulation time before cleanup removes it.
+2. Wreck registration and destruction explosion trigger only after that freeze window elapses.
+3. Explosion audio must trigger at the same delayed destruction moment so audio and visuals stay synchronized.
+

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -40,6 +40,7 @@ const DESKTOP_EDGE_AUTOSCROLL_DELAY_MS = 250
 const DESKTOP_EDGE_AUTOSCROLL_THRESHOLD_RATIO = 0.05
 const DESKTOP_EDGE_AUTOSCROLL_DEFAULT_FRAME_MS = 16
 const DESKTOP_EDGE_AUTOSCROLL_MAX_FRAME_MS = 64
+const UNIT_DESTRUCTION_FREEZE_MS = 2000
 
 function applyDesktopEdgeAutoScroll(gameState, gameCanvas, maxScrollX, maxScrollY) {
   if (!DESKTOP_EDGE_AUTOSCROLL_ENABLED) {
@@ -422,6 +423,7 @@ export function updateDustParticles(gameState) {
  * @param {Object} gameState - Game state object
  */
 export function cleanupDestroyedUnits(units, gameState) {
+  const simulationNow = getSimulationTime(gameState)
   for (let i = units.length - 1; i >= 0; i--) {
     if (units[i].health <= 0) {
       const unit = units[i]
@@ -433,6 +435,19 @@ export function cleanupDestroyedUnits(units, gameState) {
           continue
         }
       }
+
+      if (!Number.isFinite(unit.destroyedAtSimulationTime)) {
+        unit.destroyedAtSimulationTime = simulationNow
+        unit.velocityX = 0
+        unit.velocityY = 0
+        unit.moving = false
+        continue
+      }
+
+      if (simulationNow - unit.destroyedAtSimulationTime < UNIT_DESTRUCTION_FREEZE_MS) {
+        continue
+      }
+
       if (!unit.aiApiDestroyedRecorded && gameState.gameStarted && !gameState.mapEditMode) {
         recordDestroyed({
           killerId: unit.lastAttacker?.id,

--- a/tests/unit/gameStateManager.test.js
+++ b/tests/unit/gameStateManager.test.js
@@ -289,6 +289,48 @@ describe('gameStateManager', () => {
   })
 
   describe('cleanupDestroyedUnits', () => {
+    it('waits for the destruction freeze window before cleanup', () => {
+      const unit = {
+        id: 'tank-1',
+        type: 'tank',
+        owner: 'enemy',
+        health: 0,
+        x: 64,
+        y: 96
+      }
+      const units = [unit]
+      const gameState = {
+        simulationTime: 0,
+        unitWrecks: [],
+        factories: [],
+        buildings: [],
+        explosions: [],
+        occupancyMap: [],
+        playerUnitsDestroyed: 0,
+        enemyUnitsDestroyed: 0,
+        humanPlayer: 'player1'
+      }
+
+      cleanupDestroyedUnits(units, gameState)
+
+      expect(unit.destroyedAtSimulationTime).toBe(0)
+      expect(registerUnitWreck).not.toHaveBeenCalled()
+      expect(units).toHaveLength(1)
+
+      gameState.simulationTime = 1900
+      cleanupDestroyedUnits(units, gameState)
+
+      expect(registerUnitWreck).not.toHaveBeenCalled()
+      expect(units).toHaveLength(1)
+
+      gameState.simulationTime = 2000
+      cleanupDestroyedUnits(units, gameState)
+
+      expect(registerUnitWreck).toHaveBeenCalledWith(unit, gameState)
+      expect(gameState.explosions.length).toBeGreaterThan(0)
+      expect(units).toHaveLength(0)
+    })
+
     it('cleans up recovery tanks and tracks wreck assignments', () => {
       const unit = {
         id: 'rec-1',
@@ -302,6 +344,7 @@ describe('gameStateManager', () => {
         }
       }
       const gameState = {
+        simulationTime: 0,
         unitWrecks: [
           { assignedTankId: 'rec-1' },
           { towedBy: 'rec-1' }
@@ -314,6 +357,8 @@ describe('gameStateManager', () => {
         humanPlayer: 'player1'
       }
 
+      cleanupDestroyedUnits([unit], gameState)
+      gameState.simulationTime = 2000
       cleanupDestroyedUnits([unit], gameState)
 
       expect(releaseWreckAssignment).toHaveBeenCalledTimes(2)
@@ -330,6 +375,7 @@ describe('gameStateManager', () => {
       const tankerTruck = { id: 'tank-1', type: 'tankerTruck', owner: 'player1', health: 0 }
       const units = [ammoTruck, tankerTruck]
       const gameState = {
+        simulationTime: 0,
         factories: [],
         buildings: [],
         occupancyMap: [],
@@ -338,6 +384,8 @@ describe('gameStateManager', () => {
         humanPlayer: 'player1'
       }
 
+      cleanupDestroyedUnits(units, gameState)
+      gameState.simulationTime = 2000
       cleanupDestroyedUnits(units, gameState)
 
       expect(detonateAmmunitionTruck).toHaveBeenCalledWith(ammoTruck, expect.any(Array), [], gameState)
@@ -371,6 +419,7 @@ describe('gameStateManager', () => {
       }
       const units = [apache]
       const gameState = {
+        simulationTime: 0,
         factories: [],
         buildings: [],
         occupancyMap: [],
@@ -379,6 +428,8 @@ describe('gameStateManager', () => {
         humanPlayer: 'player1'
       }
 
+      cleanupDestroyedUnits(units, gameState)
+      gameState.simulationTime = 2000
       cleanupDestroyedUnits(units, gameState)
 
       expect(apache.destroyed).toBe(true)


### PR DESCRIPTION
### Motivation
- Ensure visual and audio impact effects stay synchronized by holding dead units in-place for a short simulation-time window so bullet impact animations can finish before the unit explodes and leaves a wreck.

### Description
- Add `UNIT_DESTRUCTION_FREEZE_MS = 2000` and use `getSimulationTime(gameState)` to record `unit.destroyedAtSimulationTime` and freeze the unit (`velocityX/velocityY = 0`, `moving = false`) when `health <= 0` in `cleanupDestroyedUnits` in `src/game/gameStateManager.js`.
- Defer the normal destruction cleanup (wreck registration, spawn of destruction explosion VFX, explosion SFX, and removal from `units` array) until the 2000ms simulation-time freeze window elapses so visual/audio events are emitted in sync.
- Update unit tests in `tests/unit/gameStateManager.test.js` to assert the freeze window behavior and to advance `gameState.simulationTime` before asserting cleanup side effects for generic units, recovery tanks, specialty trucks, and Apache rotor audio cleanup.
- Update repository tracking artifacts: add a TODO/Bugs.md entry and a follow-up note in `specs/061-bullet-impact-explosion-vfx.md`, and save the prompt to `prompt-history/20260416T101742Z_unit-destruction-delay.md`.

### Testing
- Ran unit test suite with `npm run test:unit` and the run completed successfully (all unit tests passed).
- Ran lint autofix with `npm run lint:fix:changed` and no outstanding lint errors remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b6bcf1d88328ab415242f6672695)