### PR TITLE
fix(rendering): hide HP overlay while unit destruction freeze is active

### DIFF
--- a/TODO/Bugs.md
+++ b/TODO/Bugs.md
@@ -392,6 +392,7 @@
 - [x] ✅ Map settings ore-field count control (2026-03-04): added sidebar ore field count input and deterministic seeded usage in map generation, with one center seed crystal per generated field.
 - [x] ✅ OFC zero + immediate map updates (2026-03-04): ore field count now supports 0, follows center/near/spread tier rules relative to party count, and map regenerates instantly when seed/players/dimensions/ore-fields inputs change (shuffle button removed).
 - [x] ✅ Route the `i` key and sidebar info (`ℹ️`) button to the settings modal keybindings tab and remove the redundant legacy "Game Controls" modal entirely.
+- [x] ✅ During unit-destruction freeze delay, hide HP/health bar display for destroyed units so no 0-HP HUD remains visible before cleanup.
 
 - [x] Investigate and fix the sidebar game-speed regression so simulation systems follow the speed input via a fixed-step simulation clock while render FPS stays unchanged and gameplay remains frame-rate independent.
 - [x] Follow-up: convert remaining gameplay-critical wall-clock timers from the game-speed fix (Tesla Coil sequencing and AI/LLM building sell timers) to the simulation clock so they obey sidebar speed changes too.

--- a/prompt-history/20260419T184204Z_destroyed-unit-hp-freeze.md
+++ b/prompt-history/20260419T184204Z_destroyed-unit-hp-freeze.md
@@ -1,0 +1,5 @@
+# 20260419T184204Z
+# Model: GPT-5.3-Codex
+
+## Prompt
+ensure when a unit is destroyed their HP is not displayed anymore during freeze period.

--- a/specs/061-bullet-impact-explosion-vfx.md
+++ b/specs/061-bullet-impact-explosion-vfx.md
@@ -30,6 +30,10 @@ Bullet impact explosions should look more realistic and visually rich, but rende
 8. Destruction sprite-sheet textures must be prewarmed/cached before delayed explosion start to eliminate first-frame stutter.
 9. Black-edge/halo artifacts around fire/explosion sprite content should be aggressively suppressed during sprite processing so the map render matches SSE preview quality.
 
+## Follow-up (2026-04-19): Freeze-Window HP Visibility
+1. Units in the delayed-destruction freeze window (`hp <= 0` with destruction not yet finalized) must not render a health/HP bar.
+2. This suppression applies even if the destroyed unit remains selected during the freeze window.
+
 ## Follow-up (2026-04-14): Generic Sprite-Sheet Destruction Explosions
 1. Add a reusable sprite-sheet animation abstraction that derives tile size and frame grid from asset filename format:
    - `<tileWidth>x<tileHeight>_<cols>x<rows>_<anything>.webp`

--- a/src/rendering/unitRenderer.js
+++ b/src/rendering/unitRenderer.js
@@ -818,6 +818,10 @@ export class UnitRenderer {
   }
 
   renderHealthBar(ctx, unit, scrollOffset) {
+    if (this.isPendingDestructionFreeze(unit)) {
+      return
+    }
+
     // Only show health bar if unit is damaged or selected
     const isDamaged = unit.health < unit.maxHealth
     const isSelected = unit.selected
@@ -1936,10 +1940,7 @@ export class UnitRenderer {
   shouldRenderUnit(unit, scrollOffset, viewportWidth, viewportHeight) {
     if (!unit) return false
 
-    const pendingDestructionFreeze =
-      unit.health <= 0 &&
-      Number.isFinite(unit.destructionQueuedAt) &&
-      unit.destructionExplosionSpawned !== true
+    const pendingDestructionFreeze = this.isPendingDestructionFreeze(unit)
 
     if (unit.health <= 0 && !pendingDestructionFreeze) return false
 
@@ -1992,6 +1993,15 @@ export class UnitRenderer {
 
     const visibility = visibilityMap[tileY]?.[tileX]
     return Boolean(visibility && visibility.visible)
+  }
+
+  isPendingDestructionFreeze(unit) {
+    return Boolean(
+      unit &&
+      unit.health <= 0 &&
+      Number.isFinite(unit.destructionQueuedAt) &&
+      unit.destructionExplosionSpawned !== true
+    )
   }
 
   renderRocketTubes(ctx, unit, centerX, centerY, now) {

--- a/tests/unit/unitRendererAmmoBar.test.js
+++ b/tests/unit/unitRendererAmmoBar.test.js
@@ -124,4 +124,32 @@ describe('UnitRenderer ammo HUD consistency', () => {
 
     expect(result).toBe(true)
   })
+
+  it('does not render a health bar while a destroyed unit is in freeze delay', () => {
+    const renderer = new UnitRenderer()
+    const drawHudEdgeBar = vi.spyOn(renderer, 'drawHudEdgeBar').mockImplementation(() => {})
+    const ctx = {
+      fillRect: vi.fn(),
+      strokeRect: vi.fn()
+    }
+
+    renderer.renderHealthBar(
+      ctx,
+      {
+        selected: true,
+        owner: 'player1',
+        x: 0,
+        y: 0,
+        health: 0,
+        maxHealth: 100,
+        destructionQueuedAt: 1000,
+        destructionExplosionSpawned: false
+      },
+      { x: 0, y: 0 }
+    )
+
+    expect(drawHudEdgeBar).not.toHaveBeenCalled()
+    expect(ctx.fillRect).not.toHaveBeenCalled()
+    expect(ctx.strokeRect).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
### Motivation
- Prevent a destroyed unit from showing a 0-HP health bar during the brief destruction freeze window so the HUD does not display misleading/ugly HP artifacts while the unit remains frozen for VFX/audio timing.

### Description
- Add `isPendingDestructionFreeze(unit)` helper to `UnitRenderer` to centralize the freeze-condition check (`health <= 0` && `destructionQueuedAt` set && `destructionExplosionSpawned !== true`).
- Early-return from `renderHealthBar` when the helper indicates a pending destruction freeze so no health HUD (edge bar or top bar) is drawn for frozen destroyed units.
- Update `shouldRenderUnit` to reuse the helper so renderability and HUD logic share the same condition.
- Add a unit test (`tests/unit/unitRendererAmmoBar.test.js`) that asserts a selected unit with `health: 0` and pending destruction does not draw health bar, and update tracking docs/specs and prompt-history accordingly.

### Testing
- Ran the full unit test suite with `npm run test:unit` and all tests passed: 141 test files, 3660 tests (success).
- Ran `npm run lint:fix:changed` which completed successfully (no remaining auto-fixable lint issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e521b6cf68832891d4dc5188503eb3)