### PR TITLE
Smooth mobile scroll frame pacing

### DIFF
--- a/TODO/Improvements.md
+++ b/TODO/Improvements.md
@@ -1,3 +1,4 @@
+- [x] Smooth iPhone 13 Pro Max scrolling/combat pacing by making the mobile frame watchdog a stall-only fallback and reducing allocation/overdraw in heavy effects rendering.
 - [x] Migrate runtime game persistence from direct Web Storage calls to an IndexedDB-backed browser storage layer, including saves, replays, tutorial/settings preferences, aliases, keybindings, LLM settings, sprite-sheet metadata, and legacy data migration.
 - [x] Pin the iOS Simulator benchmark to an explicit `iPhone 13 Pro Max` simulator device by default, create/use the local simulator UDID, and document install/create commands for missing devices.
 - [x] Make benchmark-mode emulator startup leave Safari navigation to the E2E test, so the plain app URL is not opened before Vite is reachable and the Simulator no longer sits on the home screen after an early emulator-script failure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-starter",
-  "version": "0.30.4",
+  "version": "0.30.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-starter",
-      "version": "0.30.4",
+      "version": "0.30.6",
       "license": "MIT",
       "dependencies": {
         "@netlify/blobs": "^10.4.2",

--- a/prompt-history/20260718T133206Z_smooth-mobile-scroll.md
+++ b/prompt-history/20260718T133206Z_smooth-mobile-scroll.md
@@ -1,0 +1,5 @@
+UTC timestamp: 20260718T133206Z
+LLM: codex
+
+Prompt:
+analyse the game for reasons causing micro stutters and fix them so scrolling the map is super smooth and also when lots of action takes place on the map with animations and explosions ensure that there are no stutters on an iphone 13 pro max.

--- a/specs/068-mobile-fps-regression-bottleneck-overlay.md
+++ b/specs/068-mobile-fps-regression-bottleneck-overlay.md
@@ -99,3 +99,9 @@ Recent street sprite-sheet routing work introduced a major mobile framerate regr
 - The E2E benchmark can enforce that visible terrain samples do not turn black during fast scroll sweeps.
 - A local non-throttled mobile benchmark profile can reach the 60fps target when mobile terrain pixel density is set to 1x.
 - The benchmark evidence is used to validate that mobile render time improves after fixes.
+
+## Smooth mobile scrolling follow-up (2026-07-18)
+
+- Mobile foreground frame scheduling must prioritize native `requestAnimationFrame` cadence during camera movement and combat effects; any timeout watchdog must be a stall recovery fallback only and must not race active scroll/combat frames.
+- Heavy effect rendering on touch devices should preserve core readability while skipping nonessential explosion adornments, per-frame blend-list allocations, and offscreen dust work when the viewport is moving or many effects are visible.
+- Acceptance: map scrolling on iPhone 13 Pro Max should avoid non-vsync micro-stutter, and large action scenes should keep effects within the mobile frame budget without hiding core explosions/smoke/projectiles.

--- a/src/game/gameLoop.js
+++ b/src/game/gameLoop.js
@@ -18,7 +18,11 @@ import { advanceSimulationTime, getFixedSimulationStepMs, getSimulationTime } fr
 import { performanceMonitor } from '../performance/performanceMonitor.js'
 import { getCanvasLogicalSize } from '../rendering/renderingUtils.js'
 
-const MOBILE_FRAME_WATCHDOG_MS = 17
+// Foreground mobile Safari/Chrome already align requestAnimationFrame to
+// the device refresh driver. Racing RAF with a fixed timeout introduced
+// uneven 8/17ms cadence on ProMotion iPhones during touch scrolling, which
+// surfaced as micro-stutter even when update/render work was below budget.
+const MOBILE_FRAME_WATCHDOG_MS = 250
 const MAX_FOREGROUND_SIMULATION_DELTA_MS = 100
 
 export class GameLoop {
@@ -151,7 +155,7 @@ export class GameLoop {
         this.animate(timestamp)
       }
       this.animationId = requestAnimationFrame((timestamp) => runFrame(timestamp, 'raf'))
-      if (this.isMobileRenderProfile()) {
+      if (this.shouldUseMobileWatchdog()) {
         this.frameTimeoutId = setTimeout(() => runFrame(performance.now(), 'watchdog'), MOBILE_FRAME_WATCHDOG_MS)
       }
       return
@@ -173,6 +177,14 @@ export class GameLoop {
     const velocityActive = velocityX > velocityThreshold || velocityY > velocityThreshold
 
     return gameState.isRightDragging || keyScrollActive || velocityActive
+  }
+
+  shouldUseMobileWatchdog() {
+    // Keep the watchdog only as a genuine stall recovery path. Never compete
+    // with active camera motion or visible combat effects, because that creates
+    // non-vsync frame starts on iPhone 13 Pro Max and reads as scroll hitching.
+    return this.isMobileRenderProfile() && !this.hasActiveScrollActivity() &&
+      !(gameState.explosions?.length || gameState.smokeParticles?.length || gameState.dustParticles?.length)
   }
 
   isMobileRenderProfile() {

--- a/src/rendering/effectsRenderer.js
+++ b/src/rendering/effectsRenderer.js
@@ -168,6 +168,16 @@ function getExplosionCoreSprite(radius) {
   return canvas
 }
 
+function isMobileRenderProfile() {
+  const body = typeof document !== 'undefined' ? document.body : null
+  return Boolean(
+    body?.classList.contains('is-touch') ||
+    body?.classList.contains('mobile-landscape') ||
+    body?.classList.contains('mobile-portrait') ||
+    (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0)
+  )
+}
+
 export class EffectsRenderer {
   constructor() {
     // Initialize sprite cache on first renderer creation
@@ -426,21 +436,25 @@ export class EffectsRenderer {
   }
 
   renderDust(ctx, gameState, scrollOffset) {
-    if (gameState?.dustParticles && gameState.dustParticles.length > 0) {
-      gameState.dustParticles.forEach(p => {
-        ctx.save()
-        ctx.globalAlpha = p.alpha
-        const x = p.x - scrollOffset.x
-        const y = p.y - scrollOffset.y
-        const size = p.currentSize || p.size
+    const particles = gameState?.dustParticles
+    if (!particles || particles.length === 0) return
 
-        ctx.fillStyle = p.color || '#D2B48C'
-        ctx.beginPath()
-        ctx.arc(x, y, size, 0, Math.PI * 2)
-        ctx.fill()
-        ctx.restore()
-      })
+    const { width: canvasWidth, height: canvasHeight } = getCanvasLogicalSize(ctx.canvas)
+    const padding = 48
+    const previousAlpha = ctx.globalAlpha
+    for (let i = 0; i < particles.length; i++) {
+      const p = particles[i]
+      if (!p) continue
+      const x = p.x - scrollOffset.x
+      const y = p.y - scrollOffset.y
+      if (x < -padding || x > canvasWidth + padding || y < -padding || y > canvasHeight + padding) continue
+      ctx.globalAlpha = p.alpha
+      ctx.fillStyle = p.color || '#D2B48C'
+      ctx.beginPath()
+      ctx.arc(x, y, p.currentSize || p.size, 0, Math.PI * 2)
+      ctx.fill()
     }
+    ctx.globalAlpha = previousAlpha
   }
 
   renderExplosions(ctx, gameState, scrollOffset) {
@@ -530,18 +544,22 @@ export class EffectsRenderer {
       }
       ctx.globalAlpha = 1
 
-      // Draw an energetic shockwave ring with time-varying jitter
-      const shockwaveRadius = plumeRadius * (0.92 + 0.12 * progress)
+      const mobileQualityMode = isMobileRenderProfile() && (len > 4 || gameState?.isRightDragging)
       const jitterSeed = (exp.x * 0.13 + exp.y * 0.09 + exp.startTime * 0.001) % (Math.PI * 2)
-      const jitter = Math.sin(progress * 34 + jitterSeed) * 0.08 + 1
-      ctx.strokeStyle = `rgba(255,200,110,${alpha * 0.75})`
-      ctx.lineWidth = 1.2 + 1.8 * fade
-      ctx.beginPath()
-      ctx.arc(centerX, centerY, shockwaveRadius * jitter, 0, 2 * Math.PI)
-      ctx.stroke()
+
+      // Draw an energetic shockwave ring with time-varying jitter
+      if (!mobileQualityMode) {
+        const shockwaveRadius = plumeRadius * (0.92 + 0.12 * progress)
+        const jitter = Math.sin(progress * 34 + jitterSeed) * 0.08 + 1
+        ctx.strokeStyle = `rgba(255,200,110,${alpha * 0.75})`
+        ctx.lineWidth = 1.2 + 1.8 * fade
+        ctx.beginPath()
+        ctx.arc(centerX, centerY, shockwaveRadius * jitter, 0, 2 * Math.PI)
+        ctx.stroke()
+      }
 
       // Faint embers at low count keep the effect fancy without heavy particle systems
-      if (fade > 0.2) {
+      if (!mobileQualityMode && fade > 0.2) {
         const emberCount = Math.min(4, Math.max(1, Math.floor(maxRadius / TILE_SIZE)))
         ctx.fillStyle = `rgba(255,215,120,${alpha * 0.5})`
         for (let e = 0; e < emberCount; e++) {
@@ -561,22 +579,20 @@ export class EffectsRenderer {
       const previousOperation = ctx.globalCompositeOperation
       const previousAlpha = ctx.globalAlpha
       const previousSmoothing = ctx.imageSmoothingEnabled
-      const blackBlendAnimations = additiveAnimations.filter(animation => (animation?.blendMode || 'black') === 'black')
-      const alphaBlendAnimations = additiveAnimations.filter(animation => (animation?.blendMode || 'black') === 'alpha')
-
-      if (blackBlendAnimations.length > 0) {
-        ctx.globalCompositeOperation = 'lighter'
-        ctx.imageSmoothingEnabled = false
-        for (let i = 0; i < blackBlendAnimations.length; i++) {
-          renderSpriteSheetAnimation(ctx, blackBlendAnimations[i], scrollOffset, currentTime)
+      ctx.imageSmoothingEnabled = false
+      ctx.globalCompositeOperation = 'lighter'
+      for (let i = 0; i < additiveAnimations.length; i++) {
+        const animation = additiveAnimations[i]
+        if ((animation?.blendMode || 'black') === 'black') {
+          renderSpriteSheetAnimation(ctx, animation, scrollOffset, currentTime)
         }
       }
 
-      if (alphaBlendAnimations.length > 0) {
-        ctx.globalCompositeOperation = 'source-over'
-        ctx.imageSmoothingEnabled = false
-        for (let i = 0; i < alphaBlendAnimations.length; i++) {
-          renderSpriteSheetAnimation(ctx, alphaBlendAnimations[i], scrollOffset, currentTime)
+      ctx.globalCompositeOperation = 'source-over'
+      for (let i = 0; i < additiveAnimations.length; i++) {
+        const animation = additiveAnimations[i]
+        if ((animation?.blendMode || 'black') === 'alpha') {
+          renderSpriteSheetAnimation(ctx, animation, scrollOffset, currentTime)
         }
       }
 
@@ -591,11 +607,15 @@ export class EffectsRenderer {
     if (gameState?.dustParticles && gameState?.dustParticles.length > 0) {
       const currentTime = performance.now()
 
-      // Clean up expired particles
-      gameState.dustParticles = gameState.dustParticles.filter(dust => {
-        const age = currentTime - dust.startTime
-        return age < dust.lifetime
-      })
+      // Clean up expired particles in place to avoid per-frame array allocation.
+      let writeIndex = 0
+      for (let readIndex = 0; readIndex < gameState.dustParticles.length; readIndex++) {
+        const dust = gameState.dustParticles[readIndex]
+        if (dust && currentTime - dust.startTime < dust.lifetime) {
+          gameState.dustParticles[writeIndex++] = dust
+        }
+      }
+      gameState.dustParticles.length = writeIndex
 
       // Render active particles
       gameState.dustParticles.forEach(dust => {


### PR DESCRIPTION
### Motivation
- Fix micro-stutters observed on touch devices (notably iPhone 13 Pro Max) where racing a short watchdog against `requestAnimationFrame` produced uneven cadence during scroll/drag. 
- Reduce render-side CPU pressure during heavy-action scenes (explosions, smoke, dust, sprite animations) so scrolling and combat remain smooth at mobile frame budgets. 
- Record the change in project TODO/specs and preserve the request in prompt history for traceability.

### Description
- Change the mobile frame watchdog behavior in `src/game/gameLoop.js` by increasing `MOBILE_FRAME_WATCHDOG_MS` and adding `shouldUseMobileWatchdog()` so the timeout is used only as a stall recovery path and is disabled while the camera is actively scrolling or many effects are visible. 
- Reduce effects rendering overhead in `src/rendering/effectsRenderer.js` by adding `isMobileRenderProfile()`, culling offscreen dust, avoiding per-particle `save()`/`restore()` allocations, skipping nonessential explosion adornments (shockwave/embers) in mobile-quality mode, collapsing per-frame additive-animation filter allocations into simple loops, and doing in-place dust-particle cleanup to avoid per-frame array allocations. 
- Update documentation/telemetry artifacts by adding a TODO entry and a spec follow-up (`TODO/Improvements.md`, `specs/068-mobile-fps-regression-bottleneck-overlay.md`) and writing the prompt to `prompt-history/20260718T133206Z_smooth-mobile-scroll.md`; `package-lock.json` was also updated by the environment.

### Testing
- Ran unit tests with `npm run test:unit`, which completed successfully: 146 test files, 3,729 tests passed. 
- Ran automatic lint fix with `npm run lint:fix:changed`, which executed without remaining auto-fix errors. 
- Local static checks (`node --check` on modified modules) and the project test suite passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b7ffbefb4832896ad8f186d3c3a26)