### PR TITLE
Fix rocket turret impacts against airborne aircraft

### DIFF
--- a/TODO/Bugs.md
+++ b/TODO/Bugs.md
@@ -468,3 +468,6 @@
 - [x] Make S cancel any selected transport or participating cargo unit's complete embark/disembark operation, restoring occupancy/embarked state and removing every pending lock/reference so a new operation can start immediately.
 - [x] Add one prepared Playwright E2E covering a Ferry with ten tanks, a land-based Hovercraft with five tanks, and a coast-water Hovercraft with five tanks, including command priority, cancellation cleanup, cursor behavior, and completed capacity loading.
 - [x] Fix player-commanded and enemy-AI Destroyers never firing by making their combat turret tracking follow assigned targets, with human and AI regression coverage.
+## 2026-07-31 Rocket turret anti-air impact bug
+
+- [x] Ensure Rocket Turret homing rockets track the altitude-adjusted visible center of enemy Apache, F22, and F35 aircraft and detonate directly on the aircraft rather than at its ground coordinate.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-starter",
   "private": true,
-  "version": "0.36.2",
+  "version": "0.36.3",
   "license": "MIT",
   "author": "patrick.beyer.software@gmail.com",
   "type": "module",

--- a/prompt-history/2026-07-31T20-51-16Z_rocket-aircraft-impact.md
+++ b/prompt-history/2026-07-31T20-51-16Z_rocket-aircraft-impact.md
@@ -1,0 +1,7 @@
+# 2026-07-31T20:51:16Z
+
+**LLM:** Codex (GPT-5.6 Sol)
+
+## Prompt
+
+> there is a bug with rockets from the rocket turret when they attack aircraft because the rockets are not impacting on the aircraft but on ground. Ensure the rockets do hit enemy aircraft directly.

--- a/specs/054-rocket-turret-apache-damage.md
+++ b/specs/054-rocket-turret-apache-damage.md
@@ -14,3 +14,12 @@
    - a Playwright E2E scenario that proves a rocket turret with only three rockets can still kill an Apache.
 
 5. Airborne Apache explosion damage uses the same centered impact distance as grounded Apache hits, so a direct rocket impact deals the same damage in both states.
+6. Rocket Turret aim, homing, collision, and proximity detonation use the visible sprite center for every supported airborne aircraft (`apache`, `f22Raptor`, and `f35`), including the aircraft's altitude lift, rather than its ground coordinate.
+7. The altitude targeting calculation is allocation-free in the per-projectile update path. It performs constant-time type checks for each active homing rocket and does not add unit-array scans or per-frame collections.
+8. The opt-in live benchmark exercises 120 simultaneous Rocket Turret rockets against a mixed airborne fleet. Run it with `PERF_ROCKET_TURRET_AIR=1 npx playwright test tests/e2e/rocketTurretApacheBurst.test.js --project=chromium --grep "120 homing" --reporter=line`; the active scene must retain at least 80% of the same-run baseline FPS while recording update/render timing and heap delta.
+
+## 2026-07-31 Performance verification
+
+- Hot-path frequency: altitude correction runs once at each relevant aim/homing/collision calculation per active projectile per simulation tick. The representative worst case is 120 rockets, so the added work is at most 120 constant-time helper calls at each affected projectile stage per tick; it does not scale with device pixel ratio because no pixels are drawn by the helper.
+- Baseline result: unavailable in this container because Playwright Chromium was absent and `npx playwright install chromium` was rejected by the browser CDN with HTTP 403 before the benchmark could launch.
+- Fixed result: unavailable for the same environment limitation. The reproducible opt-in benchmark remains in the suite and enforces no more than a 20% same-scene FPS loss while reporting CPU timing and heap delta.

--- a/src/game/aircraftTargeting.js
+++ b/src/game/aircraftTargeting.js
@@ -1,0 +1,12 @@
+export function getAircraftAltitudeLift(target) {
+  const isAircraft = target && (
+    target.type === 'apache' ||
+    target.type === 'f22Raptor' ||
+    target.type === 'f35'
+  )
+  if (!isAircraft || target.flightState === 'grounded') {
+    return 0
+  }
+
+  return Number.isFinite(target.altitude) ? target.altitude * 0.4 : 0
+}

--- a/src/game/buildingSystem.js
+++ b/src/game/buildingSystem.js
@@ -17,6 +17,7 @@ import { gameState as globalGameState } from '../gameState.js'
 import { ROCKET_TURRET_IMAGE_COORDS_SIZE, ROCKET_TURRET_MUZZLE_OFFSETS } from './turretMuzzleConfig.js'
 import { spawnDestructionExplosion } from './spriteSheetEffects.js'
 import { setBuildingDebrisDecals } from './tileDecals.js'
+import { getAircraftAltitudeLift } from './aircraftTargeting.js'
 
 
 /**
@@ -313,7 +314,7 @@ const updateDefensiveBuildings = logPerformance(function updateDefensiveBuilding
         if (targetObj) {
           // Calculate target angle
           const targetX = targetObj.x + (targetObj.width ? targetObj.width * TILE_SIZE / 2 : TILE_SIZE / 2)
-          const targetY = targetObj.y + (targetObj.height ? targetObj.height * TILE_SIZE / 2 : TILE_SIZE / 2)
+          const targetY = targetObj.y + (targetObj.height ? targetObj.height * TILE_SIZE / 2 : TILE_SIZE / 2) - getAircraftAltitudeLift(targetObj)
           const targetAngle = Math.atan2(targetY - centerY, targetX - centerX)
 
           // Smoothly rotate turret towards target
@@ -467,7 +468,7 @@ const updateDefensiveBuildings = logPerformance(function updateDefensiveBuilding
               }
               // For gun turrets, target angle is already calculated in continuous tracking above
               const targetX = firingTarget.x + (firingTarget.width ? firingTarget.width * TILE_SIZE / 2 : TILE_SIZE / 2)
-              const targetY = firingTarget.y + (firingTarget.height ? firingTarget.height * TILE_SIZE / 2 : TILE_SIZE / 2)
+              const targetY = firingTarget.y + (firingTarget.height ? firingTarget.height * TILE_SIZE / 2 : TILE_SIZE / 2) - getAircraftAltitudeLift(firingTarget)
               const targetDistance = Math.hypot(targetX - centerX, targetY - centerY)
 
               if (targetDistance < minRange) {
@@ -663,7 +664,7 @@ function fireTurretProjectile(building, target, centerX, centerY, now, bullets, 
       // Fallback to current target position if target exists
       projectile.targetPosition = {
         x: target.x + TILE_SIZE / 2,
-        y: target.y + TILE_SIZE / 2
+        y: target.y + TILE_SIZE / 2 - getAircraftAltitudeLift(target)
       }
     } else {
       // No valid target position, don't fire

--- a/src/game/bulletCollision.js
+++ b/src/game/bulletCollision.js
@@ -1,5 +1,6 @@
 // bulletCollision.js - Handles bullet collision detection
 import { TILE_SIZE } from '../config.js'
+import { getAircraftAltitudeLift } from './aircraftTargeting.js'
 
 /**
  * Checks if a bullet collides with a specific unit
@@ -36,12 +37,9 @@ export function checkUnitCollision(bullet, unit) {
     const unitCenterX = unit.x + TILE_SIZE / 2
     let unitCenterY = unit.y + TILE_SIZE / 2
 
-    // For Apache helicopters, adjust the collision Y to account for altitude visual offset
-    // The Apache visual is rendered at y - (altitude * 0.4), so collision should match
-    if ((unit.type === 'apache' || unit.type === 'f35') && unit.altitude) {
-      const altitudeLift = unit.altitude * 0.4
-      unitCenterY -= altitudeLift
-    }
+    // Airborne sprites render above their ground coordinates, so collide with
+    // the visible aircraft instead of the empty ground position below it.
+    unitCenterY -= getAircraftAltitudeLift(unit)
 
     const dx = unitCenterX - bullet.x
     const dy = unitCenterY - bullet.y

--- a/src/game/bulletSystem.js
+++ b/src/game/bulletSystem.js
@@ -27,6 +27,7 @@ import { recordDamageValue } from '../utils/combatStats.js'
 import { recordDamage } from '../ai-api/transitionCollector.js'
 import { getSimulationTime } from './time.js'
 import { setWorldDecal } from './tileDecals.js'
+import { getAircraftAltitudeLift } from './aircraftTargeting.js'
 
 const APACHE_REMOTE_DAMAGE = 10
 const APACHE_TANK_DAMAGE_MULTIPLIER = 1.67
@@ -156,10 +157,7 @@ export const updateBullets = logPerformance(function updateBullets(bullets, unit
             // Unit target
             targetX = bullet.target.x + TILE_SIZE / 2
             targetY = bullet.target.y + TILE_SIZE / 2
-            // Adjust for Apache altitude visual offset
-            if (bullet.target.type === 'apache' && bullet.target.altitude) {
-              targetY -= bullet.target.altitude * 0.4
-            }
+            targetY -= getAircraftAltitudeLift(bullet.target)
           }
         } else if (bullet.targetPosition) {
           targetX = bullet.targetPosition.x
@@ -277,12 +275,7 @@ export const updateBullets = logPerformance(function updateBullets(bullets, unit
             targetCenterX_pixels = bullet.target.x + (typeof bullet.target.width === 'undefined' ? TILE_SIZE / 2 : 0)
             targetCenterY_pixels = bullet.target.y + (typeof bullet.target.height === 'undefined' ? TILE_SIZE / 2 : 0)
 
-            // For Apache helicopters, adjust target Y to account for altitude visual offset
-            // The Apache visual is rendered at y - (altitude * 0.4), so we need to aim higher
-            if (bullet.target.type === 'apache' && bullet.target.altitude) {
-              const altitudeLift = bullet.target.altitude * 0.4
-              targetCenterY_pixels -= altitudeLift
-            }
+            targetCenterY_pixels -= getAircraftAltitudeLift(bullet.target)
           }
 
           const dx = targetCenterX_pixels - bullet.x
@@ -581,9 +574,7 @@ export const updateBullets = logPerformance(function updateBullets(bullets, unit
             // Unit target
             targetX = bullet.target.x + TILE_SIZE / 2
             targetY = bullet.target.y + TILE_SIZE / 2
-            if (bullet.target.type === 'apache' && bullet.target.altitude) {
-              targetY -= bullet.target.altitude * 0.4
-            }
+            targetY -= getAircraftAltitudeLift(bullet.target)
           }
         }
 
@@ -1138,10 +1129,7 @@ export function fireBullet(unit, target, bullets, now) {
   if (target.tileX !== undefined) {
     targetCenterX = target.x + TILE_SIZE / 2
     targetCenterY = target.y + TILE_SIZE / 2
-    // Adjust for Apache altitude visual offset
-    if (target.type === 'apache' && target.altitude) {
-      targetCenterY -= target.altitude * 0.4
-    }
+    targetCenterY -= getAircraftAltitudeLift(target)
   } else {
     targetCenterX = target.x * TILE_SIZE + (target.width * TILE_SIZE) / 2
     targetCenterY = target.y * TILE_SIZE + (target.height * TILE_SIZE) / 2

--- a/src/version.js
+++ b/src/version.js
@@ -2,4 +2,4 @@
 // This file is generated during build time from package.json
 // To update the version, modify package.json or use the bump-version script
 
-export const APP_VERSION = '0.36.2'
+export const APP_VERSION = '0.36.3'

--- a/tests/e2e/rocketTurretApacheBurst.test.js
+++ b/tests/e2e/rocketTurretApacheBurst.test.js
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test'
 
+const RUN_ROCKET_TURRET_PERF = process.env.PERF_ROCKET_TURRET_AIR === '1'
+
 test.describe('Rocket turret anti-air Apache damage', () => {
   /** @type {string[]} */
   let consoleErrors = []
@@ -140,5 +142,94 @@ test.describe('Rocket turret anti-air Apache damage', () => {
     expect(airborneResult.ammoRemaining).toBe(0)
 
     expect(consoleErrors, `Console errors encountered\n${consoleErrors.join('\n')}`).toEqual([])
+  })
+})
+
+test.describe('Rocket turret anti-air performance', () => {
+  test.skip(!RUN_ROCKET_TURRET_PERF, 'Set PERF_ROCKET_TURRET_AIR=1 to run this benchmark.')
+
+  test('keeps 120 homing rockets tracking airborne targets within the frame budget', async({ page }) => {
+    await page.goto('/?seed=11')
+    await page.waitForFunction(() => Boolean(window.gameState?.gameStarted && window.gameInstance?.units))
+
+    const result = await page.evaluate(async() => {
+      const { performanceMonitor } = await import('/src/performance/performanceMonitor.js')
+      const gs = window.gameState
+      const units = window.gameInstance.units
+      const bullets = gs.bullets
+      const owner = gs.humanPlayer === 'player1' ? 'player2' : 'player1'
+      const centerX = (gs.scrollOffset?.x || 0) + 500
+      const centerY = (gs.scrollOffset?.y || 0) + 350
+
+      const sample = duration => new Promise(resolve => {
+        const frames = []
+        const heapStart = performance.memory?.usedJSHeapSize ?? null
+        performanceMonitor.start()
+        let previous = performance.now()
+        const start = previous
+        const record = now => {
+          frames.push(now - previous)
+          previous = now
+          if (now - start >= duration) {
+            const usable = frames.filter(frame => frame > 0 && frame < 250)
+            const elapsed = usable.reduce((sum, frame) => sum + frame, 0)
+            const monitor = performanceMonitor.stop()
+            const heapEnd = performance.memory?.usedJSHeapSize ?? null
+            resolve({
+              fps: elapsed ? usable.length * 1000 / elapsed : 0,
+              frameCount: usable.length,
+              heapDeltaMb: heapStart !== null && heapEnd !== null ? (heapEnd - heapStart) / 1048576 : null,
+              timingMs: monitor?.timingMs || null
+            })
+            return
+          }
+          requestAnimationFrame(record)
+        }
+        requestAnimationFrame(record)
+      })
+
+      const baseline = await sample(2000)
+      for (let index = 0; index < 120; index++) {
+        const aircraft = {
+          id: `perf-air-${index}`,
+          type: index % 3 === 0 ? 'apache' : index % 3 === 1 ? 'f22Raptor' : 'f35',
+          owner,
+          x: centerX + (index % 12) * 8,
+          y: centerY + Math.floor(index / 12) * 8,
+          health: 100000,
+          maxHealth: 100000,
+          flightState: 'airborne',
+          altitude: 90 + (index % 3) * 10,
+          path: []
+        }
+        units.push(aircraft)
+        bullets.push({
+          id: `perf-rocket-${index}`,
+          x: centerX - 300,
+          y: centerY,
+          vx: 0,
+          vy: 0,
+          speed: 0.05,
+          baseDamage: 18,
+          active: true,
+          shooter: { id: `perf-turret-${index}`, type: 'rocketTurret', owner: gs.humanPlayer, isBuilding: true, x: 0, y: 0, width: 2, height: 2 },
+          homing: true,
+          target: aircraft,
+          targetPosition: { x: aircraft.x + 16, y: aircraft.y + 16 },
+          projectileType: 'rocket',
+          originType: 'rocketTurret',
+          skipCollisionChecks: true,
+          creationTime: gs.simulationTime,
+          startTime: gs.simulationTime,
+          maxFlightTime: 60000
+        })
+      }
+      const active = await sample(2000)
+      return { baseline, active }
+    })
+
+    console.log(`ROCKET_TURRET_AIR_PERF ${JSON.stringify(result)}`)
+    expect(result.active.frameCount).toBeGreaterThan(0)
+    expect(result.active.fps).toBeGreaterThanOrEqual(result.baseline.fps * 0.8)
   })
 })

--- a/tests/unit/bulletSystem.test.js
+++ b/tests/unit/bulletSystem.test.js
@@ -1316,6 +1316,56 @@ describe('Bullet System', () => {
       )
     })
 
+    it.each([
+      ['apache', 90],
+      ['f22Raptor', 120],
+      ['f35', 110]
+    ])('detonates rocket turret rockets directly on airborne %s sprites', (type, altitude) => {
+      const aircraft = createMockUnit({
+        id: `${type}-air-1`,
+        type,
+        owner: 'enemy',
+        flightState: 'airborne',
+        altitude,
+        x: 160,
+        y: 160
+      })
+      const spriteCenterY = aircraft.y + TILE_SIZE / 2 - altitude * 0.4
+      const bullet = createMockBullet({
+        originType: 'rocketTurret',
+        projectileType: 'rocket',
+        homing: true,
+        speed: 3,
+        x: aircraft.x + TILE_SIZE / 2,
+        y: spriteCenterY,
+        target: aircraft,
+        targetPosition: {
+          x: aircraft.x + TILE_SIZE / 2,
+          y: aircraft.y + TILE_SIZE / 2
+        },
+        creationTime: 1000,
+        startTime: 1000,
+        maxFlightTime: 5000,
+        explosionRadius: TILE_SIZE * 1.5
+      })
+
+      updateBullets([bullet], [aircraft], [], createGameState({ simulationTime: 1200 }), mapGrid)
+
+      expect(triggerExplosion).toHaveBeenCalledWith(
+        aircraft.x + TILE_SIZE / 2,
+        spriteCenterY,
+        bullet.baseDamage,
+        [aircraft],
+        [],
+        bullet.shooter,
+        1200,
+        mapGrid,
+        bullet.explosionRadius,
+        false,
+        expect.objectContaining({ allowAirborneDamage: true })
+      )
+    })
+
     it('explodes rocket tank homing missiles when they reach their target', () => {
       const target = createMockUnit({ owner: 'enemy', x: 160, y: 160 })
       const bullet = createMockBullet({


### PR DESCRIPTION
### Motivation

- Rockets from rocket turrets were detonating at the ground coordinate under airborne aircraft instead of the aircraft sprite, causing missed hits on Apaches/F22/F35.
- Centralize and standardize altitude-adjusted targeting so aim, homing guidance, proximity detonation, and collision use the visible aircraft sprite center.

### Description

- Add `src/game/aircraftTargeting.js` with `getAircraftAltitudeLift(target)` to compute the altitude visual lift for supported aircraft (`apache`, `f22Raptor`, `f35`).
- Use the altitude helper in `src/game/buildingSystem.js` so turret rotation, range checks, and fired projectile `targetPosition` use the aircraft's visible center (altitude-adjusted Y).
- Update `src/game/bulletSystem.js` homing/proximity logic and velocity initialization to aim at the altitude-adjusted target center and to detonate at that position for rocket-turret rockets.
- Update `src/game/bulletCollision.js` so unit collision tests use the altitude-adjusted visible center for airborne aircraft.
- Add unit regression tests in `tests/unit/bulletSystem.test.js` that verify rocket-turret rockets detonate directly on airborne `apache`, `f22Raptor`, and `f35` sprites.
- Add an opt-in Playwright e2e benchmark `tests/e2e/rocketTurretApacheBurst.test.js` that exercises 120 simultaneous homing rockets for performance verification, and update TODO/spec/prompt-history entries documenting the change and performance guidance.

### Testing

- Ran full unit test suite: `npm run test:unit` — 152 test files, 3,820 tests passed.
- Focused unit regression: `npx vitest run tests/unit/bulletSystem.test.js -t "detonates rocket turret rockets directly"` — the added aircraft direct-impact cases passed.
- Lint auto-fix: `npm run lint:fix:changed` was executed (no remaining blocking lint errors reported).
- Playwright perf scenario: attempted `PERF_ROCKET_TURRET_AIR=1 npx playwright test tests/e2e/rocketTurretApacheBurst.test.js` but could not run inside this environment because Playwright Chromium download failed (CDN returned HTTP 403) and no browser executable was available; the benchmark remains opt-in in the suite.
- Commit message for copy/paste: `fix: make rocket turrets hit airborne aircraft`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d0a0d467c8328a5afb73ee9b22194)