### PR TITLE
Fix Destroyers failing to fire in combat

### DIFF
--- a/TODO/Bugs.md
+++ b/TODO/Bugs.md
@@ -467,3 +467,4 @@
 - [x] Show the normal move cursor for a selected Hovercraft over passable land as well as water.
 - [x] Make S cancel any selected transport or participating cargo unit's complete embark/disembark operation, restoring occupancy/embarked state and removing every pending lock/reference so a new operation can start immediately.
 - [x] Add one prepared Playwright E2E covering a Ferry with ten tanks, a land-based Hovercraft with five tanks, and a coast-water Hovercraft with five tanks, including command priority, cancellation cleanup, cursor behavior, and completed capacity loading.
+- [x] Fix player-commanded and enemy-AI Destroyers never firing by making their combat turret tracking follow assigned targets, with human and AI regression coverage.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-starter",
   "private": true,
-  "version": "0.36.1",
+  "version": "0.36.2",
   "license": "MIT",
   "author": "patrick.beyer.software@gmail.com",
   "type": "module",

--- a/prompt-history/2026-07-31T20-07-06Z_destroyer-combat-fix.md
+++ b/prompt-history/2026-07-31T20-07-06Z_destroyer-combat-fix.md
@@ -1,0 +1,7 @@
+# 2026-07-31T20:07:06Z
+
+Processed by: Codex (GPT-5.6 Sol)
+
+## Prompt
+
+BUG: destroyers are currently not firing when commanded to attack by the user. Also the enemy AI does not fire with their destroyers. Ensure to fix the issue so destroyers can be used for combat.

--- a/specs/073-shipyard-destroyer/spec.md
+++ b/specs/073-shipyard-destroyer/spec.md
@@ -26,6 +26,8 @@
 ## Balancing
 - Shipyard: 5x5 footprint, 5000 credits, -120 power, 450 health, requires Radar Station and Vehicle Factory.
 - Destroyer: 4500 credits, 250 health, armor 1.5, 5% per-crew-member casualty chance on damaging hits, 60 ammunition, 6000 fuel, slow acceleration, naval movement, long 18-tile range.
+- Destroyers continuously aim their gun tracking at an assigned attack target, allowing both player-issued attacks and enemy-AI attacks to fire once aimed and in range.
+- Hot-path verification (2026-07-31): the focused opt-in benchmark is `PERF_DESTROYER_COMBAT=1 npx playwright test tests/e2e/destroyerCombatPerformance.test.js --project=chromium --reporter=line`; it exercises 120 simultaneously targeting Destroyers for 240 live movement frames and reports FPS, movement CPU time, and browser heap delta. The local measurement was blocked before browser launch because Chromium was absent and the Playwright CDN returned HTTP 403 while downloading it; no misleading FPS/CPU/heap result is recorded.
 - Destroyer sidebar build art shows the entire ship from a photorealistic elevated three-quarter perspective over water, with the horizon inside the second quarter from the top; map art remains strict top-down, south-facing, and transparent.
 
 ## Validation

--- a/src/game/unitMovement.js
+++ b/src/game/unitMovement.js
@@ -437,8 +437,8 @@ function updateUnitRotation(unit, now) {
   }
   unit.isRotating = bodyNeedsRotation
 
-  // Update turret direction for tanks (after body direction is updated)
-  if (unit.type === 'tank' || unit.type === 'tank_v1' || unit.type === 'tank-v2' || unit.type === 'tank-v3' || unit.type === 'rocketTank') {
+  // Update turret direction for combat units with tracked guns (after body direction is updated)
+  if (unit.type === 'tank' || unit.type === 'tank_v1' || unit.type === 'tank-v2' || unit.type === 'tank-v3' || unit.type === 'rocketTank' || unit.type === 'destroyer') {
     if (unit.target) {
       // Tank has a target - rotate turret to track target
       let targetCenterX, targetCenterY

--- a/src/version.js
+++ b/src/version.js
@@ -2,4 +2,4 @@
 // This file is generated during build time from package.json
 // To update the version, modify package.json or use the bump-version script
 
-export const APP_VERSION = '0.36.1'
+export const APP_VERSION = '0.36.2'

--- a/tests/e2e/destroyerCombatPerformance.test.js
+++ b/tests/e2e/destroyerCombatPerformance.test.js
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test'
+
+const RUN_PERF = process.env.PERF_DESTROYER_COMBAT === '1'
+
+test.describe('Destroyer combat tracking performance', () => {
+  test.skip(!RUN_PERF, 'Set PERF_DESTROYER_COMBAT=1 to run this opt-in performance benchmark.')
+
+  test('tracks 120 active Destroyer targets without exceeding the frame budget', async({ page }, testInfo) => {
+    await page.goto('/')
+    const result = await page.evaluate(async() => {
+      const [{ updateUnitMovement }, { TILE_SIZE }] = await Promise.all([
+        import('/src/game/unitMovement.js'),
+        import('/src/config.js')
+      ])
+      const size = 80
+      const mapGrid = Array.from({ length: size }, () =>
+        Array.from({ length: size }, () => ({ type: 'water' })))
+      const occupancyMap = Array.from({ length: size }, () => Array(size).fill(0))
+      const units = Array.from({ length: 120 }, (_, index) => {
+        const tileX = 5 + (index % 20) * 3
+        const tileY = 5 + Math.floor(index / 20) * 5
+        return {
+          id: `perf-destroyer-${index}`,
+          type: 'destroyer',
+          owner: index % 2 ? 'player1' : 'player2',
+          isNaval: true,
+          health: 250,
+          maxHealth: 250,
+          x: tileX * TILE_SIZE,
+          y: tileY * TILE_SIZE,
+          tileX,
+          tileY,
+          direction: 0,
+          turretDirection: 0,
+          rotationSpeed: 0.024,
+          turretRotationSpeed: 0.024,
+          path: [],
+          movement: {},
+          target: {
+            id: `perf-target-${index}`,
+            owner: index % 2 ? 'player2' : 'player1',
+            health: 250,
+            x: tileX * TILE_SIZE,
+            y: (tileY + 8) * TILE_SIZE,
+            tileX,
+            tileY: tileY + 8
+          }
+        }
+      })
+      const state = { occupancyMap, buildings: [], units, mapGrid, humanPlayer: 'player1' }
+      const heapStartBytes = performance.memory?.usedJSHeapSize || null
+      let movementCpuMs = 0
+      const frameStart = performance.now()
+      for (let frame = 0; frame < 240; frame++) {
+        const startedAt = performance.now()
+        updateUnitMovement(units, mapGrid, occupancyMap, state, frame * (1000 / 60))
+        movementCpuMs += performance.now() - startedAt
+        await new Promise(resolve => requestAnimationFrame(resolve))
+      }
+      const elapsedMs = performance.now() - frameStart
+      const heapEndBytes = performance.memory?.usedJSHeapSize || null
+      return {
+        fps: 240000 / elapsedMs,
+        movementCpuMs,
+        averageMovementCpuMs: movementCpuMs / 240,
+        heapDeltaBytes: heapStartBytes === null || heapEndBytes === null ? null : heapEndBytes - heapStartBytes
+      }
+    })
+
+    await testInfo.attach('destroyer-combat-performance.json', {
+      body: JSON.stringify(result, null, 2),
+      contentType: 'application/json'
+    })
+    console.log(`Destroyer combat performance: ${JSON.stringify(result)}`)
+    expect(result.fps).toBeGreaterThan(50)
+    expect(result.averageMovementCpuMs).toBeLessThan(16.67)
+  })
+})

--- a/tests/unit/gameFolderUnitCombat.test.js
+++ b/tests/unit/gameFolderUnitCombat.test.js
@@ -198,6 +198,46 @@ describe('unitCombat.js', () => {
       expect(bullets.length).toBe(0)
     })
 
+    it.each([
+      ['a player command', 'player1', undefined],
+      ['enemy AI permission', 'player2', true]
+    ])('fires an aimed Destroyer for %s', (_scenario, owner, allowedToAttack) => {
+      const target = {
+        id: 'naval-target',
+        owner: owner === 'player1' ? 'player2' : 'player1',
+        type: 'destroyer',
+        isNaval: true,
+        x: 4 * 32,
+        y: 7 * 32,
+        tileX: 4,
+        tileY: 7,
+        health: 250
+      }
+      const destroyer = {
+        id: 'destroyer-attacker',
+        type: 'destroyer',
+        owner,
+        isNaval: true,
+        x: 4 * 32,
+        y: 4 * 32,
+        tileX: 4,
+        tileY: 4,
+        health: 250,
+        target,
+        ammunition: 60,
+        direction: Math.PI / 2,
+        turretDirection: Math.PI / 2,
+        allowedToAttack
+      }
+      const bullets = []
+
+      updateUnitCombat([destroyer, target], bullets, mockMapGrid, mockGameState, 10000)
+
+      expect(bullets).toHaveLength(1)
+      expect(bullets[0].shooter).toBe(destroyer)
+      expect(destroyer.ammunition).toBe(59)
+    })
+
     it('should process attack queue', () => {
       const target1 = { id: 1, x: 64, y: 32, tileX: 2, health: 100 }
       const target2 = { id: 2, x: 96, y: 32, tileX: 3, health: 100 }

--- a/tests/unit/unitMovement.test.js
+++ b/tests/unit/unitMovement.test.js
@@ -593,6 +593,40 @@ describe('unitMovement.js', () => {
       expect(unit.isRotating).toBe(false)
     })
 
+    it('aims a Destroyer gun at its assigned combat target', () => {
+      const target = {
+        id: 'destroyer-target',
+        health: 100,
+        x: 5 * 32,
+        y: 9 * 32,
+        tileX: 5,
+        tileY: 9
+      }
+      const destroyer = {
+        id: 'attacking-destroyer',
+        type: 'destroyer',
+        isNaval: true,
+        health: 250,
+        x: 5 * 32,
+        y: 5 * 32,
+        tileX: 5,
+        tileY: 5,
+        direction: 0,
+        turretDirection: 0,
+        rotationSpeed: 0.1,
+        turretRotationSpeed: 0.1,
+        path: [],
+        movement: {},
+        target
+      }
+
+      for (let frame = 0; frame < 20; frame++) {
+        updateUnitMovement([destroyer], mockMapGrid, mockOccupancyMap, mockGameState, frame * 16)
+      }
+
+      expect(destroyer.turretDirection).toBeCloseTo(Math.PI / 2, 5)
+    })
+
     it('should handle howitzer rotation locked to body', () => {
       const unit = {
         health: 100,


### PR DESCRIPTION
### Motivation
- Destroyers were not firing for player-issued attacks or enemy AI because their turret aiming was not being updated, preventing the firing preconditions from being satisfied.

### Description
- Include `destroyer` in the turret-update logic in `src/game/unitMovement.js` so the unit's `turretDirection` smoothly tracks an assigned `target` and can meet firing alignment checks.
- Add unit tests to verify destroyer turret aiming in `tests/unit/unitMovement.test.js` and that both player-commanded and AI-authorized destroyers fire and consume ammunition in `tests/unit/gameFolderUnitCombat.test.js`.
- Add an opt-in Playwright hot-path benchmark `tests/e2e/destroyerCombatPerformance.test.js` that exercises many targeting destroyers for performance verification, and update `TODO/Bugs.md`, `specs/073-shipyard-destroyer/spec.md`, and prompt history to record the change and verification notes.

### Testing
- Ran targeted unit tests with `npx vitest run tests/unit/unitMovement.test.js tests/unit/gameFolderUnitCombat.test.js` and the targeted suites passed (63 tests passed).
- Ran the full unit test suite with `npm run test:unit` resulting in 152 files and 3,820 tests passed.
- Ran `npm run lint:fix:changed` to apply lint fixes on changed files.
- Attempted the opt-in Playwright benchmark `PERF_DESTROYER_COMBAT=1 npx playwright test tests/e2e/destroyerCombatPerformance.test.js` but the run was blocked because Chromium was unavailable and `npx playwright install chromium` failed to download browsers (Playwright CDN returned HTTP 403), and this environment limitation is documented in the spec update.
- Commit message: `Fix destroyer combat firing`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cffdae9e483288fda7a31e41e67ef)