### PR TITLE
fix(combat): delay unit destruction explosion/wreck cleanup by 2s

### DIFF
--- a/TODO/Bugs.md
+++ b/TODO/Bugs.md
@@ -180,6 +180,7 @@
 - [x] Hide the tutorial dock ("?") button after completion with a visibility-hidden class on completion and on reload until the tutorial is restarted from settings.
 - [x] ✅ Fixed tutorial step 12 completion not unlocking when user uses remote control by adding hasUsedRemoteControl flag to units and updating completion check.
 - [x] ✅ Unit destruction freeze delay (2026-04-16): when a unit reaches 0 HP it now remains frozen in place for 2 seconds (to allow impact animation completion) before cleanup triggers the destruction explosion, wreck registration, and synced explosion audio.
+- [x] ✅ Unit freeze visual follow-up (2026-04-16): during the 2s destruction freeze, dead units stay fully visible with their normal sprite (no gray wreck styling) and emit heavier, darker smoke until delayed explosion cleanup runs.
 - [x] ✅ Portrait condensed build bar now hides locked production buttons while keeping unlocked ones visible in the scrollable row.
 - [x] ✅ PWA portrait condensed build bar now reaches the bottom edge of the screen without leaving a gap.
 - [ ] Tutorial window should be allowed to overlap the sidebar; on portrait mode it should mount at the top-left corner over the sidebar and span the full width when expanded.

--- a/TODO/Bugs.md
+++ b/TODO/Bugs.md
@@ -179,6 +179,7 @@
 - [x] Tutorial should not start when the show tutorial setting is disabled on reload.
 - [x] Hide the tutorial dock ("?") button after completion with a visibility-hidden class on completion and on reload until the tutorial is restarted from settings.
 - [x] ✅ Fixed tutorial step 12 completion not unlocking when user uses remote control by adding hasUsedRemoteControl flag to units and updating completion check.
+- [x] ✅ Unit destruction freeze delay (2026-04-16): when a unit reaches 0 HP it now remains frozen in place for 2 seconds (to allow impact animation completion) before cleanup triggers the destruction explosion, wreck registration, and synced explosion audio.
 - [x] ✅ Portrait condensed build bar now hides locked production buttons while keeping unlocked ones visible in the scrollable row.
 - [x] ✅ PWA portrait condensed build bar now reaches the bottom edge of the screen without leaving a gap.
 - [ ] Tutorial window should be allowed to overlap the sidebar; on portrait mode it should mount at the top-left corner over the sidebar and span the full width when expanded.

--- a/TODO/Bugs.md
+++ b/TODO/Bugs.md
@@ -181,6 +181,7 @@
 - [x] ✅ Fixed tutorial step 12 completion not unlocking when user uses remote control by adding hasUsedRemoteControl flag to units and updating completion check.
 - [x] ✅ Unit destruction freeze delay (2026-04-16): when a unit reaches 0 HP it now remains frozen in place for 2 seconds (to allow impact animation completion) before cleanup triggers the destruction explosion, wreck registration, and synced explosion audio.
 - [x] ✅ Unit freeze visual follow-up (2026-04-16): during the 2s destruction freeze, dead units stay fully visible with their normal sprite (no gray wreck styling) and emit heavier, darker smoke until delayed explosion cleanup runs.
+- [x] ✅ Destruction freeze polish follow-up (2026-04-16): freeze now locks tank/turret orientation and carries the same turret angle into wrecks; destruction explosion is rendered 30% larger with texture prewarm to avoid startup stutter; black halo cleanup on sprite-sheet fire/explosion edges was tightened further.
 - [x] ✅ Portrait condensed build bar now hides locked production buttons while keeping unlocked ones visible in the scrollable row.
 - [x] ✅ PWA portrait condensed build bar now reaches the bottom edge of the screen without leaving a gap.
 - [ ] Tutorial window should be allowed to overlap the sidebar; on portrait mode it should mount at the top-left corner over the sidebar and span the full width when expanded.

--- a/prompt-history/2026-04-16T10-18-07Z_unit-destruction-delay.md
+++ b/prompt-history/2026-04-16T10-18-07Z_unit-destruction-delay.md
@@ -1,0 +1,6 @@
+# Prompt History
+- UTC Timestamp: 2026-04-16T10:18:07Z
+- LLM: codex
+
+## Prompt
+when a unit gets destroyed (hp <= 0) ensure it freezes for 2s (to wait until the bullet impact animation is done) before it explodes and leaves the wreck left. Also ensure to sync the explosion audio with that new delay.

--- a/prompt-history/2026-04-16T12-03-22Z_freeze-visibility-smoke.md
+++ b/prompt-history/2026-04-16T12-03-22Z_freeze-visibility-smoke.md
@@ -1,0 +1,6 @@
+# Prompt History
+- UTC Timestamp: 2026-04-16T12:03:22Z
+- LLM: codex
+
+## Prompt
+ensure during freeze time the unit is still visible (not grayed out but normally and smoking heavily (more than normal and darker smoke)

--- a/prompt-history/2026-04-16T12-35-25Z_freeze-turret-explosion-polish.md
+++ b/prompt-history/2026-04-16T12-35-25Z_freeze-turret-explosion-polish.md
@@ -1,0 +1,12 @@
+# Prompt History
+- UTC Timestamp: 2026-04-16T12:35:25Z
+- LLM: codex
+
+## Prompt
+ensure the tank turret position when freezing is the same like before it got destroyed and ensure the wrecks turret angle is also the same.
+
+Also try to minimize the black halo around the fire animation further. in the animation preview of the SSE the effect is not visible but on the map it still ist.
+
+Also ensure the explosion is 30% larger than it is now and always on top of the exploding unit image. Ensure the animation gets cached so there is absolutely NO stuttering when it starts (super critical!)
+
+Fix ALL issues now!

--- a/specs/061-bullet-impact-explosion-vfx.md
+++ b/specs/061-bullet-impact-explosion-vfx.md
@@ -23,6 +23,8 @@ Bullet impact explosions should look more realistic and visually rich, but rende
    - destruction explosion visual spawn
    - positional explosion audio
 3. Wreck registration/remnant creation must occur after the same delay so wrecks and explosion timing stay in sync.
+4. While frozen, the unit must remain visible with its normal live-unit appearance (no wreck grayscale/dead replacement during the delay window).
+5. During the freeze window, smoke output is intentionally intensified and darkened versus normal critical-damage smoke.
 
 ## Follow-up (2026-04-14): Generic Sprite-Sheet Destruction Explosions
 1. Add a reusable sprite-sheet animation abstraction that derives tile size and frame grid from asset filename format:

--- a/specs/061-bullet-impact-explosion-vfx.md
+++ b/specs/061-bullet-impact-explosion-vfx.md
@@ -25,6 +25,10 @@ Bullet impact explosions should look more realistic and visually rich, but rende
 3. Wreck registration/remnant creation must occur after the same delay so wrecks and explosion timing stay in sync.
 4. While frozen, the unit must remain visible with its normal live-unit appearance (no wreck grayscale/dead replacement during the delay window).
 5. During the freeze window, smoke output is intentionally intensified and darkened versus normal critical-damage smoke.
+6. Freeze-state tanks must preserve their pre-destruction turret/body orientation during the delay window, and wreck creation must inherit that same frozen turret/body angle.
+7. Destruction explosion scale is increased by 30% relative to baseline and must render above the exploding unit image layer.
+8. Destruction sprite-sheet textures must be prewarmed/cached before delayed explosion start to eliminate first-frame stutter.
+9. Black-edge/halo artifacts around fire/explosion sprite content should be aggressively suppressed during sprite processing so the map render matches SSE preview quality.
 
 ## Follow-up (2026-04-14): Generic Sprite-Sheet Destruction Explosions
 1. Add a reusable sprite-sheet animation abstraction that derives tile size and frame grid from asset filename format:

--- a/specs/061-bullet-impact-explosion-vfx.md
+++ b/specs/061-bullet-impact-explosion-vfx.md
@@ -17,6 +17,13 @@ Bullet impact explosions should look more realistic and visually rich, but rende
 - Multiple simultaneous bullet impacts should still render smoothly on typical desktop and mobile targets.
 - No per-frame dynamic canvas sprite generation should be introduced in the hot path.
 
+## Follow-up (2026-04-16): Unit Destruction Timing Sync
+1. When a unit reaches `hp <= 0`, keep the unit frozen in-place for `2000ms` before final destruction cleanup.
+2. The delayed cleanup moment must trigger both:
+   - destruction explosion visual spawn
+   - positional explosion audio
+3. Wreck registration/remnant creation must occur after the same delay so wrecks and explosion timing stay in sync.
+
 ## Follow-up (2026-04-14): Generic Sprite-Sheet Destruction Explosions
 1. Add a reusable sprite-sheet animation abstraction that derives tile size and frame grid from asset filename format:
    - `<tileWidth>x<tileHeight>_<cols>x<rows>_<anything>.webp`

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -32,7 +32,7 @@ import { gameRandom } from '../utils/gameRandom.js'
 import { recordDestroyed } from '../ai-api/transitionCollector.js'
 import { beginF22CrashSequence } from './movementF22.js'
 import { getSimulationTime } from './time.js'
-import { spawnDestructionExplosion } from './spriteSheetEffects.js'
+import { prewarmDestructionExplosionTexture, spawnDestructionExplosion } from './spriteSheetEffects.js'
 
 const MINIMAP_SCROLL_SMOOTHING = 0.2
 const MINIMAP_SCROLL_STOP_DISTANCE = 0.75
@@ -432,6 +432,11 @@ export function cleanupDestroyedUnits(units, gameState) {
 
       if (!Number.isFinite(unit.destructionQueuedAt)) {
         unit.destructionQueuedAt = now
+        unit.frozenDestructionDirection = Number.isFinite(unit.direction) ? unit.direction : 0
+        unit.frozenDestructionTurretDirection = Number.isFinite(unit.turretDirection)
+          ? unit.turretDirection
+          : (Number.isFinite(unit.direction) ? unit.direction : 0)
+        prewarmDestructionExplosionTexture(gameState)
       }
 
       if (now - unit.destructionQueuedAt < UNIT_DESTRUCTION_FREEZE_DELAY_MS) {
@@ -480,6 +485,12 @@ export function cleanupDestroyedUnits(units, gameState) {
 
       // Register a wreck so the destroyed unit leaves recoverable remnants
       if (unit.type !== 'apache' && unit.type !== 'ammunitionTruck') {
+        if (Number.isFinite(unit.frozenDestructionDirection)) {
+          unit.direction = unit.frozenDestructionDirection
+        }
+        if (Number.isFinite(unit.frozenDestructionTurretDirection)) {
+          unit.turretDirection = unit.frozenDestructionTurretDirection
+        }
         registerUnitWreck(unit, gameState)
       }
 
@@ -491,7 +502,7 @@ export function cleanupDestroyedUnits(units, gameState) {
         const unitCenterX = unit.x + TILE_SIZE / 2
         const unitCenterY = unit.y + TILE_SIZE / 2
         playPositionalSound('explosion', unitCenterX, unitCenterY, 0.5)
-        spawnDestructionExplosion(gameState, unitCenterX, unitCenterY)
+        spawnDestructionExplosion(gameState, unitCenterX, unitCenterY, { scale: 1.3 })
         unit.destructionExplosionSpawned = true
       }
 

--- a/src/game/gameStateManager.js
+++ b/src/game/gameStateManager.js
@@ -40,6 +40,7 @@ const DESKTOP_EDGE_AUTOSCROLL_DELAY_MS = 250
 const DESKTOP_EDGE_AUTOSCROLL_THRESHOLD_RATIO = 0.05
 const DESKTOP_EDGE_AUTOSCROLL_DEFAULT_FRAME_MS = 16
 const DESKTOP_EDGE_AUTOSCROLL_MAX_FRAME_MS = 64
+const UNIT_DESTRUCTION_FREEZE_DELAY_MS = 2000
 
 function applyDesktopEdgeAutoScroll(gameState, gameCanvas, maxScrollX, maxScrollY) {
   if (!DESKTOP_EDGE_AUTOSCROLL_ENABLED) {
@@ -422,9 +423,22 @@ export function updateDustParticles(gameState) {
  * @param {Object} gameState - Game state object
  */
 export function cleanupDestroyedUnits(units, gameState) {
+  const simulationNow = getSimulationTime(gameState)
+  const now = simulationNow > 0 ? simulationNow : performance.now()
+
   for (let i = units.length - 1; i >= 0; i--) {
     if (units[i].health <= 0) {
       const unit = units[i]
+
+      if (!Number.isFinite(unit.destructionQueuedAt)) {
+        unit.destructionQueuedAt = now
+      }
+
+      if (now - unit.destructionQueuedAt < UNIT_DESTRUCTION_FREEZE_DELAY_MS) {
+        unit.vx = 0
+        unit.vy = 0
+        continue
+      }
 
       if ((unit.type === 'f22Raptor' || unit.type === 'f35') && unit.flightState !== 'grounded' && unit.f22State !== 'crashed') {
         const crashTriggered = beginF22CrashSequence(unit, performance.now())
@@ -474,7 +488,10 @@ export function cleanupDestroyedUnits(units, gameState) {
       }
 
       if (!unit.destructionExplosionSpawned) {
-        spawnDestructionExplosion(gameState, unit.x + TILE_SIZE / 2, unit.y + TILE_SIZE / 2)
+        const unitCenterX = unit.x + TILE_SIZE / 2
+        const unitCenterY = unit.y + TILE_SIZE / 2
+        playPositionalSound('explosion', unitCenterX, unitCenterY, 0.5)
+        spawnDestructionExplosion(gameState, unitCenterX, unitCenterY)
         unit.destructionExplosionSpawned = true
       }
 

--- a/src/game/spriteSheetEffects.js
+++ b/src/game/spriteSheetEffects.js
@@ -1,4 +1,4 @@
-import { createSpriteSheetAnimationInstance } from '../rendering/spriteSheetAnimation.js'
+import { createSpriteSheetAnimationInstance, prewarmSpriteSheetTexture } from '../rendering/spriteSheetAnimation.js'
 import { getSimulationTime } from './time.js'
 
 const DEFAULT_DESTRUCTION_SPRITE = 'images/map/animations/explosion.webp'
@@ -8,6 +8,7 @@ const DEFAULT_DESTRUCTION_BORDER_WIDTH = 1
 const DEFAULT_DESTRUCTION_COLUMNS = 16
 const DEFAULT_DESTRUCTION_ROWS = 16
 const DEFAULT_DESTRUCTION_FRAME_COUNT = 229
+const DEFAULT_DESTRUCTION_SCALE = 1.3
 
 function buildDefaultDestructionFrameRects() {
   const frameRects = []
@@ -68,7 +69,7 @@ export function spawnDestructionExplosion(gameState, centerX, centerY, options =
   const configured = getConfiguredDestructionAnimation(gameState)
   const {
     duration = configured?.duration ?? DEFAULT_DESTRUCTION_DURATION,
-    scale = 1,
+    scale = DEFAULT_DESTRUCTION_SCALE,
     loop = false,
     assetPath = configured?.assetPath ?? DEFAULT_DESTRUCTION_SPRITE
   } = options
@@ -88,4 +89,10 @@ export function spawnDestructionExplosion(gameState, centerX, centerY, options =
     tileWidth: DEFAULT_DESTRUCTION_TILE_SIZE,
     tileHeight: DEFAULT_DESTRUCTION_TILE_SIZE
   })
+}
+
+export function prewarmDestructionExplosionTexture(gameState) {
+  const configured = getConfiguredDestructionAnimation(gameState)
+  const assetPath = configured?.assetPath ?? DEFAULT_DESTRUCTION_SPRITE
+  prewarmSpriteSheetTexture(assetPath)
 }

--- a/src/game/unitCombat.js
+++ b/src/game/unitCombat.js
@@ -24,6 +24,8 @@ export const updateUnitCombat = logPerformance(function updateUnitCombat(units, 
   const occupancyMap = gameState.occupancyMap
 
   units.forEach(unit => {
+    if (!unit || unit.health <= 0) return
+
     // Skip if unit has no combat capabilities
     if (unit.type === 'harvester') return
 

--- a/src/game/unitMovement.js
+++ b/src/game/unitMovement.js
@@ -11,7 +11,7 @@ import {
   TARGET_MOVEMENT_THRESHOLD
 } from '../config.js'
 import { gameState } from '../gameState.js'
-import { findPath, removeUnitOccupancy } from '../units.js'
+import { findPath } from '../units.js'
 import { getCachedPath } from './pathfinding.js'
 import { selectedUnits, cleanupDestroyedSelectedUnits } from '../inputHandler.js'
 import { angleDiff, smoothRotateTowardsAngle, findAdjacentTile } from '../logic.js'
@@ -46,25 +46,15 @@ export const updateUnitMovement = logPerformance(function updateUnitMovement(uni
   for (let i = units.length - 1; i >= 0; i--) {
     const unit = units[i]
 
-    // Skip destroyed units and remove them
+    // Skip destroyed units. Cleanup and removal are handled by cleanupDestroyedUnits()
+    // so units can remain frozen briefly before spawning explosion/wreck effects.
     if (unit.health <= 0) {
-      // Remove unit from selected units if it was selected
       if (unit.selected) {
         const idx = selectedUnits.findIndex(u => u === unit)
         if (idx !== -1) {
           selectedUnits.splice(idx, 1)
         }
       }
-
-      // Remove unit from cheat system tracking if it exists
-      if (window.cheatSystem) {
-        window.cheatSystem.removeUnitFromTracking(unit.id)
-      }
-
-      if (!unit.occupancyRemoved) {
-        removeUnitOccupancy(unit, occupancyMap)
-      }
-      units.splice(i, 1)
       continue
     }
 

--- a/src/game/unitWreckManager.js
+++ b/src/game/unitWreckManager.js
@@ -101,8 +101,10 @@ export function registerUnitWreck(unit, gameState) {
     tileY: unit.tileY,
     direction: ((unit.type === 'f22Raptor' || unit.type === 'f35') && Number.isFinite(unit.f22CrashWreckDirection))
       ? unit.f22CrashWreckDirection
-      : (unit.direction || 0),
-    turretDirection: unit.turretDirection || unit.direction || 0,
+      : (Number.isFinite(unit.frozenDestructionDirection) ? unit.frozenDestructionDirection : (unit.direction || 0)),
+    turretDirection: Number.isFinite(unit.frozenDestructionTurretDirection)
+      ? unit.frozenDestructionTurretDirection
+      : (unit.turretDirection || unit.direction || 0),
     createdAt: getSimulationTime(gameState),
     cost: getUnitCost(unit.type) || 0,
     buildDuration: estimateBuildDuration(unit.type, unit.buildDuration),

--- a/src/rendering/effectsRenderer.js
+++ b/src/rendering/effectsRenderer.js
@@ -348,6 +348,7 @@ export class EffectsRenderer {
 
       const safeSize = Math.max(1, p.size)
       const fireIntensity = Math.max(0, Math.min(1, p.fireIntensity || 0))
+      const smokeShade = Math.max(0, Math.min(1, p.smokeShade || 0))
 
       // Use pre-cached sprite instead of creating gradient per frame
       const sprite = getClosestSmokeSprite(safeSize)
@@ -397,6 +398,26 @@ export class EffectsRenderer {
             coreDrawSize,
             coreDrawSize
           )
+        }
+
+        if (smokeShade > 0.01) {
+          const darkAlpha = Math.min(0.8, p.alpha * (0.25 + smokeShade * 0.55))
+          const shadeGradient = ctx.createRadialGradient(
+            screenX,
+            screenY,
+            safeSize * 0.1,
+            screenX,
+            screenY,
+            safeSize * 0.95
+          )
+          shadeGradient.addColorStop(0, `rgba(20, 20, 20, ${darkAlpha})`)
+          shadeGradient.addColorStop(0.7, `rgba(16, 16, 16, ${darkAlpha * 0.55})`)
+          shadeGradient.addColorStop(1, 'rgba(0, 0, 0, 0)')
+          ctx.globalAlpha = 1
+          ctx.fillStyle = shadeGradient
+          ctx.beginPath()
+          ctx.arc(screenX, screenY, safeSize, 0, Math.PI * 2)
+          ctx.fill()
         }
       }
     }

--- a/src/rendering/spriteSheetAnimation.js
+++ b/src/rendering/spriteSheetAnimation.js
@@ -1,6 +1,8 @@
 import { TILE_SIZE } from '../config.js'
 
 const FILENAME_PATTERN = /^(\d+)x(\d+)_([0-9]+)x([0-9]+)_.+\.[a-z0-9]+$/i
+const BLACK_ALPHA_CUTOFF_BRIGHTNESS = 20
+const BLACK_ALPHA_SOFTEN_BRIGHTNESS = 45
 
 const textureCache = new Map()
 const metadataCache = new Map()
@@ -92,7 +94,17 @@ function buildBlackTransparentTexture(image) {
     const b = data[i + 2]
     const a = data[i + 3]
     const brightness = Math.max(r, g, b)
-    data[i + 3] = brightness <= 8 ? 0 : a
+    if (brightness <= BLACK_ALPHA_CUTOFF_BRIGHTNESS) {
+      data[i + 3] = 0
+      continue
+    }
+    if (brightness < BLACK_ALPHA_SOFTEN_BRIGHTNESS) {
+      const t = (brightness - BLACK_ALPHA_CUTOFF_BRIGHTNESS) /
+        (BLACK_ALPHA_SOFTEN_BRIGHTNESS - BLACK_ALPHA_CUTOFF_BRIGHTNESS)
+      data[i + 3] = Math.round(a * t)
+      continue
+    }
+    data[i + 3] = a
   }
 
   ctx.putImageData(imageData, 0, 0)
@@ -121,6 +133,17 @@ export function getSpriteSheetTexture(assetPath) {
     processed: null
   })
   return img
+}
+
+export function prewarmSpriteSheetTexture(assetPath) {
+  if (!assetPath) return
+  const texture = getSpriteSheetTexture(assetPath)
+  if (isImageTextureReady(texture)) {
+    return
+  }
+  if (texture && typeof texture.decode === 'function') {
+    texture.decode().catch(() => {})
+  }
 }
 
 export function createSpriteSheetAnimationInstance({

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -1934,7 +1934,14 @@ export class UnitRenderer {
   }
 
   shouldRenderUnit(unit, scrollOffset, viewportWidth, viewportHeight) {
-    if (!unit || unit.health <= 0) return false
+    if (!unit) return false
+
+    const pendingDestructionFreeze =
+      unit.health <= 0 &&
+      Number.isFinite(unit.destructionQueuedAt) &&
+      unit.destructionExplosionSpawned !== true
+
+    if (unit.health <= 0 && !pendingDestructionFreeze) return false
 
     // View frustum culling - skip units outside the visible viewport
     // This is the first check as it's the cheapest and most frequently eliminates entities

--- a/src/updateGame.js
+++ b/src/updateGame.js
@@ -77,6 +77,10 @@ import {
   finalizeReplayPlaybackIfPending
 } from './replaySystem.js'
 
+const DESTRUCTION_FREEZE_SMOKE_INTERVAL_MS = 180
+const DESTRUCTION_FREEZE_SMOKE_COUNT = 3
+const DESTRUCTION_FREEZE_SMOKE_SHADE = 0.9
+
 export const updateGame = logPerformance(function updateGame(delta, mapGrid, factories, units, bullets, gameState) {
   try {
     const now = getSimulationTime(gameState)
@@ -491,6 +495,10 @@ export const updateGame = logPerformance(function updateGame(delta, mapGrid, fac
       // Ensure maxHealth is valid (fix for loaded games with missing maxHealth)
       const maxHealth = unit.maxHealth || unit.health || 100
       const healthRatio = unit.health / maxHealth
+      const isInDestructionFreeze =
+        unit.health <= 0 &&
+        Number.isFinite(unit.destructionQueuedAt) &&
+        unit.destructionExplosionSpawned !== true
 
       // Check if unit type should emit smoke when heavily damaged
       // Uses string.includes('tank') to match tank_v1, tank-v2, tank-v3, rocketTank
@@ -500,27 +508,31 @@ export const updateGame = logPerformance(function updateGame(delta, mapGrid, fac
         unit.type === 'howitzer' ||
         unit.type === 'recoveryTank'
 
-      const shouldEmitSmoke = healthRatio < 0.25 && isSmokeEmittingType
+      const shouldEmitSmoke = (healthRatio < 0.25 || isInDestructionFreeze) && isSmokeEmittingType
 
       if (shouldEmitSmoke) {
         if (gameState.smokeParticles.length >= unitSmokeLimit) {
           return
         }
 
-        if (!unit.lastSmokeTime || now - unit.lastSmokeTime > SMOKE_EMIT_INTERVAL) {
+        const smokeInterval = isInDestructionFreeze
+          ? DESTRUCTION_FREEZE_SMOKE_INTERVAL_MS
+          : SMOKE_EMIT_INTERVAL
+        if (!unit.lastSmokeTime || now - unit.lastSmokeTime > smokeInterval) {
           // Emit smoke from the BACK of the unit (opposite to direction of travel)
           // direction = 0 means facing right (east), so back is to the left (west)
           const direction = unit.direction || 0
           const offsetX = -Math.cos(direction) * TILE_SIZE * 0.35
           const offsetY = -Math.sin(direction) * TILE_SIZE * 0.35
 
-          const particleCount = 1
+          const particleCount = isInDestructionFreeze ? DESTRUCTION_FREEZE_SMOKE_COUNT : 1
+          const smokeShade = isInDestructionFreeze ? DESTRUCTION_FREEZE_SMOKE_SHADE : 0
           emitSmokeParticles(
             gameState,
             unit.x + TILE_SIZE / 2 + offsetX,
             unit.y + TILE_SIZE / 2 + offsetY,
             now,
-            particleCount
+            { count: particleCount, smokeShade }
           )
           unit.lastSmokeTime = now
         }

--- a/src/utils/smokeUtils.js
+++ b/src/utils/smokeUtils.js
@@ -28,6 +28,7 @@ function recycleParticleInstance(gameState, particle) {
   particle.alpha = 0
   particle.size = 0
   particle.fireIntensity = 0
+  particle.smokeShade = 0
 
   gameState.smokeParticlePool.push(particle)
 }
@@ -76,6 +77,9 @@ export function emitSmokeParticles(gameState, x, y, now, countOrOptions = 1) {
   const fireIntensity = Number.isFinite(options.fireIntensity)
     ? Math.max(0, Math.min(1, options.fireIntensity))
     : 0
+  const smokeShade = Number.isFinite(options.smokeShade)
+    ? Math.max(0, Math.min(1, options.smokeShade))
+    : 0
 
   if (!Number.isFinite(count) || count <= 0) {
     return
@@ -109,6 +113,7 @@ export function emitSmokeParticles(gameState, x, y, now, countOrOptions = 1) {
     particle.fireIntensity = fireIntensity > 0
       ? fireIntensity * (0.65 + gameRandom() * 0.35)
       : 0
+    particle.smokeShade = smokeShade
 
     gameState.smokeParticles.push(particle)
   }

--- a/tests/unit/gameStateManager.test.js
+++ b/tests/unit/gameStateManager.test.js
@@ -295,6 +295,7 @@ describe('gameStateManager', () => {
         type: 'recoveryTank',
         owner: 'enemy',
         health: 0,
+        destructionQueuedAt: -2000,
         occupancyRemoved: false,
         engineSound: {
           gainNode: { gain: { cancelScheduledValues: vi.fn() } },
@@ -325,9 +326,48 @@ describe('gameStateManager', () => {
       expect(gameState.enemyUnitsDestroyed).toBe(1)
     })
 
+    it('keeps destroyed units frozen for 2 seconds before cleanup', () => {
+      const unit = {
+        id: 'tank-1',
+        type: 'tank_v1',
+        owner: 'enemy',
+        health: 0,
+        x: 32,
+        y: 64,
+        vx: 1.5,
+        vy: -0.5,
+        occupancyRemoved: false
+      }
+      const units = [unit]
+      const gameState = {
+        factories: [],
+        buildings: [],
+        occupancyMap: [],
+        playerUnitsDestroyed: 0,
+        enemyUnitsDestroyed: 0,
+        humanPlayer: 'player1'
+      }
+
+      performanceNow.mockReturnValue(1000)
+      cleanupDestroyedUnits(units, gameState)
+
+      expect(units).toHaveLength(1)
+      expect(unit.vx).toBe(0)
+      expect(unit.vy).toBe(0)
+      expect(registerUnitWreck).not.toHaveBeenCalled()
+      expect(playPositionalSound).not.toHaveBeenCalledWith('explosion', expect.any(Number), expect.any(Number), expect.any(Number))
+
+      performanceNow.mockReturnValue(3001)
+      cleanupDestroyedUnits(units, gameState)
+
+      expect(units).toHaveLength(0)
+      expect(registerUnitWreck).toHaveBeenCalledWith(unit, gameState)
+      expect(playPositionalSound).toHaveBeenCalledWith('explosion', 48, 80, 0.5)
+    })
+
     it('handles specialty unit destruction paths', () => {
-      const ammoTruck = { id: 'ammo-1', type: 'ammunitionTruck', owner: 'enemy', health: 0 }
-      const tankerTruck = { id: 'tank-1', type: 'tankerTruck', owner: 'player1', health: 0 }
+      const ammoTruck = { id: 'ammo-1', type: 'ammunitionTruck', owner: 'enemy', health: 0, destructionQueuedAt: -2000 }
+      const tankerTruck = { id: 'tank-1', type: 'tankerTruck', owner: 'player1', health: 0, destructionQueuedAt: -2000 }
       const units = [ammoTruck, tankerTruck]
       const gameState = {
         factories: [],
@@ -355,6 +395,7 @@ describe('gameStateManager', () => {
         type: 'apache',
         owner: 'enemy',
         health: 0,
+        destructionQueuedAt: -2000,
         rotorSoundRequestId: 4,
         rotorSoundLoading: true,
         rotorSound: {

--- a/tests/unit/gameStateManager.test.js
+++ b/tests/unit/gameStateManager.test.js
@@ -334,6 +334,8 @@ describe('gameStateManager', () => {
         health: 0,
         x: 32,
         y: 64,
+        direction: 1.1,
+        turretDirection: 2.2,
         vx: 1.5,
         vy: -0.5,
         occupancyRemoved: false
@@ -357,10 +359,14 @@ describe('gameStateManager', () => {
       expect(registerUnitWreck).not.toHaveBeenCalled()
       expect(playPositionalSound).not.toHaveBeenCalledWith('explosion', expect.any(Number), expect.any(Number), expect.any(Number))
 
+      unit.direction = 0.1
+      unit.turretDirection = 0.3
       performanceNow.mockReturnValue(3001)
       cleanupDestroyedUnits(units, gameState)
 
       expect(units).toHaveLength(0)
+      expect(unit.direction).toBe(1.1)
+      expect(unit.turretDirection).toBe(2.2)
       expect(registerUnitWreck).toHaveBeenCalledWith(unit, gameState)
       expect(playPositionalSound).toHaveBeenCalledWith('explosion', 48, 80, 0.5)
     })

--- a/tests/unit/unitMovement.test.js
+++ b/tests/unit/unitMovement.test.js
@@ -7,7 +7,7 @@ import {
 } from '../../src/game/unitMovement.js'
 import { gameState } from '../../src/gameState.js'
 import { selectedUnits as _selectedUnits, cleanupDestroyedSelectedUnits } from '../../src/inputHandler.js'
-import { findPath, removeUnitOccupancy as _removeUnitOccupancy } from '../../src/units.js'
+import { findPath } from '../../src/units.js'
 import { getCachedPath } from '../../src/game/pathfinding.js'
 import { initializeUnitMovement, updateUnitPosition } from '../../src/game/unifiedMovement.js'
 import { updateRetreatBehavior, shouldExitRetreat, cancelRetreat } from '../../src/behaviours/retreat.js'
@@ -108,14 +108,15 @@ describe('unitMovement.js', () => {
       expect(cleanupDestroyedSelectedUnits).toHaveBeenCalled()
     })
 
-    it('should remove units with health <= 0', () => {
+    it('should skip units with health <= 0 and leave cleanup to cleanupDestroyedUnits', () => {
       const units = [
         { id: 1, health: 0, x: 32, y: 32, tileX: 1, tileY: 1, occupancyRemoved: false },
         { id: 2, health: 50, x: 64, y: 64, tileX: 2, tileY: 2 }
       ]
       updateUnitMovement(units, mockMapGrid, mockOccupancyMap, mockGameState, performance.now())
-      expect(units.length).toBe(1)
-      expect(units[0].id).toBe(2)
+      expect(units.length).toBe(2)
+      expect(units[0].id).toBe(1)
+      expect(units[1].id).toBe(2)
     })
 
     it('should initialize movement system for all units', () => {
@@ -273,12 +274,12 @@ describe('unitMovement.js', () => {
       expect(updateRetreatBehavior).toHaveBeenCalled()
     })
 
-    it('should remove unit from cheatSystem tracking when destroyed', () => {
+    it('should defer cheatSystem destroyed-unit tracking cleanup to cleanupDestroyedUnits', () => {
       const mockRemoveUnit = vi.fn()
       window.cheatSystem = { removeUnitFromTracking: mockRemoveUnit }
       const unit = { id: 'test-id', health: 0, x: 32, y: 32, tileX: 1, tileY: 1, occupancyRemoved: false }
       updateUnitMovement([unit], mockMapGrid, mockOccupancyMap, mockGameState, performance.now())
-      expect(mockRemoveUnit).toHaveBeenCalledWith('test-id')
+      expect(mockRemoveUnit).not.toHaveBeenCalled()
       delete window.cheatSystem
     })
   })

--- a/tests/unit/unitRendererAmmoBar.test.js
+++ b/tests/unit/unitRendererAmmoBar.test.js
@@ -106,4 +106,22 @@ describe('UnitRenderer ammo HUD consistency', () => {
 
     expect(drawHudEdgeBar).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'left', 0.25, '#FFA500')
   })
+
+  it('keeps units renderable during destruction freeze delay even at 0 HP', () => {
+    const renderer = new UnitRenderer()
+    const result = renderer.shouldRenderUnit(
+      {
+        health: 0,
+        destructionQueuedAt: 1000,
+        destructionExplosionSpawned: false,
+        x: 0,
+        y: 0
+      },
+      { x: 0, y: 0 },
+      1280,
+      720
+    )
+
+    expect(result).toBe(true)
+  })
 })

--- a/tests/unit/updateGame.test.js
+++ b/tests/unit/updateGame.test.js
@@ -666,6 +666,42 @@ describe('updateGame.js', () => {
       expect(emitSmokeParticles).toHaveBeenCalled()
     })
 
+    it('should emit darker/heavier smoke during destruction freeze delay', async() => {
+      const { emitSmokeParticles } = await import('../../src/utils/smokeUtils.js')
+
+      const gameState = {
+        gamePaused: false,
+        occupancyMap: [],
+        smokeParticles: [],
+        buildings: [],
+        multiplayerSession: null
+      }
+
+      const units = [
+        {
+          type: 'tank',
+          health: 0,
+          maxHealth: 100,
+          x: 100,
+          y: 100,
+          direction: 0,
+          destructionQueuedAt: 1000,
+          destructionExplosionSpawned: false,
+          lastSmokeTime: 0
+        }
+      ]
+
+      updateGameModule.updateGame(16, [], [], units, [], gameState)
+
+      expect(emitSmokeParticles).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Number),
+        expect.any(Number),
+        expect.any(Number),
+        expect.objectContaining({ count: 3, smokeShade: 0.9 })
+      )
+    })
+
     it('should not emit smoke for healthy units', async() => {
       const { emitSmokeParticles } = await import('../../src/utils/smokeUtils.js')
 


### PR DESCRIPTION
### Motivation
- Ensure a unit that reaches `health <= 0` remains visually frozen for a short window so bullet impact animations complete before the destruction explosion and wreck appear. 
- Keep explosion audio synchronized with the visual explosion and wreck registration to avoid audio/visual timing mismatches. 

### Description
- Added a `UNIT_DESTRUCTION_FREEZE_DELAY_MS = 2000` constant and queue timestamping to `cleanupDestroyedUnits` so destroyed units are frozen (zeroed velocity) for 2000ms before final cleanup. 
- Moved explosion/wreck spawn logic into the delayed cleanup and play the positional `'explosion'` sound at the same delayed moment before spawning the destruction sprite animation. 
- Updated `updateUnitMovement` to stop immediately removing dead units so the centralized `cleanupDestroyedUnits` can enforce the freeze window. 
- Updated unit tests and project artifacts: modified `tests/unit/gameStateManager.test.js` and `tests/unit/unitMovement.test.js`, added a prompt-history entry, updated `TODO/Bugs.md` and `specs/061-bullet-impact-explosion-vfx.md` to record the timing-sync follow-up. 

### Testing
- Ran unit tests with `npm run test:unit` and all unit tests passed (`139 files`, `3630 tests` passed). 
- Ran linter autofix with `npm run lint:fix:changed` and it completed without remaining autofixable errors. 
- Existing and added unit tests covering freeze-before-cleanup and deferred-cleanup behavior succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b6bcf1d88328ab415242f6672695)