### PR TITLE
Clamp building repair countdown bar to building width

### DIFF
--- a/TODO/Bugs.md
+++ b/TODO/Bugs.md
@@ -471,3 +471,7 @@
 ## 2026-07-31 Rocket turret anti-air impact bug
 
 - [x] Ensure Rocket Turret homing rockets track the altitude-adjusted visible center of enemy Apache, F22, and F35 aircraft and detonate directly on the aircraft rather than at its ground coordinate.
+
+## 2026-08-02 Building repair timeout HUD overflow
+
+- [x] Clamp a building's red pending-repair timeout fill so malformed or out-of-range cooldown values can never draw it wider than the building.

--- a/prompt-history/20260802T184902Z_repair-bar-width.md
+++ b/prompt-history/20260802T184902Z_repair-bar-width.md
@@ -1,0 +1,7 @@
+# 2026-08-02T18:49:02Z
+
+Processed by: Codex (GPT-5.6 Sol)
+
+## Prompt
+
+Sometimes the red bar indicating repair timeout on a building's HUD can become far too large. Ensure it never becomes wider than the building. The attached image demonstrates the bug.

--- a/specs/000-global-specs.md
+++ b/specs/000-global-specs.md
@@ -67,6 +67,13 @@ The following unit types are considered attack-capable for cursor/range detectio
   - Fuel: `fuel <value>m` converted to meters using `CURSOR_METERS_PER_TILE` (1 tile = 10m)
 - Tooltip value resolution must be field-based (shared stat fields like `health`, `maxAmmunition`, `maxRocketAmmo`, `maxAmmoCargo`, `maxGas`) so newly added compatible units/buildings inherit behavior automatically without per-type hardcoding.
 
+## Building Repair Countdown HUD
+
+- A pending-repair countdown renders as a red fill above the building health bar.
+- The fill width must be capped at the rendered building width even when restored or synchronized cooldown state exceeds the normal ten-second duration.
+- Hot-path verification command: `PERF_BUILDING_REPAIR_HUD=1 npx playwright test tests/e2e/buildingRepairCountdownPerformance.test.js --project=chromium --reporter=line`.
+- The benchmark compares 120-frame same-scene baseline and 100-building active-countdown samples, enforcing no more than 20% FPS loss, under 50 ms total repair-HUD CPU time, and under 8 MB JS heap growth. The 2026-08-02 container run was blocked before measurement because its Playwright Chromium binary was unavailable and the browser CDN returned HTTP 403 during installation.
+
 ## Sidebar Money Tooltip
 
 - Clicking or tapping the sidebar money bar (or the mobile money display) opens a tooltip showing:

--- a/src/rendering/buildingRenderer.js
+++ b/src/rendering/buildingRenderer.js
@@ -883,7 +883,10 @@ export class BuildingRenderer {
     }
 
     // Calculate progress (reverse progress bar: 100% to 0%)
-    const progress = secondsRemaining / 10 // 10 seconds total
+    // Saved/remote repair state can occasionally contain a cooldown above the
+    // normal ten-second duration. Keep that bad state from drawing beyond the
+    // building HUD while the repair system brings it back into range.
+    const progress = Math.min(secondsRemaining / 10, 1) // 10 seconds total
 
     // Position above the health bar to avoid overlap with selection markers
     // Health bar is at screenY - 10, so we place this at screenY - 13 (3px height)

--- a/tests/e2e/buildingRepairCountdownPerformance.test.js
+++ b/tests/e2e/buildingRepairCountdownPerformance.test.js
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+
+const RUN_REPAIR_HUD_PERF = process.env.PERF_BUILDING_REPAIR_HUD === '1'
+
+test.describe('Building repair countdown HUD performance', () => {
+  test.skip(!RUN_REPAIR_HUD_PERF, 'Set PERF_BUILDING_REPAIR_HUD=1 to run this benchmark.')
+
+  test('stays within the frame budget with many active countdown bars', async({ page, baseURL }) => {
+    await page.goto(`${baseURL || 'http://localhost:5173'}?seed=31&size=64&players=2&oreFields=8`)
+    await page.waitForFunction(() => Boolean(window.gameInstance?.gameLoop && window.gameState?.gameStarted), null, { timeout: 45000 })
+
+    const sample = () => page.evaluate(() => new Promise(resolve => {
+      const heapStart = performance.memory?.usedJSHeapSize ?? null
+      const frameTimes = []
+      let previous = performance.now()
+      let renderCpuMs = 0
+      const renderer = window.gameInstance.renderer.buildingRenderer
+      const original = renderer.renderPendingRepairCountdown
+      renderer.renderPendingRepairCountdown = function measuredRepairCountdown(...args) {
+        const start = performance.now()
+        const result = original.apply(this, args)
+        renderCpuMs += performance.now() - start
+        return result
+      }
+      const frame = now => {
+        frameTimes.push(now - previous)
+        previous = now
+        if (frameTimes.length < 120) return requestAnimationFrame(frame)
+        renderer.renderPendingRepairCountdown = original
+        const elapsed = frameTimes.reduce((sum, time) => sum + time, 0)
+        const heapEnd = performance.memory?.usedJSHeapSize ?? null
+        resolve({
+          fps: frameTimes.length * 1000 / elapsed,
+          renderCpuMs,
+          heapDeltaMb: heapStart === null || heapEnd === null ? null : (heapEnd - heapStart) / 1048576
+        })
+      }
+      requestAnimationFrame(frame)
+    }))
+
+    const baseline = await sample()
+    await page.evaluate(() => {
+      const buildings = window.gameState.buildings.slice(0, 100)
+      window.gameState.buildingsAwaitingRepair = buildings.map(building => ({
+        building,
+        remainingCooldown: 100
+      }))
+    })
+    const active = await sample()
+    console.log(`BUILDING_REPAIR_HUD_PERF ${JSON.stringify({ baseline, active })}`)
+
+    expect(active.fps).toBeGreaterThanOrEqual(baseline.fps * 0.8)
+    expect(active.renderCpuMs).toBeLessThan(50)
+    if (active.heapDeltaMb !== null) expect(active.heapDeltaMb).toBeLessThan(8)
+  })
+})

--- a/tests/unit/buildingRepairCountdown.test.js
+++ b/tests/unit/buildingRepairCountdown.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/gameState.js', () => ({
+  gameState: {
+    buildingsAwaitingRepair: []
+  }
+}))
+
+vi.mock('../../src/inputHandler.js', () => ({ selectedUnits: [] }))
+vi.mock('../../src/buildingImageMap.js', () => ({ getBuildingImage: vi.fn() }))
+vi.mock('../../src/rendering/turretImageRenderer.js', () => ({
+  renderTurretWithImages: vi.fn(),
+  turretImagesAvailable: vi.fn(() => false)
+}))
+
+describe('building repair countdown HUD', () => {
+  it('never draws the timeout fill wider than the building', async() => {
+    globalThis.Image = class Image {}
+    const [{ BuildingRenderer }, { gameState }] = await Promise.all([
+      import('../../src/rendering/buildingRenderer.js'),
+      import('../../src/gameState.js')
+    ])
+    const building = { id: 'repairing-building' }
+    gameState.buildingsAwaitingRepair = [{ building, remainingCooldown: 100 }]
+    const fillRect = vi.fn()
+    const ctx = {
+      fillRect,
+      restore: vi.fn(),
+      save: vi.fn(),
+      set fillStyle(_value) {}
+    }
+
+    new BuildingRenderer().renderPendingRepairCountdown(ctx, building, 20, 30, 96, 64)
+
+    expect(fillRect).toHaveBeenNthCalledWith(1, 20, 17, 96, 3)
+    expect(fillRect).toHaveBeenNthCalledWith(2, 20, 17, 96, 3)
+  })
+})


### PR DESCRIPTION
### Motivation
- The pending-repair countdown HUD could render a red fill wider than the building when restored or synchronized cooldown state contained out-of-range values, causing a visible overflow above the health bar.

### Description
- Clamp the pending-repair progress to `1` in `renderPendingRepairCountdown` so `progress = Math.min(secondsRemaining / 10, 1)` and the red fill never exceeds the building width (`src/rendering/buildingRenderer.js`).
- Add a unit test that simulates an oversized cooldown and verifies both the background and red fill calls use the building width (`tests/unit/buildingRepairCountdown.test.js`).
- Add an opt-in Playwright e2e performance benchmark that measures FPS, repair-HUD render CPU time, and heap growth with up to 100 active countdowns (`tests/e2e/buildingRepairCountdownPerformance.test.js`).
- Update project tracking and global specs to document the HUD constraint and the benchmark command, and record the prompt in `prompt-history` and `TODO/Bugs.md`.

### Testing
- Ran the new unit test: `npx vitest run tests/unit/buildingRepairCountdown.test.js` and it passed.
- Ran the full unit test suite: `npm run test:unit` and observed existing unit tests complete successfully in this environment.
- Ran the lint autofix flow: `npm run lint:fix:changed` (completed without new lint failures reported).
- The opt-in Playwright benchmark was added but could not be executed here because Playwright Chromium was not available and `npx playwright install chromium` failed due to the browser CDN returning HTTP 403; the benchmark is therefore blocked in this environment.
- Commit message: `Fix building repair countdown bar overflow`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f90b5b5948328ab464633b54c74b2)