### PR TITLE
Add deterministic 4‑bit road autotile mask generator to Sprite Sheet Editor

### DIFF
--- a/TODO/Features.md
+++ b/TODO/Features.md
@@ -378,3 +378,4 @@ The DZM overlay will look like a height map overlay with red 1px width lines tha
 - Decal selection must be pseudo-random from map seed and replace prior tile decal when a new event occurs.
 - Save/load support required for tile decals (type + deterministic variant state/counter).
 - Rendering order requirement: ore/seed overlays must remain above decals.
+- [x] Integrate a deterministic road autotile mask generator into the existing sprite sheet editor with strict 4-bit connectivity mapping (Top=1, Right=2, Bottom=4, Left=8), 16 unique base patterns, in-editor preview/inspector overlays, and PNG/WebP export of a 1024x1024 sheet where only the first 16 tiles are generated and all remaining tiles stay black.

--- a/index.html
+++ b/index.html
@@ -1215,6 +1215,55 @@
               <div id="sseImageConverterStatus" class="sse-image-converter__status" aria-live="polite"></div>
             </div>
           </div>
+
+          <div class="sprite-sheet-editor__autotile-panel" id="sseAutotilePanel">
+            <span class="sprite-sheet-editor__tags-title">Autotile mask generator</span>
+            <label class="sprite-sheet-editor__field">
+              <span>Generator type</span>
+              <select id="sseGeneratorTypeSelect" class="sidebar-input">
+                <option value="road-4bit-mask" selected>Road 4-bit mask</option>
+              </select>
+            </label>
+            <div class="sprite-sheet-editor__autotile-grid">
+              <div class="floating-label-input sprite-sheet-editor__floating-input">
+                <input id="sseGeneratorTileSize" class="sidebar-input" type="number" min="8" max="256" value="64" placeholder=" ">
+                <label for="sseGeneratorTileSize">Tile size</label>
+              </div>
+              <div class="floating-label-input sprite-sheet-editor__floating-input">
+                <input id="sseGeneratorColumns" class="sidebar-input" type="number" min="1" max="32" value="16" placeholder=" ">
+                <label for="sseGeneratorColumns">Columns</label>
+              </div>
+              <div class="floating-label-input sprite-sheet-editor__floating-input">
+                <input id="sseGeneratorRows" class="sidebar-input" type="number" min="1" max="32" value="16" placeholder=" ">
+                <label for="sseGeneratorRows">Rows</label>
+              </div>
+              <div class="floating-label-input sprite-sheet-editor__floating-input">
+                <input id="sseGeneratorRoadWidth" class="sidebar-input" type="range" min="4" max="56" value="24">
+                <label for="sseGeneratorRoadWidth">Road width</label>
+              </div>
+              <div class="floating-label-input sprite-sheet-editor__floating-input">
+                <input id="sseGeneratorFadeDistance" class="sidebar-input" type="range" min="1" max="32" value="14">
+                <label for="sseGeneratorFadeDistance">Fade distance</label>
+              </div>
+              <div class="floating-label-input sprite-sheet-editor__floating-input">
+                <input id="sseGeneratorCornerRadius" class="sidebar-input" type="range" min="0" max="24" value="6">
+                <label for="sseGeneratorCornerRadius">Corner smoothing</label>
+              </div>
+            </div>
+            <div id="sseBitOrderDisplay" class="sprite-sheet-editor__autotile-bit-order">Bit order: Top=1 Right=2 Bottom=4 Left=8</div>
+            <label class="sprite-sheet-editor__checkbox-row">
+              <input id="sseGeneratorShowDebugLabels" type="checkbox" checked>
+              <span>Show autotile debug labels</span>
+            </label>
+            <div class="sprite-sheet-editor__autotile-inspector" id="sseAutotileInspector">Selected: tile 0 • T0 R0 B0 L0</div>
+            <canvas id="sseGeneratorPreviewCanvas" class="sprite-sheet-editor__autotile-preview" width="256" height="256"></canvas>
+            <div class="sprite-sheet-editor__zoom-row">
+              <button id="sseGeneratorRegenerateBtn" class="action-button" type="button">Regenerate</button>
+              <button id="sseGeneratorExportBtn" class="action-button" type="button">Export PNG</button>
+              <button id="sseGeneratorExportWebpBtn" class="action-button" type="button">Export WebP</button>
+            </div>
+          </div>
+
           <div class="sprite-sheet-editor__field">
             <div class="floating-label-input sprite-sheet-editor__floating-input">
               <input id="sseTileSizeInput" class="sidebar-input" type="number" min="8" value="64" placeholder=" ">

--- a/prompt-history/20260422T193527Z_road-autotile-generator.md
+++ b/prompt-history/20260422T193527Z_road-autotile-generator.md
@@ -1,0 +1,18 @@
+# UTC Timestamp
+2026-04-22T19:35:27Z
+
+# Model
+codex (GPT-5.3-Codex)
+
+# Prompt
+Implement a deterministic 4-bit road autotile mask generator and integrate it into the existing sprite sheet editor in my RTS game.
+
+Key requirements included:
+- integrate into existing sprite sheet editor workflow/UI
+- strict 16-tile 4-bit edge connectivity set (Top/Right/Bottom/Left)
+- exact 1024x1024 export sheet using 16x16 grid of 64x64 tiles
+- generate each bitmask once with no duplicates and black-fill remaining tiles
+- deterministic white-on-black geometry with connected edge border touching and disconnected edge fade-out
+- editor panel controls, preview canvas, debug overlays, tile inspector, regenerate/export actions
+- modular architecture and validation checks
+- provide developer note/spec updates and implementation summary

--- a/specs/041-sse-road-autotile-generator.md
+++ b/specs/041-sse-road-autotile-generator.md
@@ -1,0 +1,61 @@
+# Spec 041: Sprite Sheet Editor deterministic 4-bit road autotile mask generator
+
+## Goal
+Add a production-usable generator to the existing Sprite Sheet Editor (SSE) that procedurally builds a strict 4-bit road mask sheet for RTS autotiling.
+
+## Bit order (must be explicit and stable)
+- LSB→MSB mapping:
+  - Top = `1`
+  - Right = `2`
+  - Bottom = `4`
+  - Left = `8`
+- Connectivity bits are binary (`0` = disconnected, `1` = connected).
+- Generate each bitmask `0..15` exactly once.
+
+## Output constraints
+- Sheet size: exactly `1024x1024`.
+- Grid: `16x16`.
+- Tile size: `64x64`.
+- Only first 16 tiles contain generated base connectivity set.
+- All remaining tiles remain pure black.
+
+## Geometry constraints
+- White roads on black mask.
+- Connected edges must touch the tile border center.
+- Disconnected edges must not reach border center and must fade into black before the border.
+- Road width is globally consistent across all 16 patterns.
+- Deterministic rendering only (no randomness, no variants in base set).
+
+## SSE integration requirements
+- Add generator panel inside existing SSE UI (no disconnected page).
+- Include controls for:
+  - generator type
+  - tile size
+  - sheet columns/rows
+  - road width
+  - fade distance
+  - corner smoothing
+  - regenerate
+  - export
+- Add dedicated preview canvas.
+- Add tile overlay/debug labels toggle (`index` and `T/R/B/L` bits).
+- Add tile click inspector to show selected tile connectivity.
+- Add export options:
+  - PNG
+  - WebP (if browser supports export encoder)
+
+## Architecture requirements
+- Keep generation logic independent from UI.
+- Separate concerns:
+  - connectivity conversion
+  - tile geometry/rasterization
+  - sheet assembly
+  - validation
+  - editor integration/export
+
+## Validation requirements
+- Ensure 16 unique connectivity masks exist.
+- Ensure no duplicates.
+- Ensure connected edges reach border center.
+- Ensure disconnected edges do not hit border center.
+- Ensure export dimension remains exactly 1024x1024.

--- a/src/ui/autotileMaskGenerator.js
+++ b/src/ui/autotileMaskGenerator.js
@@ -1,0 +1,265 @@
+// Deterministic 4-bit order (LSB→MSB): top=1, right=2, bottom=4, left=8
+export const ROAD_AUTOTILE_BIT_ORDER = Object.freeze(['top', 'right', 'bottom', 'left'])
+
+export const ROAD_AUTOTILE_GENERATOR_TYPE = 'road-4bit-mask'
+
+export const ROAD_AUTOTILE_DEFAULT_CONFIG = Object.freeze({
+  generatorType: ROAD_AUTOTILE_GENERATOR_TYPE,
+  tileSize: 64,
+  columns: 16,
+  rows: 16,
+  sheetWidth: 1024,
+  sheetHeight: 1024,
+  roadWidth: 24,
+  fadeDistance: 14,
+  cornerRadius: 6
+})
+
+function clampNumber(value, min, max, fallback) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.max(min, Math.min(max, parsed))
+}
+
+export function normalizeRoadAutotileConfig(raw = {}) {
+  const tileSize = ROAD_AUTOTILE_DEFAULT_CONFIG.tileSize
+  const columns = ROAD_AUTOTILE_DEFAULT_CONFIG.columns
+  const rows = ROAD_AUTOTILE_DEFAULT_CONFIG.rows
+  const sheetWidth = ROAD_AUTOTILE_DEFAULT_CONFIG.sheetWidth
+  const sheetHeight = ROAD_AUTOTILE_DEFAULT_CONFIG.sheetHeight
+  const maxRoadWidth = Math.max(4, tileSize - 4)
+  return {
+    generatorType: ROAD_AUTOTILE_GENERATOR_TYPE,
+    tileSize,
+    columns,
+    rows,
+    sheetWidth,
+    sheetHeight,
+    roadWidth: Math.floor(clampNumber(raw.roadWidth, 4, maxRoadWidth, ROAD_AUTOTILE_DEFAULT_CONFIG.roadWidth)),
+    fadeDistance: Math.floor(clampNumber(raw.fadeDistance, 1, tileSize / 2, ROAD_AUTOTILE_DEFAULT_CONFIG.fadeDistance)),
+    cornerRadius: Math.floor(clampNumber(raw.cornerRadius, 0, tileSize / 2, ROAD_AUTOTILE_DEFAULT_CONFIG.cornerRadius))
+  }
+}
+
+export function bitmaskToConnectivity(bitmask) {
+  const normalizedMask = Math.max(0, Math.min(15, Math.floor(bitmask) || 0))
+  return {
+    top: Boolean(normalizedMask & 0b0001),
+    right: Boolean(normalizedMask & 0b0010),
+    bottom: Boolean(normalizedMask & 0b0100),
+    left: Boolean(normalizedMask & 0b1000)
+  }
+}
+
+export function connectivityToDebugLabel(connectivity) {
+  return `T${connectivity.top ? 1 : 0} R${connectivity.right ? 1 : 0} B${connectivity.bottom ? 1 : 0} L${connectivity.left ? 1 : 0}`
+}
+
+function computeDirectionalContribution(connectivity, config, x, y) {
+  const center = (config.tileSize - 1) / 2
+  const halfRoad = config.roadWidth / 2
+  const inVerticalBand = Math.abs(x - center) <= halfRoad
+  const inHorizontalBand = Math.abs(y - center) <= halfRoad
+  let alpha = 0
+
+  if (inVerticalBand) {
+    if (y <= center) {
+      if (connectivity.top) {
+        alpha = Math.max(alpha, 1)
+      } else {
+        const fade = Math.max(1, config.fadeDistance)
+        alpha = Math.max(alpha, Math.max(0, Math.min(1, y / fade)))
+      }
+    }
+
+    if (y >= center) {
+      if (connectivity.bottom) {
+        alpha = Math.max(alpha, 1)
+      } else {
+        const fade = Math.max(1, config.fadeDistance)
+        const distFromBottom = (config.tileSize - 1) - y
+        alpha = Math.max(alpha, Math.max(0, Math.min(1, distFromBottom / fade)))
+      }
+    }
+  }
+
+  if (inHorizontalBand) {
+    if (x >= center) {
+      if (connectivity.right) {
+        alpha = Math.max(alpha, 1)
+      } else {
+        const fade = Math.max(1, config.fadeDistance)
+        const distFromRight = (config.tileSize - 1) - x
+        alpha = Math.max(alpha, Math.max(0, Math.min(1, distFromRight / fade)))
+      }
+    }
+
+    if (x <= center) {
+      if (connectivity.left) {
+        alpha = Math.max(alpha, 1)
+      } else {
+        const fade = Math.max(1, config.fadeDistance)
+        alpha = Math.max(alpha, Math.max(0, Math.min(1, x / fade)))
+      }
+    }
+  }
+
+  return alpha
+}
+
+function applyCornerSmoothing(alpha, config, x, y) {
+  if (alpha <= 0 || config.cornerRadius <= 0) return alpha
+  const center = (config.tileSize - 1) / 2
+  const halfRoad = config.roadWidth / 2
+  const cornerRadius = config.cornerRadius
+
+  const dx = Math.max(0, Math.abs(x - center) - halfRoad)
+  const dy = Math.max(0, Math.abs(y - center) - halfRoad)
+  if (dx <= 0 || dy <= 0) return alpha
+
+  const distance = Math.sqrt((dx * dx) + (dy * dy))
+  if (distance <= 0) return alpha
+  const edgeAlpha = Math.max(0, Math.min(1, 1 - (distance / Math.max(1, cornerRadius))))
+  return Math.min(alpha, edgeAlpha)
+}
+
+export function generateRoadAutotileMaskTile(bitmask, rawConfig = {}) {
+  const config = normalizeRoadAutotileConfig(rawConfig)
+  const connectivity = bitmaskToConnectivity(bitmask)
+  const tileSize = config.tileSize
+  const pixels = new Uint8ClampedArray(tileSize * tileSize * 4)
+
+  for (let y = 0; y < tileSize; y++) {
+    for (let x = 0; x < tileSize; x++) {
+      let alpha = computeDirectionalContribution(connectivity, config, x, y)
+      alpha = applyCornerSmoothing(alpha, config, x, y)
+      const value = Math.max(0, Math.min(255, Math.round(alpha * 255)))
+      const idx = (y * tileSize + x) * 4
+      pixels[idx] = value
+      pixels[idx + 1] = value
+      pixels[idx + 2] = value
+      pixels[idx + 3] = 255
+    }
+  }
+
+  return {
+    bitmask: Math.max(0, Math.min(15, Math.floor(bitmask) || 0)),
+    connectivity,
+    width: tileSize,
+    height: tileSize,
+    pixels
+  }
+}
+
+function createCanvas(width, height) {
+  if (typeof document !== 'undefined' && typeof document.createElement === 'function') {
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    return canvas
+  }
+
+  if (typeof globalThis !== 'undefined' && typeof globalThis.OffscreenCanvas !== 'undefined') {
+    return new globalThis.OffscreenCanvas(width, height)
+  }
+
+  throw new Error('Canvas API is not available in this environment.')
+}
+
+export function validateRoadAutotileMaskSheet(sheet, rawConfig = {}) {
+  const config = normalizeRoadAutotileConfig(rawConfig)
+  const errors = []
+  const seen = new Set(sheet?.tileMap?.map(entry => entry.bitmask) || [])
+
+  if (seen.size !== 16) {
+    errors.push(`Expected 16 unique bitmasks but got ${seen.size}.`)
+  }
+
+  for (let mask = 0; mask < 16; mask++) {
+    if (!seen.has(mask)) {
+      errors.push(`Missing bitmask ${mask}.`)
+    }
+  }
+
+  if (!sheet?.canvas || sheet.canvas.width !== config.sheetWidth || sheet.canvas.height !== config.sheetHeight) {
+    errors.push(`Sheet must be exactly ${config.sheetWidth}x${config.sheetHeight}.`)
+  }
+
+  const tileCenter = Math.floor(config.tileSize / 2)
+  sheet?.tileMap?.forEach((entry) => {
+    const tile = entry.tile
+    const read = (x, y) => {
+      const idx = (y * tile.width + x) * 4
+      return tile.pixels[idx]
+    }
+    const borderSamples = {
+      top: read(tileCenter, 0),
+      right: read(tile.width - 1, tileCenter),
+      bottom: read(tileCenter, tile.height - 1),
+      left: read(0, tileCenter)
+    }
+
+    ROAD_AUTOTILE_BIT_ORDER.forEach((edge) => {
+      const connected = entry.connectivity[edge]
+      const value = borderSamples[edge]
+      if (connected && value < 250) {
+        errors.push(`Bitmask ${entry.bitmask}: connected ${edge} edge does not touch border center.`)
+      }
+      if (!connected && value > 0) {
+        errors.push(`Bitmask ${entry.bitmask}: non-connected ${edge} edge reaches border center.`)
+      }
+    })
+  })
+
+  return {
+    valid: errors.length === 0,
+    errors
+  }
+}
+
+export function generateRoadAutotileMaskSheet(rawConfig = {}) {
+  const config = normalizeRoadAutotileConfig(rawConfig)
+  const canvas = createCanvas(config.sheetWidth, config.sheetHeight)
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })
+  if (!ctx) {
+    throw new Error('Unable to get 2D context for autotile sheet generation.')
+  }
+
+  ctx.imageSmoothingEnabled = false
+  ctx.fillStyle = '#000'
+  ctx.fillRect(0, 0, config.sheetWidth, config.sheetHeight)
+
+  const tileMap = []
+  for (let bitmask = 0; bitmask < 16; bitmask++) {
+    const tile = generateRoadAutotileMaskTile(bitmask, config)
+    const col = bitmask % config.columns
+    const row = Math.floor(bitmask / config.columns)
+    const offsetX = col * config.tileSize
+    const offsetY = row * config.tileSize
+    for (let y = 0; y < tile.height; y++) {
+      for (let x = 0; x < tile.width; x++) {
+        const idx = (y * tile.width + x) * 4
+        const value = tile.pixels[idx]
+        if (value <= 0) continue
+        ctx.fillStyle = `rgb(${value}, ${value}, ${value})`
+        ctx.fillRect(offsetX + x, offsetY + y, 1, 1)
+      }
+    }
+    tileMap.push({
+      bitmask,
+      connectivity: tile.connectivity,
+      col,
+      row,
+      tile
+    })
+  }
+
+  const validation = validateRoadAutotileMaskSheet({ canvas, tileMap }, config)
+  return {
+    config,
+    canvas,
+    tileMap,
+    validation,
+    bitOrderDescription: 'Bit order (LSB→MSB): Top=1, Right=2, Bottom=4, Left=8'
+  }
+}

--- a/src/ui/spriteSheetEditor.js
+++ b/src/ui/spriteSheetEditor.js
@@ -5,6 +5,14 @@ import {
   normalizeSpriteSheetBlendMode,
   parseSpriteSheetMetadataFromFilename
 } from '../rendering/spriteSheetAnimation.js'
+import {
+  ROAD_AUTOTILE_DEFAULT_CONFIG,
+  ROAD_AUTOTILE_GENERATOR_TYPE,
+  bitmaskToConnectivity,
+  connectivityToDebugLabel,
+  generateRoadAutotileMaskSheet,
+  normalizeRoadAutotileConfig
+} from './autotileMaskGenerator.js'
 
 const DEFAULT_TILE_SIZE = 64
 const DEFAULT_BORDER_WIDTH = 1
@@ -1496,6 +1504,112 @@ function resolveSheetDisplayLabel(state, sheetPath) {
   return sheetPath?.split('/').pop() || sheetPath || ''
 }
 
+function downloadCanvasImage(canvas, filename, mimeType = 'image/png', quality) {
+  if (!canvas || typeof canvas.toBlob !== 'function') return false
+  canvas.toBlob((blob) => {
+    if (!blob) return
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = filename
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    URL.revokeObjectURL(url)
+  }, mimeType, quality)
+  return true
+}
+
+function drawAutotilePreview(state) {
+  if (!state.generatorPreviewCanvas || !state.generatedAutotileSheet?.canvas) return
+  const ctx = state.generatorPreviewCanvas.getContext('2d')
+  if (!ctx) return
+  const source = state.generatedAutotileSheet.canvas
+  const scale = state.generatorPreviewCanvas.width / source.width
+  ctx.clearRect(0, 0, state.generatorPreviewCanvas.width, state.generatorPreviewCanvas.height)
+  ctx.imageSmoothingEnabled = false
+  ctx.drawImage(source, 0, 0, state.generatorPreviewCanvas.width, state.generatorPreviewCanvas.height)
+
+  if (!state.generatorShowDebugLabels) return
+  const tileSize = state.generatedAutotileSheet.config.tileSize
+  for (let bitmask = 0; bitmask < 16; bitmask++) {
+    const col = bitmask % state.generatedAutotileSheet.config.columns
+    const row = Math.floor(bitmask / state.generatedAutotileSheet.config.columns)
+    const x = col * tileSize * scale
+    const y = row * tileSize * scale
+    const connectivity = bitmaskToConnectivity(bitmask)
+    const label = connectivityToDebugLabel(connectivity)
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.75)'
+    ctx.fillRect(x + 2, y + 2, Math.min(84, (tileSize * scale) - 4), 22)
+    ctx.fillStyle = '#fff'
+    ctx.font = '8px sans-serif'
+    ctx.fillText(`#${bitmask}`, x + 4, y + 10)
+    ctx.fillText(label, x + 4, y + 19)
+  }
+
+  if (Number.isFinite(state.generatorSelectedBitmask)) {
+    const bitmask = Math.max(0, Math.min(15, state.generatorSelectedBitmask))
+    const col = bitmask % state.generatedAutotileSheet.config.columns
+    const row = Math.floor(bitmask / state.generatedAutotileSheet.config.columns)
+    const x = col * tileSize * scale
+    const y = row * tileSize * scale
+    ctx.strokeStyle = '#00d4ff'
+    ctx.lineWidth = 2
+    ctx.strokeRect(x + 1, y + 1, (tileSize * scale) - 2, (tileSize * scale) - 2)
+  }
+}
+
+function updateAutotileInspector(state) {
+  if (!state.generatorInspectorEl) return
+  const bitmask = Math.max(0, Math.min(15, state.generatorSelectedBitmask || 0))
+  state.generatorSelectedBitmask = bitmask
+  const connectivity = bitmaskToConnectivity(bitmask)
+  state.generatorInspectorEl.textContent = `Selected: tile ${bitmask} • ${connectivityToDebugLabel(connectivity)}`
+}
+
+async function regenerateAutotileSheet(state, { loadIntoEditor = true } = {}) {
+  const normalizedConfig = normalizeRoadAutotileConfig({
+    generatorType: state.generatorTypeSelect?.value || ROAD_AUTOTILE_GENERATOR_TYPE,
+    tileSize: Number.parseInt(state.generatorTileSizeInput?.value, 10),
+    columns: Number.parseInt(state.generatorColumnsInput?.value, 10),
+    rows: Number.parseInt(state.generatorRowsInput?.value, 10),
+    sheetWidth: Number.parseInt(state.generatorColumnsInput?.value, 10) * Number.parseInt(state.generatorTileSizeInput?.value, 10),
+    sheetHeight: Number.parseInt(state.generatorRowsInput?.value, 10) * Number.parseInt(state.generatorTileSizeInput?.value, 10),
+    roadWidth: Number.parseInt(state.generatorRoadWidthInput?.value, 10),
+    fadeDistance: Number.parseInt(state.generatorFadeDistanceInput?.value, 10),
+    cornerRadius: Number.parseInt(state.generatorCornerRadiusInput?.value, 10)
+  })
+  state.generatedAutotileSheet = generateRoadAutotileMaskSheet(normalizedConfig)
+
+  if (state.generatorTileSizeInput) state.generatorTileSizeInput.value = `${state.generatedAutotileSheet.config.tileSize}`
+  if (state.generatorColumnsInput) state.generatorColumnsInput.value = `${state.generatedAutotileSheet.config.columns}`
+  if (state.generatorRowsInput) state.generatorRowsInput.value = `${state.generatedAutotileSheet.config.rows}`
+  if (state.generatorRoadWidthInput) state.generatorRoadWidthInput.value = `${state.generatedAutotileSheet.config.roadWidth}`
+  if (state.generatorFadeDistanceInput) state.generatorFadeDistanceInput.value = `${state.generatedAutotileSheet.config.fadeDistance}`
+  if (state.generatorCornerRadiusInput) state.generatorCornerRadiusInput.value = `${state.generatedAutotileSheet.config.cornerRadius}`
+  if (state.bitOrderDisplayEl) state.bitOrderDisplayEl.textContent = state.generatedAutotileSheet.bitOrderDescription
+
+  drawAutotilePreview(state)
+  updateAutotileInspector(state)
+
+  if (!state.generatedAutotileSheet.validation.valid) {
+    setStatus(state, `Autotile validation failed: ${state.generatedAutotileSheet.validation.errors.join(' ')}`, 'error')
+    return
+  }
+
+  if (!loadIntoEditor) {
+    setStatus(state, 'Regenerated 4-bit road autotile sheet.')
+    return
+  }
+
+  const dataUrl = state.generatedAutotileSheet.canvas.toDataURL('image/png')
+  ensureSheetPathInMode(state, dataUrl, 'generated-road-4bit-mask.png', 'static')
+  state.sheetPaths = state.mode === 'animated' ? state.animationSheetPaths : state.staticSheetPaths
+  renderSheetOptions(state)
+  await loadSheet(state, dataUrl, { mode: state.mode })
+  setStatus(state, 'Generated and loaded deterministic road 4-bit mask sheet.')
+}
+
 export async function initSpriteSheetEditor(options = {}) {
   const state = {
     modal: document.getElementById('spriteSheetEditorModal'),
@@ -1515,6 +1629,20 @@ export async function initSpriteSheetEditor(options = {}) {
     sheetInfoWrap: document.getElementById('sseSheetInfoWrap'),
     sheetInfoBtn: document.getElementById('sseSheetInfoBtn'),
     sheetInfoPopover: document.getElementById('sseSheetInfoPopover'),
+    generatorTypeSelect: document.getElementById('sseGeneratorTypeSelect'),
+    generatorTileSizeInput: document.getElementById('sseGeneratorTileSize'),
+    generatorColumnsInput: document.getElementById('sseGeneratorColumns'),
+    generatorRowsInput: document.getElementById('sseGeneratorRows'),
+    generatorRoadWidthInput: document.getElementById('sseGeneratorRoadWidth'),
+    generatorFadeDistanceInput: document.getElementById('sseGeneratorFadeDistance'),
+    generatorCornerRadiusInput: document.getElementById('sseGeneratorCornerRadius'),
+    generatorPreviewCanvas: document.getElementById('sseGeneratorPreviewCanvas'),
+    generatorShowDebugLabelsCheckbox: document.getElementById('sseGeneratorShowDebugLabels'),
+    generatorInspectorEl: document.getElementById('sseAutotileInspector'),
+    generatorRegenerateBtn: document.getElementById('sseGeneratorRegenerateBtn'),
+    generatorExportBtn: document.getElementById('sseGeneratorExportBtn'),
+    generatorExportWebpBtn: document.getElementById('sseGeneratorExportWebpBtn'),
+    bitOrderDisplayEl: document.getElementById('sseBitOrderDisplay'),
     tileSizeInput: document.getElementById('sseTileSizeInput'),
     rowHeightInput: document.getElementById('sseRowHeightInput'),
     borderWidthInput: document.getElementById('sseBorderWidthInput'),
@@ -1582,6 +1710,9 @@ export async function initSpriteSheetEditor(options = {}) {
     animatedModeSnapshot: null,
     sidebarHidden: false,
     sidebarSwipeState: null,
+    generatedAutotileSheet: null,
+    generatorSelectedBitmask: 0,
+    generatorShowDebugLabels: true,
     onSheetDataChange: options.onSheetDataChange || null,
     onAnimationSheetDataChange: options.onAnimationSheetDataChange || null
   }
@@ -1628,6 +1759,18 @@ export async function initSpriteSheetEditor(options = {}) {
       : (lastSheet && state.sheetPaths.includes(lastSheet) ? lastSheet : state.sheetPaths[0]))
 
   await loadSheet(state, initialSheetPath, { saveCurrent: false, mode: state.mode })
+
+  if (state.generatorTypeSelect) {
+    state.generatorTypeSelect.value = ROAD_AUTOTILE_GENERATOR_TYPE
+  }
+  if (state.generatorTileSizeInput) state.generatorTileSizeInput.value = `${ROAD_AUTOTILE_DEFAULT_CONFIG.tileSize}`
+  if (state.generatorColumnsInput) state.generatorColumnsInput.value = `${ROAD_AUTOTILE_DEFAULT_CONFIG.columns}`
+  if (state.generatorRowsInput) state.generatorRowsInput.value = `${ROAD_AUTOTILE_DEFAULT_CONFIG.rows}`
+  if (state.generatorRoadWidthInput) state.generatorRoadWidthInput.value = `${ROAD_AUTOTILE_DEFAULT_CONFIG.roadWidth}`
+  if (state.generatorFadeDistanceInput) state.generatorFadeDistanceInput.value = `${ROAD_AUTOTILE_DEFAULT_CONFIG.fadeDistance}`
+  if (state.generatorCornerRadiusInput) state.generatorCornerRadiusInput.value = `${ROAD_AUTOTILE_DEFAULT_CONFIG.cornerRadius}`
+  if (state.bitOrderDisplayEl) state.bitOrderDisplayEl.textContent = 'Bit order (LSB→MSB): Top=1, Right=2, Bottom=4, Left=8'
+  await regenerateAutotileSheet(state, { loadIntoEditor: false })
 
   const switchMode = async(nextMode) => {
     if (state.mode === nextMode) return
@@ -1923,6 +2066,64 @@ export async function initSpriteSheetEditor(options = {}) {
     state.showTaggedOverlay = Boolean(state.showTaggedOverlayCheckbox.checked)
     drawSseCanvas(state)
     applyCanvasZoom(state)
+  })
+
+  state.generatorRegenerateBtn?.addEventListener('click', async() => {
+    await regenerateAutotileSheet(state, { loadIntoEditor: true })
+  })
+
+  state.generatorShowDebugLabelsCheckbox?.addEventListener('change', () => {
+    state.generatorShowDebugLabels = Boolean(state.generatorShowDebugLabelsCheckbox.checked)
+    drawAutotilePreview(state)
+  })
+
+  state.generatorPreviewCanvas?.addEventListener('click', (event) => {
+    if (!state.generatedAutotileSheet) return
+    const rect = state.generatorPreviewCanvas.getBoundingClientRect()
+    const x = event.clientX - rect.left
+    const y = event.clientY - rect.top
+    const scaleX = state.generatedAutotileSheet.canvas.width / rect.width
+    const scaleY = state.generatedAutotileSheet.canvas.height / rect.height
+    const sourceX = x * scaleX
+    const sourceY = y * scaleY
+    const col = Math.floor(sourceX / state.generatedAutotileSheet.config.tileSize)
+    const row = Math.floor(sourceY / state.generatedAutotileSheet.config.tileSize)
+    const bitmask = (row * state.generatedAutotileSheet.config.columns) + col
+    if (bitmask < 0 || bitmask > 15) return
+    state.generatorSelectedBitmask = bitmask
+    updateAutotileInspector(state)
+    drawAutotilePreview(state)
+  })
+
+  state.generatorExportBtn?.addEventListener('click', () => {
+    if (!state.generatedAutotileSheet?.canvas) return
+    const ok = downloadCanvasImage(state.generatedAutotileSheet.canvas, 'road_4bit_mask_1024x1024.png', 'image/png')
+    if (ok) {
+      setStatus(state, 'Exported PNG autotile mask (1024x1024).')
+    }
+  })
+
+  state.generatorExportWebpBtn?.addEventListener('click', () => {
+    if (!state.generatedAutotileSheet?.canvas) return
+    const ok = downloadCanvasImage(state.generatedAutotileSheet.canvas, 'road_4bit_mask_1024x1024.webp', 'image/webp', 0.95)
+    if (ok) {
+      setStatus(state, 'Exported WebP autotile mask (1024x1024).')
+    }
+  })
+
+  const generatorInputs = [
+    state.generatorTypeSelect,
+    state.generatorTileSizeInput,
+    state.generatorColumnsInput,
+    state.generatorRowsInput,
+    state.generatorRoadWidthInput,
+    state.generatorFadeDistanceInput,
+    state.generatorCornerRadiusInput
+  ]
+  generatorInputs.forEach((input) => {
+    input?.addEventListener('change', async() => {
+      await regenerateAutotileSheet(state, { loadIntoEditor: false })
+    })
   })
 
   state.zoomInBtn?.addEventListener('click', () => {

--- a/styles/overlays.css
+++ b/styles/overlays.css
@@ -479,6 +479,36 @@ body.config-modal-open {
   margin-top: auto;
 }
 
+
+.sprite-sheet-editor__autotile-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(8, 12, 18, 0.88);
+}
+
+.sprite-sheet-editor__autotile-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.sprite-sheet-editor__autotile-bit-order,
+.sprite-sheet-editor__autotile-inspector {
+  font-size: 12px;
+  color: #b9c7d6;
+}
+
+.sprite-sheet-editor__autotile-preview {
+  width: 100%;
+  max-width: 256px;
+  image-rendering: pixelated;
+  border: 1px solid #2d3640;
+  background: #000;
+}
+
 .sprite-sheet-editor__zoom-controls {
   display: flex;
   flex-direction: column;

--- a/tests/unit/autotileMaskGenerator.test.js
+++ b/tests/unit/autotileMaskGenerator.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import '../setup.js'
+import {
+  bitmaskToConnectivity,
+  connectivityToDebugLabel,
+  generateRoadAutotileMaskSheet,
+  generateRoadAutotileMaskTile,
+  validateRoadAutotileMaskSheet
+} from '../../src/ui/autotileMaskGenerator.js'
+
+describe('autotileMaskGenerator', () => {
+  it('maps bitmasks to deterministic 4-bit connectivity labels', () => {
+    expect(bitmaskToConnectivity(0)).toEqual({ top: false, right: false, bottom: false, left: false })
+    expect(bitmaskToConnectivity(5)).toEqual({ top: true, right: false, bottom: true, left: false })
+    expect(connectivityToDebugLabel(bitmaskToConnectivity(10))).toBe('T0 R1 B0 L1')
+  })
+
+  it('creates connected edges that touch border center and disconnected edges that do not', () => {
+    const connectedTop = generateRoadAutotileMaskTile(1)
+    const disconnectedTop = generateRoadAutotileMaskTile(0)
+    const center = Math.floor(connectedTop.width / 2)
+
+    const read = (tile, x, y) => tile.pixels[((y * tile.width) + x) * 4]
+    expect(read(connectedTop, center, 0)).toBeGreaterThanOrEqual(250)
+    expect(read(disconnectedTop, center, 0)).toBe(0)
+  })
+
+  it('generates a strict 1024x1024 sheet with exactly 16 unique patterns', () => {
+    const result = generateRoadAutotileMaskSheet({
+      tileSize: 32,
+      columns: 8,
+      rows: 8
+    })
+
+    expect(result.config.tileSize).toBe(64)
+    expect(result.config.columns).toBe(16)
+    expect(result.config.rows).toBe(16)
+    expect(result.canvas.width).toBe(1024)
+    expect(result.canvas.height).toBe(1024)
+    expect(result.tileMap).toHaveLength(16)
+    expect(new Set(result.tileMap.map(entry => entry.bitmask)).size).toBe(16)
+    expect(result.validation.valid).toBe(true)
+  })
+
+  it('detects validation errors when a non-connected edge reaches border center', () => {
+    const result = generateRoadAutotileMaskSheet()
+    const entry = result.tileMap.find(tile => tile.bitmask === 0)
+    const center = Math.floor(entry.tile.width / 2)
+    const idx = ((0 * entry.tile.width) + center) * 4
+    entry.tile.pixels[idx] = 255
+
+    const validation = validateRoadAutotileMaskSheet(result)
+    expect(validation.valid).toBe(false)
+    expect(validation.errors.join(' ')).toMatch(/non-connected top edge reaches border center/)
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide an integrated, production-ready generator inside the existing Sprite Sheet Editor to produce a strict 4-bit (16 pattern) road mask sheet for autotiling workflows.
- Ensure deterministic, topology-correct masks (connected edges reach the border center; disconnected edges fade to black) with exact export dimensions (1024×1024, 16×16 grid, 64×64 tiles).
- Expose bit-order mapping and per-tile inspection/debugging to make tile index ↔ connectivity mapping obvious and auditable.

### Description
- Added a reusable generator module `src/ui/autotileMaskGenerator.js` implementing: `generateRoadAutotileMaskSheet`, `generateRoadAutotileMaskTile`, `bitmaskToConnectivity`, `connectivityToDebugLabel`, config normalization, rasterization and validation (ensures 16 unique patterns, topology checks, and exact sheet dimensions). The file documents the bit order (LSB→MSB: Top=1, Right=2, Bottom=4, Left=8).
- Integrated the feature into the existing SSE UI (no separate demo): updated `index.html` to include the Autotile panel and `styles/overlays.css` for styling, and wired editor logic in `src/ui/spriteSheetEditor.js` to provide preview canvas, debug label toggle, bit-order display, tile inspector (click selection), regenerate button, and PNG/WebP export using canvas `toBlob`.
- Kept generation logic UI-free and modular: connectivity model, tile geometry builder, rasterization and validation are in the generator module; editor code only handles controls/preview/export/load-into-editor flow.
- Added docs and bookkeeping entries: new spec `specs/041-sse-road-autotile-generator.md`, TODO update `TODO/Features.md`, and prompt history `prompt-history/20260422T193527Z_road-autotile-generator.md` per repository rules.

### Testing
- Unit tests added at `tests/unit/autotileMaskGenerator.test.js` covering bitmask→connectivity mapping, border-center connectivity assertions, sheet generation uniqueness/size, and validation failure detection; these tests were run with `npx vitest run tests/unit/autotileMaskGenerator.test.js` and passed.
- Ran full unit test suite with `npm run test:unit`; all tests passed (summary: 3691 tests passed across the project after adjustments made during rollout).
- Ran lint fix step `npm run lint:fix:changed` and addressed an environment reference (`OffscreenCanvas`) to satisfy linting.
- Validation is also performed at generation time inside the generator and surfacing errors to the SSE status if generation fails validation.

Files changed/added (high level):
- Added: `src/ui/autotileMaskGenerator.js`, `tests/unit/autotileMaskGenerator.test.js`, `specs/041-sse-road-autotile-generator.md`, `prompt-history/20260422T193527Z_road-autotile-generator.md`
- Modified: `src/ui/spriteSheetEditor.js`, `index.html`, `styles/overlays.css`, `TODO/Features.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9219af14c8328bd3592beb32be717)